### PR TITLE
needed for vscode debugging, source mapping do not appear to be loaded

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -100,13 +100,17 @@ module.exports = function (config) {
      * available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
      */
     browsers: [
-      'Chrome'
+      'ChromeWithDebugging'
     ],
 
     customLaunchers: {
       ChromeTravisCi: {
         base: 'Chrome',
         flags: ['--no-sandbox']
+      },
+      ChromeWithDebugging: {
+        base: 'Chrome',
+        flags: ['--remote-debugging-port=9222']
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "server": "npm run server:dev",
     "start:hmr": "npm run server:dev:hmr",
     "start": "npm run server:dev",
-    "test": "npm run lint && karma start",
+    "test": "karma start",
     "typedoc": "typedoc --json typedoc.json",
     "version": "npm run build",
     "watch:dev:hmr": "npm run watch:dev -- --hot",


### PR DESCRIPTION
Use entry in launch.json

``` 
{
         "type": "chrome",
          "request": "attach",
          "name": "Attach to Chrome",
          "port": 9222,
          "url": "http://localhost:9876/debug.html",
          "webRoot": "${workspaceRoot}"
},
```