### PR TITLE
Initial Layout Checkpoint

### DIFF
--- a/src/app/assess/assess.module.ts
+++ b/src/app/assess/assess.module.ts
@@ -19,6 +19,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { assessmentReducer } from './store/assess.reducers';
 import { AssessLayoutComponent } from './layout/assess-layout.component';
+import { ResultModule } from './result/result.module';
 
 const moduleComponents = [
   AssessLayoutComponent,
@@ -36,6 +37,7 @@ const materialModules = [
   imports: [
     CommonModule,
     ReactiveFormsModule,
+    ResultModule,
     ...materialModules,
     routing,
     StoreModule.forFeature('assessment', assessmentReducer),

--- a/src/app/assess/assess.routing.ts
+++ b/src/app/assess/assess.routing.ts
@@ -2,10 +2,12 @@ import { RouterModule } from '@angular/router';
 
 import { CreateComponent } from './create/create.component';
 import { AssessLayoutComponent } from './layout/assess-layout.component';
+import { SummaryComponent } from './result/summary/summary.component';
+import { FullComponent } from './result/full/full.component';
 
 const routes = [
     {
-        path: '', 
+        path: '',
         component: AssessLayoutComponent,
         children: [
             { path: 'create', component: CreateComponent },
@@ -13,6 +15,8 @@ const routes = [
             // { path: 'wizard/edit/:type/:id', loadChildren: 'app/assess/wizard/wizard.module#WizardModule' },
         ]
     },
+    { path: 'result/summary/:id', component: SummaryComponent },
+    { path: 'result/full/:id', component: FullComponent }
 ];
 
 export const routing = RouterModule.forChild(routes);

--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -1,0 +1,18 @@
+<!-- TODO full -->
+<div id="newAssessmentsSummary" *ngIf="assessment; else loadingBlock" class="fadeIn">
+  <mat-sidenav-container>
+    <mat-sidenav id="sidePanel" mode="side" opened="true">
+      Unfetter Side Panel
+      <!-- <unfetter-side-panel></unfetter-side-panel> -->
+    </mat-sidenav>
+    <mat-sidenav-content>
+      <div id="mainWindow">
+        <result-header></result-header>
+      </div>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
+</div>
+
+<ng-template #loadingBlock>
+  <loading-spinner></loading-spinner>
+</ng-template>

--- a/src/app/assess/result/full/full.component.scss
+++ b/src/app/assess/result/full/full.component.scss
@@ -1,0 +1,9 @@
+@import '../../../../styles/_variables.scss';
+
+#sidePanel {
+    width: 320px;
+}
+
+#mainWindow {
+    min-height: calc(100vh - #{$navbar-height}px);
+}

--- a/src/app/assess/result/full/full.component.spec.ts
+++ b/src/app/assess/result/full/full.component.spec.ts
@@ -1,0 +1,35 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { MatSidenavModule } from '@angular/material';
+
+import { FullComponent } from './full.component';
+
+describe('FullComponent', () => {
+  let component: FullComponent;
+  let fixture: ComponentFixture<FullComponent>;
+
+  const materialModules = [
+    MatSidenavModule
+  ];
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [materialModules,
+        BrowserAnimationsModule],
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [FullComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FullComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'full',
+  templateUrl: './full.component.html',
+  styleUrls: ['./full.component.scss']
+})
+export class FullComponent implements OnInit {
+
+  assessment: boolean;
+
+  constructor() { }
+
+  ngOnInit() {
+    this.assessment = true;
+  }
+}

--- a/src/app/assess/result/result-header/result-header.component.html
+++ b/src/app/assess/result/result-header/result-header.component.html
@@ -1,0 +1,18 @@
+<div id="tabWrapper">
+  <div class="container-fluid height-100-percent">
+    <div class="row height-100-percent flex flexRow">
+      <div class="row height-100-percent flex flexColumn">
+        <div class="flex1"></div>
+        <nav mat-tab-nav-bar class="indent">
+          <a class="noUnderline" mat-tab-link [routerLink]="['../../summary/', 'l']" routerLinkActive #summary="routerLinkActive" [active]="summary.isActive">SUMMARY</a>
+          <a class="noUnderline" mat-tab-link [routerLink]="['../../full/', 'l']" routerLinkActive #full="routerLinkActive" [active]="full.isActive">FULL RESULTS</a>
+        </nav>
+      </div>
+      <div class="flex1"></div>
+      <div class="row height-100-percent flex flexColumn">
+        <div class="flex1"></div>
+        <button mat-raised-button id="publishButton">PUBLISH</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/assess/result/result-header/result-header.component.scss
+++ b/src/app/assess/result/result-header/result-header.component.scss
@@ -1,0 +1,28 @@
+@import '../../../../styles/_variables.scss';
+
+.noUnderline {
+    text-decoration: none;
+}
+
+#tabWrapper {
+    background-color: $assessments-primary-lighter;
+    height: 128px;
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+#publishButton {
+    background-color: $assessments-primary;
+    color: $light-text-default;
+    font-weight: normal;
+    margin-right: 24px;
+    margin-bottom: 7px;
+}
+
+.indent {
+    margin-left: 56px;
+}
+
+.flexColumn {
+    flex-direction: column;
+}

--- a/src/app/assess/result/result-header/result-header.component.spec.ts
+++ b/src/app/assess/result/result-header/result-header.component.spec.ts
@@ -1,0 +1,29 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { ResultHeaderComponent } from './result-header.component';
+
+describe('ResultHeaderComponent', () => {
+  let component: ResultHeaderComponent;
+  let fixture: ComponentFixture<ResultHeaderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [ResultHeaderComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ResultHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/result-header/result-header.component.ts
+++ b/src/app/assess/result/result-header/result-header.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'result-header',
+  templateUrl: './result-header.component.html',
+  styleUrls: ['./result-header.component.scss']
+})
+export class ResultHeaderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/assess/result/result.module.ts
+++ b/src/app/assess/result/result.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatSidenavModule, MatProgressSpinnerModule, MatTabsModule, MatCardModule, MatSliderModule } from '@angular/material';
+
+import { GlobalModule } from '../../global/global.module';
+
+import { SummaryComponent } from './summary/summary.component';
+import { FullComponent } from './full/full.component';
+import { ResultHeaderComponent } from './result-header/result-header.component';
+import { SummaryHeaderComponent } from './summary/summary-header/summary-header.component';
+import { SummaryReportComponent } from './summary/summary-report/summary-report.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatSidenavModule,
+    MatProgressSpinnerModule,
+    MatTabsModule,
+    MatCardModule,
+    MatSliderModule,
+    GlobalModule,
+  ],
+  declarations: [SummaryComponent, FullComponent, ResultHeaderComponent, SummaryHeaderComponent, SummaryReportComponent]
+})
+export class ResultModule { }

--- a/src/app/assess/result/summary/summary-header/summary-header.component.html
+++ b/src/app/assess/result/summary/summary-header/summary-header.component.html
@@ -1,0 +1,11 @@
+<div class="flex flexItemsCenter" id="assessmentsSummaryHeaderComponent">
+  <div class="headerRow" id="bannerRow">
+    <span>Good news!</span>
+  </div>
+  <div class="headerRow">
+    <span>We've reduced your risk already,</span>
+  </div>
+  <div class="headerRow">
+    <span>but we can improve some areas of your defense.</span>
+  </div>
+</div>

--- a/src/app/assess/result/summary/summary-header/summary-header.component.scss
+++ b/src/app/assess/result/summary/summary-header/summary-header.component.scss
@@ -1,0 +1,14 @@
+#assessmentsSummaryHeaderComponent {
+    flex-direction: column;
+    justify-content: center;
+    margin-top: 17px;
+    min-height: 108px; //differs from wireframe (102px) due to wireframe having cut-off letters
+}
+
+#bannerRow {
+    font-size: 34px;
+}
+
+.headerRow {
+    font-size: 24px;
+}

--- a/src/app/assess/result/summary/summary-header/summary-header.component.spec.ts
+++ b/src/app/assess/result/summary/summary-header/summary-header.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatListModule } from '@angular/material';
+
+import { SummaryHeaderComponent } from './summary-header.component';
+
+describe('SummaryHeaderComponent', () => {
+  let component: SummaryHeaderComponent;
+  let fixture: ComponentFixture<SummaryHeaderComponent>;
+
+  const materialModules = [
+    MatListModule
+  ];
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [materialModules],
+      declarations: [SummaryHeaderComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SummaryHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/summary/summary-header/summary-header.component.ts
+++ b/src/app/assess/result/summary/summary-header/summary-header.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'summary-header',
+  templateUrl: './summary-header.component.html',
+  styleUrls: ['./summary-header.component.scss']
+})
+export class SummaryHeaderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -1,0 +1,63 @@
+<div id="report">
+  <div class="container-fluid">
+    <summary-header></summary-header>
+    <div id="summaryTitle">
+      <span>Assessment Report Overview</span>
+    </div>
+    <div class="row">
+      <div class="flex flexItemsCenter">
+        <mat-card color="primary" class="card" id="riskCard">
+          <mat-card-title>Overall Implementation Risk {{totalRiskValue}}%</mat-card-title>
+          <mat-card-subtitle>Weaknesses</mat-card-subtitle>
+          <mat-card-content>
+            <ul *ngIf="weakestAttackPatterns && weakestAttackPatterns.length > 0; else noWeakestAttackPatterns">
+              <li *ngFor="let attackPattern of weakestAttackPatterns">
+                {{attackPattern.description}}
+              </li>
+            </ul>
+            <ng-template #noWeakestAttackPatterns>
+              No Weaknesses found? Either we messed up or you are good!
+            </ng-template>
+          </mat-card-content>
+        </mat-card>
+        <mat-card class="card" id="vulnerabilityCard">
+          <mat-card-title>Test</mat-card-title>
+          <mat-card-content>Test</mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+    <div class="row">
+      <div class="flex">
+        <span>Mitigation Sophistication Threshold</span>
+      </div>
+      <div class="flex flexItemsCenter">
+        <div class="flex flexItemsCenter" id="sliderContainer">
+          <mat-icon color="primary" class="mat-24" aria-hidden="false" aria-label="Least sophisticated mitigation">favorite_border</mat-icon>
+          <mat-slider min="0" max="4" step="1" value="2" id="sophisticationSlider" color="primary">
+          </mat-slider>
+          <mat-icon color="primary" class="mat-24" aria-hidden="false" aria-label="Most sophisticated mitigation">favorite</mat-icon>
+        </div>
+        <div class="flex1">&nbsp;</div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="flex flexItemsCenter">
+        <mat-card class="card" id="riskCard">
+          <mat-card-title>Test</mat-card-title>
+          <mat-card-content>Test</mat-card-content>
+        </mat-card>
+        <mat-card class="card" id="vulnerabilityCard">
+          <mat-card-title>Test</mat-card-title>
+          <mat-card-content>Test</mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+    <div class="row">
+      <div class="flex flexItemsCenter">
+        <mat-card class="card flex1">
+          <mat-card-title>Test</mat-card-title>
+          <mat-card-content>Test</mat-card-content>
+        </mat-card>
+      </div>
+    </div>
+  </div>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.scss
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.scss
@@ -1,0 +1,47 @@
+@import '../../../../../styles/_variables.scss';
+
+#report {
+    margin-left: 24px;
+    margin-right: 24px;
+}
+
+#summaryTitle {
+    font-size: 20px;
+    font-weight: lighter;
+    min-height: 24px;
+    margin-top: 11px;
+    margin-bottom: 14px;
+}
+
+#sliderContainer {
+    min-width: 50%;
+    padding-right: 10px;
+}
+
+#sophisticationSlider {
+    flex-grow: 1;
+    margin-right: 20px;
+    margin-left: 20px;
+}
+
+.card:hover {
+    box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
+}
+
+.card {
+    transition: all 0.3s ease-in-out;
+    min-height: 315px;
+    margin-bottom: 20px;
+    width: 50%;
+    min-width: 215px;
+}
+
+#riskCard {
+    flex-grow: .5;
+    margin-right: 10px;
+}
+
+#vulnerabilityCard {
+    flex-grow: .5;
+    margin-left: 10px;
+}

--- a/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { SummaryReportComponent } from './summary-report.component';
+
+describe('SummaryReportComponent', () => {
+  let component: SummaryReportComponent;
+  let fixture: ComponentFixture<SummaryReportComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [SummaryReportComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SummaryReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'summary-report',
+  templateUrl: './summary-report.component.html',
+  styleUrls: ['./summary-report.component.scss']
+})
+export class SummaryReportComponent implements OnInit {
+
+  totalRiskValue: number;
+  // TODO fix
+  weakestAttackPatterns: any;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+    // TODO fix
+    this.totalRiskValue = 78;
+  }
+}

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -1,0 +1,19 @@
+<!-- TODO summary && weakestAttackPatterns -->
+<div id="newAssessmentsSummary" *ngIf="summary; else loadingBlock" class="fadeIn">
+  <mat-sidenav-container>
+    <mat-sidenav id="sidePanel" mode="side" opened="true">
+      Unfetter Side Panel
+      <!-- <unfetter-side-panel></unfetter-side-panel> -->
+    </mat-sidenav>
+    <mat-sidenav-content>
+      <div id="mainWindow">
+        <result-header></result-header>
+        <summary-report></summary-report>
+      </div>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
+</div>
+
+<ng-template #loadingBlock>
+  <loading-spinner></loading-spinner>
+</ng-template>

--- a/src/app/assess/result/summary/summary.component.scss
+++ b/src/app/assess/result/summary/summary.component.scss
@@ -1,0 +1,9 @@
+@import '../../../../styles/_variables.scss';
+
+#sidePanel {
+    width: 320px;
+}
+
+#mainWindow {
+    min-height: calc(100vh - #{$navbar-height}px);
+}

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+import { SummaryComponent } from './summary.component';
+
+describe('SummaryComponent', () => {
+  let component: SummaryComponent;
+  let fixture: ComponentFixture<SummaryComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [SummaryComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SummaryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'summary',
+  templateUrl: './summary.component.html',
+  styleUrls: ['./summary.component.scss']
+})
+export class SummaryComponent implements OnInit {
+  summary: boolean;
+
+  constructor() { }
+
+  ngOnInit() {
+    this.summary = true;
+  }
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -41,7 +41,8 @@ $analytic-hub-primary-text: $light-text-default;
 
 // Assessments
 $assessments-primary: get-color($blue-grey, 400);
-$assessments-primary-light: get-color($blue-grey, 200);
+$assessments-primary-light: get-color($blue-grey, 300);
+$assessments-primary-lighter: get-color($blue-grey, 200);
 $assessments-accent: get-color($indigo, A400);
 $assessments-accent-text: $light-text-default;
 $assessments-primary-text: $dark-text-default;


### PR DESCRIPTION
This is an initial push of the layout of assess summary view. It also includes a stub for the assess full result view and the mechanics for switching between the two.

Looking for any feedback on the layout and mechanics (resize, look-feel).
Known issues:
  Unfetter Side Panel not integrated yet
  Tiles not fully populated
  Empty / full heart icons should be replaced (suggestions??)

Differences from the wireframes: removed FAB since ADG said FAB was not for creating a new assessment and infosec-alchemist said we should only add Assessed Objects during assessment creation time (not after).

To test: pull branch, build as normal, traverse to:

https://localhost/#/assess/result/summary/l 
Toggle back and forth with SUMMARY and FULL RESULTS.
Resize browser
Give feedback

