### PR TITLE
fix spelling, lint

### DIFF
--- a/src/app/threat-dashboard/export/export.component.html
+++ b/src/app/threat-dashboard/export/export.component.html
@@ -1,15 +1,6 @@
-<mat-card>
-    <mat-card-header>
-        <mat-card-title>{{threatReport.name}}</mat-card-title>
-        <mat-card-subtitle>Copy and paste STIX JSON for this work product</mat-card-subtitle>
-    </mat-card-header>
-
-    <mat-card-content>
-        <pre>
-           {{stringify()}}
-        </pre>
-    </mat-card-content>
-    <!-- <mat-card-actions>
-        <button color="green" mat-button>Export</button>
-    </mat-card-actions> -->
-</mat-card>
+<p class="mat-subheader">
+    Copy and paste STIX JSON for this work product
+</p>
+<pre>
+    {{generateJson()}}
+</pre>

--- a/src/app/threat-dashboard/export/export.component.scss
+++ b/src/app/threat-dashboard/export/export.component.scss
@@ -1,8 +1,4 @@
 
-
-.mat-card-content {
-
-    pre {
-        max-height: calc(100vh - 350px);
-    }
+pre {
+    max-height: calc(100vh - 350px);
 }

--- a/src/app/threat-dashboard/export/export.component.ts
+++ b/src/app/threat-dashboard/export/export.component.ts
@@ -39,7 +39,7 @@ export class ExportComponent implements OnInit, OnDestroy {
   /**
    * @description
    */
-  public stringify(): string {
+  public generateJson(): string {
     return JSON.stringify(this.threatReport, undefined, 2);
   }
 

--- a/src/app/threat-dashboard/services/threat-report-overview.service.ts
+++ b/src/app/threat-dashboard/services/threat-report-overview.service.ts
@@ -8,7 +8,7 @@ import * as UUID from 'uuid';
 import { Constance } from '../../utils/constance';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { ThreatReport } from '../../threat-report-overview/models/threat-report.model';
-import { Boundries } from '../../threat-report-overview/models/boundries';
+import { Boundaries } from '../../threat-report-overview/models/boundaries';
 import { Report } from '../../models/report';
 import { JsonApiObject } from '../models/adapter/json-api-object';
 import { SortHelper } from '../../global/static/sort-helper';
@@ -152,13 +152,13 @@ export class ThreatReportOverviewService {
           tr.published = published;
           tr.date = date;
           tr.id = id;
-          const srcBoundries = workProduct.boundries;
-          tr.boundries = new Boundries();
-          tr.boundries.startDate = srcBoundries.startDate;
-          tr.boundries.endDate = srcBoundries.endDate;
-          tr.boundries.intrusions = new Set(Array.from(srcBoundries.intrusions));
-          tr.boundries.malware = new Set(Array.from(srcBoundries.malware));
-          tr.boundries.targets = new Set(Array.from(srcBoundries.targets));
+          const srcBoundries = workProduct.boundaries;
+          tr.boundaries = new Boundaries();
+          tr.boundaries.startDate = srcBoundries.startDate;
+          tr.boundaries.endDate = srcBoundries.endDate;
+          tr.boundaries.intrusions = new Set(Array.from(srcBoundries.intrusions));
+          tr.boundaries.malware = new Set(Array.from(srcBoundries.malware));
+          tr.boundaries.targets = new Set(Array.from(srcBoundries.targets));
           tr.reports.push(report);
           return memo;
         }, {} as { [key: string]: ThreatReport })
@@ -285,13 +285,13 @@ export class ThreatReportOverviewService {
   public deepCopyThreatReportForSave(id: string, threatReport: Partial<ThreatReport>): Partial<ThreatReport> {
     const meta = { work_products: [{}] };
     const workProduct: any = meta.work_products[0];
-    workProduct.boundries = new Boundries();
-    workProduct.boundries.startDate = threatReport.boundries.startDate;
-    workProduct.boundries.endDate = threatReport.boundries.endDate;
+    workProduct.boundaries = new Boundaries();
+    workProduct.boundaries.startDate = threatReport.boundaries.startDate;
+    workProduct.boundaries.endDate = threatReport.boundaries.endDate;
     // Set does not serialize well?, so this needs to be an Array
-    workProduct.boundries.intrusions = Array.from(threatReport.boundries.intrusions || []);
-    workProduct.boundries.malware = Array.from(threatReport.boundries.malware || []);
-    workProduct.boundries.targets = Array.from(threatReport.boundries.targets || []);
+    workProduct.boundaries.intrusions = Array.from(threatReport.boundaries.intrusions || []);
+    workProduct.boundaries.malware = Array.from(threatReport.boundaries.malware || []);
+    workProduct.boundaries.targets = Array.from(threatReport.boundaries.targets || []);
     workProduct.name = threatReport.name;
     workProduct.date = threatReport.date;
     workProduct.author = threatReport.author;

--- a/src/app/threat-dashboard/side-panel/side-panel.component.html
+++ b/src/app/threat-dashboard/side-panel/side-panel.component.html
@@ -11,13 +11,13 @@
     <p class="mat-subheader-1">
         {{threatReport.reports.length || 0}} REPORTS(S)
     </p>
-    <div *ngIf="threatReport.boundries.startDate || threatReport.boundries.endDate; else dateUnspecified" class="header-details">
-        <span *ngIf="threatReport.boundries.startDate; else openEnded">
-            {{threatReport.boundries.startDate | date: 'dd/MM/yyyy'}}
+    <div *ngIf="threatReport.boundaries.startDate || threatReport.boundaries.endDate; else dateUnspecified" class="header-details">
+        <span *ngIf="threatReport.boundaries.startDate; else openEnded">
+            {{threatReport.boundaries.startDate | date: 'dd/MM/yyyy'}}
         </span>
         <span> - </span>
-        <span *ngIf="threatReport.boundries.endDate; else openEnded">
-            {{threatReport.boundries.endDate | date: 'dd/MM/yyyy'}}
+        <span *ngIf="threatReport.boundaries.endDate; else openEnded">
+            {{threatReport.boundaries.endDate | date: 'dd/MM/yyyy'}}
         </span>
         <ng-template #openEnded>
             <span>*</span>
@@ -28,7 +28,7 @@
             No Date Specified
         </div>
     </ng-template>
-    <div class="boundries-fab">
+    <div class="boundaries-fab">
         <button mat-fab color="accent" (click)="openAddReportDialog($event)" matTooltip="Modify Threat Report">
             <mat-icon class="mat-24" aria-label="Add associated reports icon">add</mat-icon>
         </button>
@@ -82,7 +82,7 @@
                 </mat-list-item>
             </mat-list>
         </mat-expansion-panel>
-        <mat-expansion-panel [disabled]="threatReport.boundries.targets.size === 0">
+        <mat-expansion-panel [disabled]="threatReport.boundaries.targets.size === 0">
             <mat-expansion-panel-header>
                 <mat-panel-title>
                     <svg>
@@ -91,16 +91,16 @@
                     <span>
                         Victims
                     </span>
-                    <span>({{threatReport.boundries.targets.size}})</span>
+                    <span>({{threatReport.boundaries.targets.size}})</span>
                 </mat-panel-title>
             </mat-expansion-panel-header>
             <mat-list dense>
-                <mat-list-item [@slideInOutAnimation] *ngFor="let target of threatReport.boundries.targets; trackBy:trackByFn">
+                <mat-list-item [@slideInOutAnimation] *ngFor="let target of threatReport.boundaries.targets; trackBy:trackByFn">
                     {{target}}
                 </mat-list-item>
             </mat-list>
         </mat-expansion-panel>
-        <mat-expansion-panel [disabled]="threatReport.boundries.intrusions.size === 0">
+        <mat-expansion-panel [disabled]="threatReport.boundaries.intrusions.size === 0">
             <mat-expansion-panel-header>
                 <mat-panel-title>
                     <svg>
@@ -109,11 +109,11 @@
                     <span>
                         Intrusion Sets
                     </span>
-                    <span class="">({{threatReport.boundries.intrusions.size}})</span>
+                    <span class="">({{threatReport.boundaries.intrusions.size}})</span>
                 </mat-panel-title>
             </mat-expansion-panel-header>
             <mat-list dense>
-                <mat-list-item [@slideInOutAnimation] class="clickable" *ngFor="let intrusion of threatReport.boundries.intrusions; trackBy:trackByFn"
+                <mat-list-item [@slideInOutAnimation] class="clickable" *ngFor="let intrusion of threatReport.boundaries.intrusions; trackBy:trackByFn"
                     (click)="onNavigateToIntrusion(intrusion.value, $event)" (mouseenter)="listItemMouseEnter($event)" (mouseleave)="listItemMouseLeave($event)">
                     <div mat-line class="">
                         <a href="#/stix/intrusion-sets/{{intrusion.value}}">{{intrusion?.displayValue}}</a>
@@ -121,7 +121,7 @@
                 </mat-list-item>
             </mat-list>
         </mat-expansion-panel>
-        <mat-expansion-panel [disabled]="threatReport.boundries.malware.size === 0">
+        <mat-expansion-panel [disabled]="threatReport.boundaries.malware.size === 0">
             <mat-expansion-panel-header>
                 <mat-panel-title>
                     <svg>
@@ -130,11 +130,11 @@
                     <span>
                         Malware
                     </span>
-                    <span class="">({{threatReport.boundries.malware.size}})</span>
+                    <span class="">({{threatReport.boundaries.malware.size}})</span>
                 </mat-panel-title>
             </mat-expansion-panel-header>
             <mat-list dense>
-                <mat-list-item [@slideInOutAnimation] class="clickable" *ngFor="let malware of threatReport.boundries.malware; trackBy:trackByFn"
+                <mat-list-item [@slideInOutAnimation] class="clickable" *ngFor="let malware of threatReport.boundaries.malware; trackBy:trackByFn"
                     (click)="onNavigateToMalware(malware.value, $event)" (mouseenter)="listItemMouseEnter($event)" (mouseleave)="listItemMouseLeave($event)">
                     <div mat-line class="">
                         <a href="#/stix/malwares/{{malware.value}}">{{malware?.displayValue}}</a>

--- a/src/app/threat-dashboard/side-panel/side-panel.component.scss
+++ b/src/app/threat-dashboard/side-panel/side-panel.component.scss
@@ -23,7 +23,7 @@
     border-bottom: 1px solid rgba(1,1,1, .12);
 }
 
-.boundries-fab {
+.boundaries-fab {
     position: relative;
     left: 270px;
     width: 56px;

--- a/src/app/threat-dashboard/side-panel/side-panel.component.ts
+++ b/src/app/threat-dashboard/side-panel/side-panel.component.ts
@@ -246,7 +246,7 @@ export class SidePanelComponent implements OnInit, OnDestroy {
 
         // add new report
         let tro = new ThreatReport();
-        tro.boundries = this.threatReport.boundries;
+        tro.boundaries = this.threatReport.boundaries;
         tro.name = this.threatReport.name;
         tro.date = this.threatReport.date;
         tro.author = this.threatReport.author;
@@ -254,13 +254,13 @@ export class SidePanelComponent implements OnInit, OnDestroy {
         tro.published = this.threatReport.published;
         tro.reports = this.threatReport.reports || [];
         const threatReport = result as Partial<ThreatReport>;
-        if (threatReport && !isBool && threatReport.boundries) {
-            // this is a boundries update,
-            //  copy over boundries to save to db
-            const boundries = threatReport.boundries;
-            Object.keys(boundries)
-                .filter((key) => boundries[key] !== undefined)
-                .forEach((key) => tro.boundries[key] = boundries[key]);
+        if (threatReport && !isBool && threatReport.boundaries) {
+            // this is a boundaries update,
+            //  copy over boundaries to save to db
+            const boundaries = threatReport.boundaries;
+            Object.keys(boundaries)
+                .filter((key) => boundaries[key] !== undefined)
+                .forEach((key) => tro.boundaries[key] = boundaries[key]);
         } else if (result) {
             // TODO: more efficiently, save this report and update the page
             // this is an update single report operation

--- a/src/app/threat-dashboard/threat-dashboard.component.html
+++ b/src/app/threat-dashboard/threat-dashboard.component.html
@@ -38,7 +38,7 @@
                     <p>Mitigations goes here!</p>
                 </mat-tab>
                 <mat-tab label="EXPORT" disabled="false">
-                    <div class="mb-18 mt-18 mat-card cardHoverShadow">
+                    <div class="mb-18 mt-18 ml-16 mr-16 mat-card cardHoverShadow">
                         <unf-export-component [threatReport]="threatReport"></unf-export-component>
                     </div>
                 </mat-tab>
@@ -58,17 +58,17 @@
                 <use class="icon" xlink:href="assets/icon/stix-icons/svg/all-defs.svg#attack-pattern"></use>
             </svg>
         </div>
-        <div matTooltip="{{threatReport.boundries.targets.size || 0 }} victim(s)" matTooltipPosition="right">
+        <div matTooltip="{{threatReport.boundaries.targets.size || 0 }} victim(s)" matTooltipPosition="right">
             <svg>
                 <use class="icon" xlink:href="assets/icon/stix-icons/svg/all-defs.svg#identity"></use>
             </svg>
         </div>
-        <div matTooltip="{{threatReport.boundries.intrusions.size || 0 }} intrusion set(s)" matTooltipPosition="right">
+        <div matTooltip="{{threatReport.boundaries.intrusions.size || 0 }} intrusion set(s)" matTooltipPosition="right">
             <svg>
                 <use class="icon" xlink:href="assets/icon/stix-icons/svg/all-defs.svg#threat-actor"></use>
             </svg>
         </div>
-        <div matTooltip="{{threatReport.boundries.malware.size || 0 }} malware" matTooltipPosition="right">
+        <div matTooltip="{{threatReport.boundaries.malware.size || 0 }} malware" matTooltipPosition="right">
             <svg>
                 <use class="icon" xlink:href="assets/icon/stix-icons/svg/all-defs.svg#malware"></use>
             </svg>

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -101,7 +101,7 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
     const logErr = (err) => console.log('request err', err);
     const noop = () => { };
     // get intrusion sets, used
-    const intrusionIds = Array.from(this.threatReport.boundries.intrusions).map((el: SelectOption) => el.value);
+    const intrusionIds = Array.from(this.threatReport.boundaries.intrusions).map((el: SelectOption) => el.value);
     if (!intrusionIds || intrusionIds.length === 0) {
       this.renderVisualizations();
       this.notifyDoneLoading();
@@ -124,7 +124,7 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
    */
   public renderVisualizations(): void {
     // get intrusion sets, used
-    const intrusionIds = Array.from(this.threatReport.boundries.intrusions).map((el: SelectOption) => el.value);
+    const intrusionIds = Array.from(this.threatReport.boundaries.intrusions).map((el: SelectOption) => el.value);
     if (!intrusionIds || intrusionIds.length === 0) {
       // build the table and short circuit the rest of the visualizations
       this.buildKillChainTable();
@@ -150,7 +150,7 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description the boundries have been modified, refresh this component
+   * @description the boundaries have been modified, refresh this component
    * @param event
    */
   public onBoundriesModified(event: ThreatReport): void {

--- a/src/app/threat-report-overview/create/threat-report-creation.component.html
+++ b/src/app/threat-report-overview/create/threat-report-creation.component.html
@@ -14,14 +14,14 @@
     <div class="row mt-18">
         <div class="col-xs-12 flex flexItemsCenter">
             <span class="flex flexItemsCenter">
-                <span>Include Boundries&nbsp;</span>
+                <span>Include boundaries&nbsp;</span>
                 <span class="slideWrapper">
-                    <mat-slide-toggle matTooltip="Include/Exclude Boundries" color="primary" (change)="boundriesToggled($event)" [checked]="shouldIncludeBoundries"></mat-slide-toggle>
+                    <mat-slide-toggle matTooltip="Include/Exclude Boundaries" color="primary" (change)="boundariesToggled($event)" [checked]="shouldIncludeBoundaries"></mat-slide-toggle>
                 </span>
             </span>
         </div>
     </div>
-    <div class="row mt-18" id="formWrapper" *ngIf="shouldIncludeBoundries">
+    <div class="row mt-18" id="formWrapper" *ngIf="shouldIncludeBoundaries">
         <div class="col-xs-12">
             <mat-form-field floatPlaceholder="always" >
                 <mat-select placeholder="Intrusion Set" color="primary" (change)="addChip($event.source.selected.value, 'intrusion-set')">
@@ -32,7 +32,7 @@
             </mat-form-field>
             <div class="mt-18 mb-10">
                 <mat-chip-list class="mat-chip-list-stacked" selectable="true">
-                    <mat-chip *ngFor="let selectedIntrusion of threatReport.boundries.intrusions" removable="true" selectable="true">
+                    <mat-chip *ngFor="let selectedIntrusion of threatReport.boundaries.intrusions" removable="true" selectable="true">
                         <div class="flex">
                             <span class="flex1 flexNowrap">{{ selectedIntrusion.displayValue }}</span>
                             <mat-icon matChipRemove (click)="removeChip(selectedIntrusion, 'intrusion-set')">cancel</mat-icon>
@@ -43,7 +43,7 @@
         </div>
         <div class="col-xs-12">
             <mat-form-field floatPlaceholder="always">
-                <input #startDateInput matInput [(ngModel)]="threatReport.boundries.startDate" [max]="maxStartDate" (dateChange)="startDateChanged(startDateInput.value)"
+                <input #startDateInput matInput [(ngModel)]="threatReport.boundaries.startDate" [max]="maxStartDate" (dateChange)="startDateChanged(startDateInput.value)"
                     [(ngModel)]="startDate" [matDatepicker]="startDatePicker" placeholder="Start Date" color="primary" floatPlaceholder="always"
                 />
                 <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
@@ -53,7 +53,7 @@
         </div>
         <div class="col-xs-12">
             <mat-form-field floatPlaceholder="always">
-                <input #endDateInput matInput [(ngModel)]="threatReport.boundries.endDate" [min]="minEndDate" (dateChange)="endDateChanged(endDateInput.value)"
+                <input #endDateInput matInput [(ngModel)]="threatReport.boundaries.endDate" [min]="minEndDate" (dateChange)="endDateChanged(endDateInput.value)"
                     [matDatepicker]="endDatePicker" placeholder="End Date" color="primary" floatPlaceholder="always">
                 <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
                 <mat-datepicker #endDatePicker></mat-datepicker>
@@ -66,7 +66,7 @@
                 <input matInput #targetSelected placeholder="Target" color="primary" floatPlaceholder="always" (keyup.enter)="addChip(targetSelected.value, 'target')">
             </mat-form-field>
             <mat-chip-list class="mat-chip-list-stacked" selectable="true">
-                <mat-chip *ngFor="let target of threatReport.boundries.targets" removable="true">
+                <mat-chip *ngFor="let target of threatReport.boundaries.targets" removable="true">
                     <div class="flex">
                         <span class="flex1 flexNowrap">{{ target }}</span>
                         <mat-icon matChipRemove (click)="removeChip(target, 'target')">cancel</mat-icon>
@@ -84,7 +84,7 @@
             </mat-form-field>
             <div class="mt-18 mb-10">
                 <mat-chip-list class="mat-chip-list-stacked" selectable="true">
-                    <mat-chip *ngFor="let malware of threatReport.boundries.malware" removable="true">
+                    <mat-chip *ngFor="let malware of threatReport.boundaries.malware" removable="true">
                         <div class="flex">
                             <span class="flex1 flexNowrap">{{ malware.displayValue }}</span>
                             <mat-icon matChipRemove (click)="removeChip(malware, 'malware')">cancel</mat-icon>

--- a/src/app/threat-report-overview/create/threat-report-creation.component.ts
+++ b/src/app/threat-report-overview/create/threat-report-creation.component.ts
@@ -12,7 +12,7 @@ import { SelectOption } from '../models/select-option';
 import { UploadService } from '../file-upload/upload.service';
 import { ThreatReport } from '../models/threat-report.model';
 import { ThreatReportSharedService } from '../services/threat-report-shared.service';
-import { Boundries } from '../models/boundries';
+import { Boundaries } from '../models/boundaries';
 import { SortHelper } from '../../global/static/sort-helper';
 import { ModifyReportDialogComponent } from '../modify-report-dialog/modify-report-dialog.component';
 import { Report } from '../../models/report';
@@ -24,7 +24,7 @@ import { Report } from '../../models/report';
 })
 export class ThreatReportCreationComponent implements OnInit, OnDestroy {
 
-  public shouldIncludeBoundries = false;
+  public shouldIncludeBoundaries = false;
   public intrusions: SelectOption[];
   public malware: SelectOption[];
   public maxStartDate;
@@ -54,7 +54,7 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     if (this.sharedService.threatReportOverview) {
       // Deep Clone
       this.clone();
-      this.shouldIncludeBoundries = !this.threatReport.boundries.isEmpty();
+      this.shouldIncludeBoundaries = !this.threatReport.boundaries.isEmpty();
     }
     const intrusionFilter = 'sort=' + encodeURIComponent(JSON.stringify({ name: '1' }));
     const instrusionUrl = `${Constance.INTRUSION_SET_URL}?${intrusionFilter}`;
@@ -100,15 +100,15 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
       this.minEndDate = null;
       this.dateError.startDate.isError = false;
       this.dateError.endDate.isSameOrBefore = false;
-      this.threatReport.boundries.startDate = null;
+      this.threatReport.boundaries.startDate = null;
     } else if (moment(value, this.dateFormat).isValid()) {
-      this.threatReport.boundries.startDate = moment(value, this.dateFormat).toDate();
+      this.threatReport.boundaries.startDate = moment(value, this.dateFormat).toDate();
       this.dateError.startDate.isError = false;
       const date = moment(value, this.dateFormat).add(1, 'd');
       this.minEndDate = new Date(date.year(), date.month(), date.date());
       this.isEndDateSameOrBeforeStartDate(value);
     } else {
-      this.threatReport.boundries.startDate = null;
+      this.threatReport.boundaries.startDate = null;
       this.dateError.startDate.isError = true;
     }
   }
@@ -121,13 +121,13 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     if (!value) {
       this.dateError.endDate.isError = false;
       this.dateError.endDate.isSameOrBefore = false;
-      this.threatReport.boundries.endDate = null;
+      this.threatReport.boundaries.endDate = null;
     } else if (moment(value, this.dateFormat).isValid()) {
       this.dateError.endDate.isError = false;
-      this.threatReport.boundries.endDate = moment(value, this.dateFormat).toDate();
+      this.threatReport.boundaries.endDate = moment(value, this.dateFormat).toDate();
       this.isEndDateSameOrBeforeStartDate(value);
     } else {
-      this.threatReport.boundries.endDate = null;
+      this.threatReport.boundaries.endDate = null;
       this.dateError.endDate.isError = true;
       this.dateError.endDate.isSameOrBefore = false;
 
@@ -135,14 +135,14 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description toggle the boundries checkboxes show hide state
+   * @description toggle the boundaries checkboxes show hide state
    * @param {UIEvent} $event
    * @returns {void}
    */
-  public boundriesToggled($event?: UIEvent): void {
+  public boundariesToggled($event?: UIEvent): void {
     const el = $event as any;
     if (el && el.checked !== undefined) {
-      this.shouldIncludeBoundries = el.checked;
+      this.shouldIncludeBoundaries = el.checked;
     }
   }
 
@@ -159,13 +159,13 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     let chips: Set<any> | undefined;
     switch (stixType) {
       case 'intrusion-set':
-        chips = this.threatReport.boundries.intrusions;
+        chips = this.threatReport.boundaries.intrusions;
         break;
       case 'malware':
-        chips = this.threatReport.boundries.malware;
+        chips = this.threatReport.boundaries.malware;
         break;
       case 'target':
-        chips = this.threatReport.boundries.targets;
+        chips = this.threatReport.boundaries.targets;
         break;
     }
 
@@ -203,13 +203,13 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     let chips;
     switch (stixType) {
       case 'intrusion-set':
-        chips = this.threatReport.boundries.intrusions;
+        chips = this.threatReport.boundaries.intrusions;
         break;
       case 'malware':
-        chips = this.threatReport.boundries.malware;
+        chips = this.threatReport.boundaries.malware;
         break;
       case 'target':
-        chips = this.threatReport.boundries.targets;
+        chips = this.threatReport.boundaries.targets;
         break;
     }
     chips.delete(stixName);
@@ -228,9 +228,9 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
    * @param {UIEvent} event optional
    */
   public onContinue(event: UIEvent): void {
-    // if the boundries check box is checked, do not use boundries provided
-    if (this.isFalsey(this.shouldIncludeBoundries)) {
-      this.threatReport.boundries = new Boundries();
+    // if the boundaries check box is checked, do not use boundaries provided
+    if (this.isFalsey(this.shouldIncludeBoundaries)) {
+      this.threatReport.boundaries = new Boundaries();
     }
     this.sharedService.threatReportOverview = this.threatReport;
     this.router.navigate([`/${this.path}/modify`, this.threatReport.id]);
@@ -291,7 +291,7 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
    */
   private isEndDateSameOrBeforeStartDate(value: any): void {
     if (moment(value, this.dateFormat).isValid() &&
-      moment(this.threatReport.boundries.endDate, this.dateFormat).isSameOrBefore(moment(this.threatReport.boundries.startDate, this.dateFormat))) {
+      moment(this.threatReport.boundaries.endDate, this.dateFormat).isSameOrBefore(moment(this.threatReport.boundaries.startDate, this.dateFormat))) {
       this.dateError.endDate.isSameOrBefore = true;
     } else {
       this.dateError.endDate.isSameOrBefore = false;
@@ -307,16 +307,16 @@ export class ThreatReportCreationComponent implements OnInit, OnDestroy {
     const tmp = Object.assign(new ThreatReport(), JSON.parse(JSON.stringify(this.sharedService.threatReportOverview)));
     this.threatReport = tmp;
     // this.csvReports = [];
-    // this is needed to make sure boundries is acutally and object and not an object literal at runtime
-    this.threatReport.boundries = new Boundries();
-    this.threatReport.boundries.intrusions = this.sharedService.threatReportOverview.boundries.intrusions || new Set<{ any }>();
-    this.threatReport.boundries.targets = this.sharedService.threatReportOverview.boundries.targets || new Set<string>();
-    this.threatReport.boundries.malware = this.sharedService.threatReportOverview.boundries.malware || new Set<{ any }>();
-    if (this.sharedService.threatReportOverview.boundries.startDate) {
-      this.threatReport.boundries.startDate = new Date(this.sharedService.threatReportOverview.boundries.startDate);
+    // this is needed to make sure boundaries is acutally and object and not an object literal at runtime
+    this.threatReport.boundaries = new Boundaries();
+    this.threatReport.boundaries.intrusions = this.sharedService.threatReportOverview.boundaries.intrusions || new Set<{ any }>();
+    this.threatReport.boundaries.targets = this.sharedService.threatReportOverview.boundaries.targets || new Set<string>();
+    this.threatReport.boundaries.malware = this.sharedService.threatReportOverview.boundaries.malware || new Set<{ any }>();
+    if (this.sharedService.threatReportOverview.boundaries.startDate) {
+      this.threatReport.boundaries.startDate = new Date(this.sharedService.threatReportOverview.boundaries.startDate);
     }
-    if (this.sharedService.threatReportOverview.boundries.endDate) {
-      this.threatReport.boundries.endDate = new Date(this.sharedService.threatReportOverview.boundries.endDate);
+    if (this.sharedService.threatReportOverview.boundaries.endDate) {
+      this.threatReport.boundaries.endDate = new Date(this.sharedService.threatReportOverview.boundaries.endDate);
     }
   }
 }

--- a/src/app/threat-report-overview/models/boundaries.ts
+++ b/src/app/threat-report-overview/models/boundaries.ts
@@ -1,4 +1,4 @@
-export class Boundries {
+export class Boundaries {
     public malware = new Set<any>();
     public intrusions = new Set<any>();
     public targets = new Set<string>();

--- a/src/app/threat-report-overview/models/threat-report.model.ts
+++ b/src/app/threat-report-overview/models/threat-report.model.ts
@@ -1,4 +1,4 @@
-import { Boundries } from './boundries';
+import { Boundaries } from './boundaries';
 import { Report } from '../../models/report';
 
 export class ThreatReport {
@@ -8,10 +8,10 @@ export class ThreatReport {
     public author = '';
     public published = false;
 
-    public boundries = new Boundries();
+    public boundaries = new Boundaries();
     public reports: Array<Partial<Report>> = [];
 
     public isEmpty(): boolean {
-        return this.boundries.emptyBoundries() && this.reports.length === 0;
+        return this.boundaries.emptyBoundries() && this.reports.length === 0;
     }
 }

--- a/src/app/threat-report-overview/modify-report-dialog/modify-intrusions/modify-intrusions.component.ts
+++ b/src/app/threat-report-overview/modify-report-dialog/modify-intrusions/modify-intrusions.component.ts
@@ -111,7 +111,7 @@ export class ModifyIntrusionsComponent implements OnInit, OnDestroy {
     const formData = this.form.value;
     this.resetForm();
     const data = {
-      boundries: {
+      boundaries: {
         intrusions: new Set(formData)
       },
     } as Partial<ThreatReport>;

--- a/src/app/threat-report-overview/modify-report-dialog/modify-malwares/modify-malwares.component.ts
+++ b/src/app/threat-report-overview/modify-report-dialog/modify-malwares/modify-malwares.component.ts
@@ -95,8 +95,8 @@ export class ModifyMalwaresComponent implements OnInit, OnDestroy {
     let selectedIdSet;
     let shouldShowSelected = false;
     if (this.threatReport) {
-      const selectedMalware: Set<{ value: string, displayValue: string }> = this.threatReport.boundries.malware;
-      // mark this malware selected if its in our boundries
+      const selectedMalware: Set<{ value: string, displayValue: string }> = this.threatReport.boundaries.malware;
+      // mark this malware selected if its in our boundaries
       selectedMalware.forEach((val) => {
         if (val.value === malware.value) {
           shouldShowSelected = true;
@@ -130,7 +130,7 @@ export class ModifyMalwaresComponent implements OnInit, OnDestroy {
         return el.value;
       });
     const data = {
-      boundries: {
+      boundaries: {
         malware: new Set(selected)
       },
     } as Partial<ThreatReport>;

--- a/src/app/threat-report-overview/modify/threat-report-modify.component.html
+++ b/src/app/threat-report-overview/modify/threat-report-modify.component.html
@@ -4,26 +4,26 @@
             {{ threatReport.name || 'Threat Report Unamed' }}
         </div>
         <div class="col-xs-5 col-md-5">
-            <h4 *ngIf="threatReport.boundries.intrusions.size > 0 || threatReport.boundries.malware.size > 0 || threatReport.boundries.targets.size > 0">
-                Boundries
+            <h4 *ngIf="threatReport.boundaries.intrusions.size > 0 || threatReport.boundaries.malware.size > 0 || threatReport.boundaries.targets.size > 0">
+                boundaries
             </h4>
             <div class="flex" *ngIf="threatReport">
-                <mat-chip-list *ngIf="threatReport.boundries.intrusions.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
-                    <mat-chip *ngFor="let intrusion of threatReport.boundries.intrusions">
+                <mat-chip-list *ngIf="threatReport.boundaries.intrusions.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
+                    <mat-chip *ngFor="let intrusion of threatReport.boundaries.intrusions">
                         <div class="flex">
                             <span class="flex1 flexNowrap">{{ intrusion.displayValue }}</span>
                         </div>
                     </mat-chip>
                 </mat-chip-list>
-                <mat-chip-list *ngIf="threatReport.boundries.targets.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
-                    <mat-chip *ngFor="let target of threatReport.boundries.targets">
+                <mat-chip-list *ngIf="threatReport.boundaries.targets.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
+                    <mat-chip *ngFor="let target of threatReport.boundaries.targets">
                         <div class="flex">
                             <span class="flex1 flexNowrap">{{ target }}</span>
                         </div>
                     </mat-chip>
                 </mat-chip-list>
-                <mat-chip-list *ngIf="threatReport.boundries.malware.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
-                    <mat-chip *ngFor="let malware of threatReport.boundries.malware">
+                <mat-chip-list *ngIf="threatReport.boundaries.malware.size > 0" class="mat-chip-list-stacked margin-chips" selectable="true">
+                    <mat-chip *ngFor="let malware of threatReport.boundaries.malware">
                         <div class="flex">
                             <span class="flex1 flexNowrap">{{ malware.displayValue }}</span>
                         </div>
@@ -34,7 +34,7 @@
         <div class="col-xs-2 col-md-2 flex middle">
             <button mat-button mat-raised-button routerLink="/{{threatDashboard}}/create">
                 <mat-icon class="mat-24">keyboard_backspace</mat-icon>
-                EDIT BOUNDRIES
+                EDIT BOUNDARIES
             </button>
         </div>
     </div>
@@ -49,20 +49,20 @@
                 <mat-icon matSuffix color="primary">search</mat-icon>
             </mat-form-field>
         </div>
-        <div class="col-xs-2 col-md-2" *ngIf="threatReport?.boundries?.startDate">
+        <div class="col-xs-2 col-md-2" *ngIf="threatReport?.boundaries?.startDate">
             <h4>
                 Start Date
             </h4>
-            <span *ngIf="threatReport?.boundries?.startDate; else nonDefined">
-                {{ threatReport?.boundries?.startDate | date:'medium' }}
+            <span *ngIf="threatReport?.boundaries?.startDate; else nonDefined">
+                {{ threatReport?.boundaries?.startDate | date:'medium' }}
             </span>
         </div>
-        <div class="col-xs-2 col-md-2" *ngIf="threatReport?.boundries?.endDate">
+        <div class="col-xs-2 col-md-2" *ngIf="threatReport?.boundaries?.endDate">
             <h4>
                 End Date
             </h4>
-            <span *ngIf="threatReport?.boundries?.endDate; else nonDefined">
-                {{ threatReport?.boundries?.endDate | date:'medium' }}
+            <span *ngIf="threatReport?.boundaries?.endDate; else nonDefined">
+                {{ threatReport?.boundaries?.endDate | date:'medium' }}
             </span>
         </div>
         <div class="col-xs-2 col-md-2 pull-right actions">

--- a/src/app/threat-report-overview/threat-report-overview.component.html
+++ b/src/app/threat-report-overview/threat-report-overview.component.html
@@ -5,7 +5,7 @@
                 Your Work Product(s)
             </h2>
             <span class="subtitle">
-                View your recent work products or create a new one. Work products contain scope, in terms of query boundries in addition
+                View your recent work products or create a new one. Work products contain scope, in terms of query boundaries in addition
                 to reporting references. Work products are not shareable at this time.
             </span>
         </div>


### PR DESCRIPTION
Language is a tool.  Smash it over something like a hammer.  If it fixes the problem great, if it breaks the hammer; even by my own fault, throw it away and get a new one.

requires, https://github.com/unfetter-discover/unfetter/pull/643

## To Test
* pull both projects
* open mongo shell, delete reports `db.getCollection('stix').remove({ 'stix.type': 'report' })`
* restart stack
* visit threat dashboard pages, https://localhost/#/threat-dashboard
* verify boundaries spelling is fixed