### PR TITLE
Fix for merged PR that caused TypeErrors in Attack Patterns.

### DIFF
--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.ts
@@ -28,8 +28,8 @@ export class AttackPatternNewComponent extends AttackPatternEditComponent implem
      public saveAttackPattern(): void {
          let sub = super.create(this.attackPattern).subscribe(
             (data) => {
-                 this.saveCourseOfAction(data[0].id);
                  this.location.back();
+                 this.saveCourseOfAction(data[0].id);
             }, (error) => {
                 // handle errors here
                  console.log('error ' + error);

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern/attack-pattern.component.ts
@@ -23,7 +23,7 @@ export class AttackPatternComponent extends BaseStixComponent implements OnInit 
     public origCoA: CourseOfAction;
     public relationship: Relationship = new Relationship();
     public coaId: string = '';
-    public target: any;
+    public target: Relationship[];
     public defaultValue = 0;
     public x_unfetter_sophistication_levels = [
           { id : 1, value: '1 - Novice' },
@@ -107,11 +107,12 @@ export class AttackPatternComponent extends BaseStixComponent implements OnInit 
     }
 
     public findCoA(): void {
-        let filter = { 'stix.target_ref': this.attackPattern.id };
-        let uri = Constance.RELATIONSHIPS_URL + '?filter=' + JSON.stringify(filter);
-        let subscription =  super.getByUrl(uri).subscribe(
+        let filter = 'filter=' + encodeURIComponent(JSON.stringify({ 'stix.target_ref': this.attackPattern.id }));
+        this.stixService.url = Constance.RELATIONSHIPS_URL;
+        let subscription =  super.load(filter).subscribe(
             (data) => {
-                this.target = data as Relationship;
+                this.stixService.url = Constance.ATTACK_PATTERN_URL;
+                this.target = data as Relationship[];
                 this.target.forEach((relationship: Relationship) => {
                     if (relationship.attributes.relationship_type === 'mitigates') {
                         this.getMitigation(relationship.attributes.source_ref);


### PR DESCRIPTION
Replaced getByUrl() with load and moved location.back() to correct position in order to pass unit tests.