### PR TITLE
Adding course-of-action to attack pattern upon creation/edit

### DIFF
--- a/src/app/models/relationship.ts
+++ b/src/app/models/relationship.ts
@@ -34,8 +34,8 @@ export class Relationship {
     private createAttributes(): any {
         return {
             // version: '1',
-            created: moment().format(Constance.DATE_FORMATE),
-            modified: moment().format(Constance.DATE_FORMATE),
+            // created: moment().format(Constance.DATE_FORMATE),
+            // modified: moment().format(Constance.DATE_FORMATE),
             labels: [],
             external_references: [],
             kill_chain_phases: [],

--- a/src/app/settings/base-stix.component.ts
+++ b/src/app/settings/base-stix.component.ts
@@ -153,10 +153,12 @@ export class BaseStixComponent {
                 (stixObject) => {
                     observer.next(stixObject);
                     observer.complete();
-                    this.snackBar.open(item.attributes.name + ' has been successfully deleted', '', {
-                        duration: this.duration,
-                        extraClasses: ['snack-bar-background-success']
-                    });
+                    if (item.attributes.name) {
+                        this.snackBar.open(item.attributes.name + ' has been successfully deleted', '', {
+                            duration: this.duration,
+                            extraClasses: ['snack-bar-background-success']
+                        });
+                    }
                 }, (error) => {
                     // handle errors here
                     this.snackBar.open('Error ' + error , '', {
@@ -175,10 +177,12 @@ export class BaseStixComponent {
             (data) => {
                 observer.next(data);
                 observer.complete();
-                this.snackBar.open(item.attributes.name + ' has been successfully saved', '', {
-                    duration: this.duration,
-                    extraClasses: ['snack-bar-background-success']
-                });
+                if (item.attributes.name) {
+                    this.snackBar.open(item.attributes.name + ' has been successfully saved', '', {
+                        duration: this.duration,
+                        extraClasses: ['snack-bar-background-success']
+                    });
+                }
                 // data.url = item.url;
                 // let sub = this.service.update(data).subscribe(
                 //     (resullts) => {
@@ -223,10 +227,12 @@ export class BaseStixComponent {
             (data) => {
                 observer.next(data);
                 observer.complete();
-                this.snackBar.open(item.attributes.name + ' has been successfully save', '', {
-                    duration: this.duration,
-                    extraClasses: ['snack-bar-background-success']
-                });
+                if (item.attributes.name) {
+                    this.snackBar.open(item.attributes.name + ' has been successfully saved', '', {
+                        duration: this.duration,
+                        extraClasses: ['snack-bar-background-success']
+                    });
+                }
             }, (error) => {
                 // handle errors here
                 this.snackBar.open('Error ' + error , '', {

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-edit/attack-pattern-edit.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-edit/attack-pattern-edit.component.html
@@ -19,6 +19,13 @@
                     </md-input-container>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <md-input-container class="full-width">
+                        <textarea mdInput mdTextareaAutosize placeholder="Mitigation" [(ngModel)]="mitigation">{{mitigation}}</textarea>
+                    </md-input-container>
+                </div>
+            </div>
              <div class="row">
                 <div class="col-md-12">
                     <form>

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-edit/attack-patterns-edit.component.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-edit/attack-patterns-edit.component.ts
@@ -43,6 +43,7 @@ export class AttackPatternEditComponent extends AttackPatternComponent implement
     public saveAttackPattern(): void {
          let sub = super.saveButtonClicked().subscribe(
             (data) => {
+                this.saveCourseOfAction(data.id);
                 this.location.back();
             }, (error) => {
                 // handle errors here

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
@@ -13,6 +13,13 @@
                 </md-input-container>
             </div>
         </div>
+        <div class="row">
+          <div class="col-md-12">
+              <md-input-container class="full-width">
+                  <textarea mdInput [(ngModel)]="mitigation"  placeholder="Mitigation"></textarea>
+              </md-input-container>
+          </div>
+        </div>
          <div class="row">
             <div class="col-md-12">
                 <form>

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.ts
@@ -28,6 +28,7 @@ export class AttackPatternNewComponent extends AttackPatternEditComponent implem
      public saveAttackPattern(): void {
          let sub = super.create(this.attackPattern).subscribe(
             (data) => {
+                 this.saveCourseOfAction(data[0].id);
                  this.location.back();
             }, (error) => {
                 // handle errors here

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.html
@@ -29,6 +29,12 @@
                         </div>
                         <div class="row">
                             <div class="col-md-12">
+                                <label>Mitigation</label>
+                                <h6>{{mitigation}}</h6>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
                                 <label>Sophistication</label>
                                 <h6>{{getSophisticationLevel(attackPattern.attributes.x_unfetter_sophistication_level)}}</h6>
                             </div>
@@ -63,4 +69,3 @@
 
     <relationship-list *ngIf="attackPattern.id" [model]="attackPattern"></relationship-list>
       <div class="pull-right grey-text">{{attackPattern.id}}</div>
-

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.ts
@@ -4,7 +4,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { Location } from '@angular/common';
 import { BaseStixComponent } from '../../../base-stix.component';
-import { AttackPattern } from '../../../../models';
+import { AttackPattern, CourseOfAction, Relationship } from '../../../../models';
 import { StixService } from '../../../stix.service';
 import { Constance } from '../../../../utils/constance';
 import { FormatHelpers } from '../../../../global/static/format-helpers'
@@ -18,6 +18,12 @@ import { FormatHelpers } from '../../../../global/static/format-helpers'
 export class AttackPatternComponent extends BaseStixComponent implements OnInit {
 
     public attackPattern: AttackPattern = new AttackPattern();
+    public mitigation: string = '';
+    public courseOfAction: CourseOfAction = new CourseOfAction();
+    public origCoA: CourseOfAction;
+    public relationship: Relationship = new Relationship();
+    public coaId: string = '';
+    public target: any;
     public defaultValue = 0;
     public x_unfetter_sophistication_levels = [
           { id : 1, value: '1 - Novice' },
@@ -59,6 +65,7 @@ export class AttackPatternComponent extends BaseStixComponent implements OnInit 
          let subscription =  super.get().subscribe(
             (data) => {
                 this.attackPattern = data as AttackPattern;
+                this.findCoA();
             }, (error) => {
                 // handle errors here
                  console.log('error ' + error);
@@ -97,6 +104,108 @@ export class AttackPatternComponent extends BaseStixComponent implements OnInit 
             }
         );
         return sophisticationLevel ? sophisticationLevel.value : '';
+    }
+
+    public findCoA(): void {
+        let filter = { 'stix.target_ref': this.attackPattern.id };
+        let uri = Constance.RELATIONSHIPS_URL + '?filter=' + JSON.stringify(filter);
+        let subscription =  super.getByUrl(uri).subscribe(
+            (data) => {
+                this.target = data as Relationship;
+                this.target.forEach((relationship: Relationship) => {
+                    if (relationship.attributes.relationship_type === 'mitigates') {
+                        this.getMitigation(relationship.attributes.source_ref);
+                    }
+                });
+               }, (error) => {
+                // handle errors here
+                 console.log('error ' + error);
+            }, () => {
+                // prevent memory links
+                if (subscription) {
+                    subscription.unsubscribe();
+                }
+            }
+        );
+    }
+
+    public getMitigation(coaId: string) {
+        let uri = Constance.COURSE_OF_ACTION_URL + '/' + coaId;
+        let subscription =  super.getByUrl(uri).subscribe(
+            (data) => {
+                this.coaId = coaId;
+                this.origCoA = data as CourseOfAction;
+                this.mitigation = this.origCoA.attributes.description;
+               }, (error) => {
+                // handle errors here
+                 console.log('error ' + error);
+            }, () => {
+                // prevent memory links
+                if (subscription) {
+                    subscription.unsubscribe();
+                }
+            }
+        );
+    }
+
+    public saveCourseOfAction(attackPatternId: string): void {
+        if (this.coaId !== '') {
+            if (this.mitigation !== this.origCoA.attributes.description) {
+                this.origCoA.attributes.description = this.mitigation;
+                this.stixService.url = Constance.COURSE_OF_ACTION_URL;
+                let subscription = super.save(this.origCoA).subscribe(
+                    (data) => {
+
+                    }, (error) => {
+                        // handle errors here
+                        console.log('error ' + error);
+                    }, () => {
+                        // prevent memory links
+                        if (subscription) {
+                            subscription.unsubscribe();
+                        }
+                    }
+                );
+            }
+        } else {
+            if (this.mitigation !== '') {
+               this.courseOfAction.attributes.description = this.mitigation;
+               this.courseOfAction.attributes.name = this.attackPattern.attributes.name + ' Mitigation';
+               let subscription = super.create(this.courseOfAction).subscribe(
+                    (stixObject) => {
+                        this.saveRelationship(attackPatternId, stixObject[0].id);
+                    }, (error) => {
+                        // handle errors here
+                         console.log('error ' + error);
+                    }, () => {
+                        // prevent memory links
+                        if (subscription) {
+                            subscription.unsubscribe();
+                        }
+                    }
+                );
+            }
+        }
+    }
+
+    public saveRelationship(attackPatternId: string, coaId: string): void {
+        this.relationship.attributes.source_ref = coaId;
+        this.relationship.attributes.target_ref = attackPatternId;
+        this.relationship.attributes.relationship_type = 'mitigates';
+        console.log(this.relationship);
+        let subscription = super.create(this.relationship).subscribe(
+            (data) => {
+                console.log(data);
+            }, (error) => {
+                // handle errors here
+                console.log('error ' + error);
+            }, () => {
+                // prevent memory links
+                if (subscription) {
+                    subscription.unsubscribe();
+                }
+            }
+        );
     }
 
     public cleanWhitespace(inputString): string {

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -28,7 +28,7 @@ export const Constance = {
 
   RELATIONSHIPS_URL: 'api/relationships',
   RELATIONSHIPS_ICON: 'assets/icon/stix-icons/svg/relationship-b.svg',
-  RELATIONSHIPS_TYPE: 'Relationships',
+  RELATIONSHIPS_TYPE: 'relationship',
   RELATIONSHIPS_TYPES: {
     MITIGATES: 'mitigates',
     INDICATES: 'indicates'


### PR DESCRIPTION
This PR addresses Issue #476 in the main unfetter project.

A mitigation field was added which can be filled in upon creation or edit of an attack pattern. If this field contains text at any point, a course-of-action is generated for this attack pattern (called <attack-pattern-name> Mitigation), and a relationship object is generated between the two.

To prevent the display of snackBar when a relationship is created (which does not contain a name), an if statement was also added to the createItem, saveItem, and deleteItem wrappers to only call snackBar.open if the name of the item is defined.