### PR TITLE
better error message on failed csv upload

### DIFF
--- a/src/app/threat-report-overview/create/threat-report-creation.component.html
+++ b/src/app/threat-report-overview/create/threat-report-creation.component.html
@@ -118,9 +118,9 @@
     </div>
     <div class="row pull-right mt-18">
         <div class="col-md-12 col-xs-12 pull-right mt-10">
-            <button color="primary" mat-button (click)="cancel($event)">CANCEL</button>
+            <button color="primary" mat-button (click)="onCancel($event)">CANCEL</button>
             <button [disabled]="dateError.startDate.isError || dateError.endDate.isError || dateError.endDate.isSameOrBefore" color="primary"
-                mat-raised-button (click)="save($event)">
+                mat-raised-button (click)="onContinue($event)">
                 CONTINUE
             </button>
         </div>

--- a/src/app/threat-report-overview/create/threat-report-creation.component.ts
+++ b/src/app/threat-report-overview/create/threat-report-creation.component.ts
@@ -234,7 +234,7 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
    * go back to list view
    * @param {UIEvent} event optional
    */
-  public cancel(event: UIEvent): void {
+  public onCancel(event: UIEvent): void {
     this.location.back();
   }
 
@@ -242,16 +242,23 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
    * @description
    * @param {UIEvent} event optional
    */
-  public save(event: UIEvent): void {
-    const currentReports = this.threatReport.reports || [];
-    const attachedReports = this.csvReports || [];
-    this.threatReport.reports = currentReports.concat(attachedReports);
+  public onContinue(event: UIEvent): void {
+    this.threatReport.reports = this.appendCsvReports(this.threatReport.reports, this.csvReports);
     // if the boundries check box is checked, do not use boundries provided
     if (this.isFalsey(this.shouldIncludeBoundries)) {
       this.threatReport.boundries = new Boundries();
     }
     this.sharedService.threatReportOverview = this.threatReport;
     this.router.navigate([`/${this.path}/modify`, this.threatReport.id]);
+  }
+
+  /**
+   * @description append / concat only new non saved reports
+   * @return {any[]}
+   */
+  public appendCsvReports(current: any[] = [], updates: any[] = []): any[] {
+    current = current.concat(updates);
+    return current;
   }
 
   /**
@@ -335,7 +342,7 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     // remember to new up an object, otherwise object method will not exist, using just an object literal copy
     const tmp = Object.assign(new ThreatReport(), JSON.parse(JSON.stringify(this.sharedService.threatReportOverview)));
     this.threatReport = tmp;
-    this.csvReports = this.sharedService.threatReportOverview.reports || [];
+    this.csvReports = [];
     // this is needed to make sure boundries is acutally and object and not an object literal at runtime
     this.threatReport.boundries = new Boundries();
     this.threatReport.boundries.intrusions = this.sharedService.threatReportOverview.boundries.intrusions || new Set<{ any }>();

--- a/src/app/threat-report-overview/file-upload/file-upload.component.html
+++ b/src/app/threat-report-overview/file-upload/file-upload.component.html
@@ -1,4 +1,5 @@
 <div *ngIf="loading === false; else loadingBlock">
+    <mat-error *ngIf="errMsg">{{errMsg}}</mat-error>
     <mat-list *ngIf="fName; else uploadBlock">
         <mat-list-item>
             <mat-icon class="paperclip mat-24" mat-list-icon>attachment</mat-icon>

--- a/src/app/threat-report-overview/file-upload/file-upload.component.ts
+++ b/src/app/threat-report-overview/file-upload/file-upload.component.ts
@@ -23,6 +23,7 @@ export class FileUploadComponent implements OnInit {
     public fName = '';
     public numEventsParsed = -1;
     public loading = false;
+    public errMsg;
     private readonly subscriptions = [];
 
   constructor(protected router: Router,
@@ -83,7 +84,12 @@ export class FileUploadComponent implements OnInit {
         this.fileParsedEvent.emit(resp as any);
         // }
       },
-      (err) => console.log(err),
+      (err) => {
+        console.log(err);
+        this.errMsg = err;
+        this.loading = false;
+        this.fName = undefined;
+      },
       () => this.loading = false);
     this.subscriptions.push(s$);
   }

--- a/src/app/threat-report-overview/modify/threat-report-modify.component.html
+++ b/src/app/threat-report-overview/modify/threat-report-modify.component.html
@@ -122,7 +122,6 @@
         <div class="col-md-12 col-xs-12">
             <button color="primary" mat-button (click)="cancel($event)">CANCEL</button>
             <button mat-raised-button color="primary" [disabled]="threatReport && threatReport.reports.length === 0" (click)="save($event)">
-                <mat-icon class="mat-24">save</mat-icon>
                 SAVE
             </button>
         </div>


### PR DESCRIPTION
supports unfetter-discover/unfetter#577

## To Test
1. visit the work product create page, https://localhost:9443/#/threat-dashboard/create
2. click the Import CSV button
3. make it fail.  In chrome 61+ in dev console -> network tab, right click on a api call and "block request domain" or "block request"
4. Verify a failed file upload (timeout, bad file name, no network) should all show a generic red error message above the import button.  Additionally the progress bar should disappear