### PR TITLE
Issue 692/delete threatdashboard

### DIFF
--- a/src/app/assess/assess.guard.ts
+++ b/src/app/assess/assess.guard.ts
@@ -13,6 +13,8 @@ import { LastModifiedAssessment } from './models/last-modified-assessment';
 @Injectable()
 export class AssessGuard implements CanActivate {
 
+    private readonly CREATE_URL = 'assess/create';
+
     constructor(
         private router: Router,
         public store: Store<AppState>,
@@ -40,7 +42,7 @@ export class AssessGuard implements CanActivate {
                     map((data) => {
                         if (data === undefined || data.length === 0) {
                             // no assessments found, navigate to creation page
-                            this.router.navigate(['assess/create']);
+                            this.router.navigate([this.CREATE_URL]);
                             return false;
                         } else {
                             // has assessments,
@@ -49,6 +51,11 @@ export class AssessGuard implements CanActivate {
                             this.router.navigate(['assess/result/summary', lastModAssessment.rollupId]);
                             return true;
                         }
+                    })
+                    .catch((err) => {
+                        console.log('error in route gaurd, routing to create page', err);
+                        this.router.navigate([this.CREATE_URL]);
+                        return Observable.of(false);
                     });
             });
     }

--- a/src/app/assess/create/create.component.html
+++ b/src/app/assess/create/create.component.html
@@ -21,7 +21,7 @@
                     </div>
                 </mat-card-content>
                 <mat-card-actions>
-                    <button mat-button>CANCEL</button>
+                    <button mat-button (click)="onCancel()">CANCEL</button>
                     <button mat-raised-button color="primary" [disabled]="form.status === 'INVALID'" type="submit">CONTINUE</button>
                 </mat-card-actions>
             </form>

--- a/src/app/assess/create/create.component.spec.ts
+++ b/src/app/assess/create/create.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MatCardModule, MatButtonModule, MatCheckboxModule, MatInputModule } from '@angular/material';
 import { StoreModule, combineReducers } from '@ngrx/store';
@@ -25,6 +26,7 @@ describe('CreateComponent', () => {
       declarations: [CreateComponent],
       imports: [
         NoopAnimationsModule,
+        RouterTestingModule,
         ReactiveFormsModule,
         ...materialModules,
         StoreModule.forRoot({

--- a/src/app/assess/create/create.component.ts
+++ b/src/app/assess/create/create.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Location } from '@angular/common';
 
 import { Store } from '@ngrx/store';
 import * as assessActions from '../store/assess.actions';
@@ -23,6 +24,7 @@ export class CreateComponent implements OnInit {
 
   constructor(
     private formBuilder: FormBuilder,
+    private location: Location,
     public store: Store<assessReducers.AssessState>,
   ) { }
 
@@ -64,5 +66,12 @@ export class CreateComponent implements OnInit {
   public formToAssessment(form: FormGroup): AssessmentMeta {
     const assessment = Object.assign(new AssessmentMeta(), form.value);
     return assessment;
+  }
+
+  /**
+   * @description on cancel, go back a step in window history
+   */
+  public onCancel(): void {
+    this.location.back();
   }
 }

--- a/src/app/assess/models/last-modified-assessment.ts
+++ b/src/app/assess/models/last-modified-assessment.ts
@@ -1,12 +1,8 @@
+import { LastModifiedStix } from '../../global/models/last-modified-stix';
 
 /**
  * @description object returned from the last modified assessments aggregate query
  */
-export class LastModifiedAssessment {
-    _id: string;
-    id: string;
+export class LastModifiedAssessment extends LastModifiedStix {
     rollupId: string;
-    name: string;
-    modified: string;
-    create_by_ref: string;
 }

--- a/src/app/core/services/genericapi.service.ts
+++ b/src/app/core/services/genericapi.service.ts
@@ -5,6 +5,8 @@ import { Constance } from '../../utils/constance';
 import { JsonApiData } from '../../models/json/jsonapi-data';
 import { JsonApi } from '../../models/json/jsonapi';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { LastModifiedStix } from '../../global/models/last-modified-stix';
+import { StixLabelEnum } from '../../models/stix/stix-label.enum';
 
 @Injectable()
 export class GenericApi {
@@ -109,6 +111,43 @@ export class GenericApi {
         this.data = (data !== undefined && data !== null) ? '/' + data : '';
         let builtUrl = this.baseUrl + url + this.data;
         return this.http.delete(builtUrl)
+            .map(this.extractData)
+            .catch(this.handleError);
+    }
+
+    /**
+     * @description retrieve <i>partial last modified stix objects</i>, for all creators/users in system
+     * @return {Observable<Partial<LastModifiedStix>[]>}
+     */
+    public getLatestByType(stixType: StixLabelEnum): Observable<Partial<LastModifiedStix>[]> {
+        if (!stixType || stixType.trim() === '') {
+            return Observable.of([]);
+        }
+
+        const url = `${this.baseUrl}/latest/type/${stixType}`;
+        return this.http
+            .get<JsonApi<Partial<LastModifiedStix>[]>>(url)
+            .map(this.extractData)
+            .catch(this.handleError);
+    }
+
+    /**
+     * @description retrieve <i>partial last modified stix objects</i> for given creator
+     * @param {string} userId, creator mongo user id, not stix identity
+     * @return {Observable<Partial<LastModifiedStix>[]>}
+     */
+    public getLatestByTypeAndCreatorId(stixType: StixLabelEnum, creatorId: string): Observable<Partial<LastModifiedStix>[]> {
+        if (!stixType || stixType.trim() === '') {
+            return Observable.of([]);
+        }
+
+        if (!creatorId || creatorId.trim() === '') {
+            return this.getLatestByType(stixType);
+        }
+
+        const url = `${this.baseUrl}/latest/type/${stixType}/creator/${creatorId}`;
+        return this.http
+            .get<JsonApi<Partial<LastModifiedStix>[]>>(url)
             .map(this.extractData)
             .catch(this.handleError);
     }

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -21,7 +21,7 @@ export class HeaderNavigationComponent {
 
   public appList = [
     {
-      url: 'threat-dashboard/navigate',
+      url: Constance.THREAT_DASHBOARD_NAVIGATE_URL,
       title: 'Threat Dashboard',
       icon: Constance.LOGO_IMG_THREAT_DASHBOARD
     },
@@ -36,7 +36,7 @@ export class HeaderNavigationComponent {
       icon: Constance.LOGO_IMG_ASSESSMENTS
     },
     {
-      url: 'assess/navigate',
+      url: Constance.X_UNFETTER_ASSESSMENT_NAVIGATE_URL,
       title: 'Assessments 2.0',
       icon: Constance.LOGO_IMG_ASSESSMENTS
     },

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -21,7 +21,7 @@ export class HeaderNavigationComponent {
 
   public appList = [
     {
-      url: 'threat-dashboard',
+      url: 'threat-dashboard/navigate',
       title: 'Threat Dashboard',
       icon: Constance.LOGO_IMG_THREAT_DASHBOARD
     },

--- a/src/app/global/models/last-modified-stix.ts
+++ b/src/app/global/models/last-modified-stix.ts
@@ -1,0 +1,11 @@
+/**
+ * @description object to hold ids, creator and last modified attributes of stix objects
+ */
+export class LastModifiedStix {
+    _id: string;
+    id: string;
+    name: string;
+    type: string;
+    modified: string;
+    create_by_ref?: string;
+}

--- a/src/app/models/stix/stix-label.enum.ts
+++ b/src/app/models/stix/stix-label.enum.ts
@@ -5,6 +5,7 @@ export enum StixLabelEnum {
     IDENTITY = 'identity',
     INDICATOR = 'indicator',
     MALWARE = 'malware',
+    REPORT = 'report',
     OBSERVED_DATA = 'observed-data',
     THREAT_REPORT = 'threat-report',
     THREAT_ACTOR = 'threat-actor',

--- a/src/app/threat-dashboard/models/last-modified-threat-report.ts
+++ b/src/app/threat-dashboard/models/last-modified-threat-report.ts
@@ -1,0 +1,6 @@
+import { LastModifiedStix } from '../../global/models/last-modified-stix';
+
+export class LastModifiedThreatReport extends LastModifiedStix {
+    workproductId: string;
+    reportIds: string[];
+}

--- a/src/app/threat-dashboard/services/threat-report-overview.service.ts
+++ b/src/app/threat-dashboard/services/threat-report-overview.service.ts
@@ -12,6 +12,10 @@ import { Boundaries } from '../../threat-report-overview/models/boundaries';
 import { Report } from '../../models/report';
 import { JsonApiObject } from '../models/adapter/json-api-object';
 import { SortHelper } from '../../global/static/sort-helper';
+import { LastModifiedAssessment } from '../../assess/models/last-modified-assessment';
+import { StixLabelEnum } from '../../models/stix/stix-label.enum';
+import { LastModifiedThreatReport } from '../models/last-modified-threat-report';
+import { JsonApi } from '../../models/json/jsonapi';
 
 @Injectable()
 export class ThreatReportOverviewService {
@@ -451,6 +455,32 @@ export class ThreatReportOverviewService {
 
     const o$ = Observable.zip(loadAll$, modifyAll);
     return o$;
+  }
+
+  /**
+   * @description fetch latest threat reports regardless of creatorid
+   * @param {string} id of the workproduct
+   * @return {Observable<Partial<LastModifiedThreatReport>[]>} reports modified
+   */
+  public getLatestReports(): Observable<Partial<LastModifiedThreatReport>[]> {
+    const url = Constance.API_HOST + `/latest/threat-report`;
+    const headers = this.ensureAuthHeaders(this.headers);
+    return this.http
+      .get<JsonApi<Partial<LastModifiedThreatReport>[]>>(url, { headers })
+      .map((resp) => resp.data);
+  }
+
+  /**
+   * @description fetch latest threat reports by creatorId
+   * @param {string} id of the workproduct
+   * @return {Observable<Partial<LastModifiedAssessment>[]>} reports modified
+   */
+  public getLatestReportsByCreatorId(creatorId: string): Observable<Partial<LastModifiedAssessment>[]> {
+    const url = Constance.API_HOST + `/latest/threat-report/creator/${creatorId}`;
+    const headers = this.ensureAuthHeaders(this.headers);
+    return this.http
+      .get<JsonApi<Partial<LastModifiedThreatReport>[]>>(url, { headers })
+      .map((resp) => resp.data);
   }
 
   /**

--- a/src/app/threat-dashboard/services/threat-report-overview.service.ts
+++ b/src/app/threat-dashboard/services/threat-report-overview.service.ts
@@ -16,6 +16,7 @@ import { LastModifiedAssessment } from '../../assess/models/last-modified-assess
 import { StixLabelEnum } from '../../models/stix/stix-label.enum';
 import { LastModifiedThreatReport } from '../models/last-modified-threat-report';
 import { JsonApi } from '../../models/json/jsonapi';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 
 @Injectable()
 export class ThreatReportOverviewService {
@@ -463,11 +464,12 @@ export class ThreatReportOverviewService {
    * @return {Observable<Partial<LastModifiedThreatReport>[]>} reports modified
    */
   public getLatestReports(): Observable<Partial<LastModifiedThreatReport>[]> {
-    const url = Constance.API_HOST + `/latest/threat-report`;
+    const url = Constance.API_HOST + Constance.LATEST_THREAT_REPORTS_URL;
     const headers = this.ensureAuthHeaders(this.headers);
     return this.http
       .get<JsonApi<Partial<LastModifiedThreatReport>[]>>(url, { headers })
-      .map((resp) => resp.data);
+      .map((resp) => resp.data)
+      .catch(this.handleError);
   }
 
   /**
@@ -476,11 +478,12 @@ export class ThreatReportOverviewService {
    * @return {Observable<Partial<LastModifiedAssessment>[]>} reports modified
    */
   public getLatestReportsByCreatorId(creatorId: string): Observable<Partial<LastModifiedAssessment>[]> {
-    const url = Constance.API_HOST + `/latest/threat-report/creator/${creatorId}`;
+    const url = Constance.API_HOST + Constance.LATEST_THREAT_REPORTS_URL + `/creator/${creatorId}`;
     const headers = this.ensureAuthHeaders(this.headers);
     return this.http
       .get<JsonApi<Partial<LastModifiedThreatReport>[]>>(url, { headers })
-      .map((resp) => resp.data);
+      .map((resp) => resp.data)
+      .catch(this.handleError);
   }
 
   /**
@@ -496,6 +499,15 @@ export class ThreatReportOverviewService {
       }
     }
     return headers;
+  }
+
+  /**
+  * @description throw error
+  * @param error
+  */
+  private handleError(error: any): ErrorObservable {
+    console.log(error);
+    return Observable.throw(error);
   }
 
 }

--- a/src/app/threat-dashboard/threat-dashboard.component.html
+++ b/src/app/threat-dashboard/threat-dashboard.component.html
@@ -8,7 +8,7 @@
             <sidepanel-option-item label="Share" icon="share" disabled="true"
                     (click)="shareButtonClicked($event)"></sidepanel-option-item>
             <sidepanel-option-item label="Delete" icon="delete"
-                    (click)="deleteButtonClicked($event)"></sidepanel-option-item>
+                    (click)="onDeleteCurrent()"></sidepanel-option-item>
 
             <master-list-dialog-trigger
                     title="Work Products" width="750px" height="400px"
@@ -18,7 +18,7 @@
                     (create)="createButtonClicked($event)"
                     (select)="cellSelected($event)"
                     (edit)="editButtonClicked($event)"
-                    (delete)="deleteButtonClicked($event)"
+                    (delete)="onDelete($event)"
             ></master-list-dialog-trigger>
 
             <sidepanel-list-item label="Threat Reports" icon="assets/icon/stix-icons/svg/all-defs.svg#campaign"

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -688,11 +688,35 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description loop all reports and delete from mongo a workproduct is related to many reports
-   * @param {ThreatReport} report the UUID of the report to delete
+   * @description clicked currently viewed assessment, confirm delete
    * @return {void}
    */
-  public deleteButtonClicked(report: ThreatReport): void {
+  public onDeleteCurrent(): void {
+    this.confirmDelete({ name: this.threatReport.name, id: this.id });
+  }
+
+  /**
+   * @description clicked master list cell, confirm delete
+   * @param {LastModifiedAssessment} assessment
+   * @return {void}
+   */
+  public onDelete(report: ThreatReport): void {
+    this.confirmDelete(report);
+  }
+  
+  /**
+   * @description loop all reports and delete from mongo a workproduct is related to many reports
+   * @param {ThreatReport} report the UUID of the report to delete
+   * @param {UIEvent} optional event
+   * @return {void}
+   */
+  public confirmDelete(report: { name: string, id: string }, event?: UIEvent): void {
+    if (!report || !report.id || !report.name) {
+      console.log('no report or id given to delete');
+      return;
+    }
+
+    const isCurrentlyViewed = report.id === this.id ? true : false;
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, { data: { attributes: report } });
     const dialogSub$ = dialogRef.afterClosed()
       .subscribe(
@@ -709,8 +733,12 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
           (resp) => {
             const s$ = resp.subscribe(
               (reports) => {
-                console.log('modified ', reports);
-                this.masterListOptions.dataSource.nextDataChange(reports);
+                if (isCurrentlyViewed === true) {
+                  // deleted currently viewed, route to next in last mod, or create page
+                  this.router.navigate([Constance.THREAT_DASHBOARD_NAVIGATE_URL]);
+                } else {
+                  this.masterListOptions.dataSource.nextDataChange(reports);
+                }
               },
               (err) => console.log(err)
             );

--- a/src/app/threat-dashboard/threat-dashboard.module.ts
+++ b/src/app/threat-dashboard/threat-dashboard.module.ts
@@ -34,6 +34,7 @@ import { RadarChartComponent } from './radar-chart/radar-chart.component';
 import { ModifyReportDialogComponent } from '../threat-report-overview/modify-report-dialog/modify-report-dialog.component';
 import { ReportTranslationService } from './services/report-translation.service';
 import { BarChartComponent } from './bar-chart/bar-chart.component';
+import { ThreatReportNavigateGuard } from './threat-report-navigate.guard';
 
 const moduleComponents = [
   AttackPatternCountComponent,
@@ -84,7 +85,8 @@ const primengModules = [CarouselModule];
     ThreatReportOverviewModule,
   ],
   providers: [
-    ...moduleServices
+    ...moduleServices,
+    ThreatReportNavigateGuard,
   ]
 })
 export class ThreatDashboardModule { }

--- a/src/app/threat-dashboard/threat-dashboard.routing.ts
+++ b/src/app/threat-dashboard/threat-dashboard.routing.ts
@@ -1,11 +1,16 @@
 import { RouterModule } from '@angular/router';
 import { ModuleWithProviders } from '@angular/core';
 import { ThreatDashboardComponent } from './threat-dashboard.component';
+import { ThreatReportNavigateGuard } from './threat-report-navigate.guard';
 
 const routes = [
-        {
-            path: 'view/:id', component: ThreatDashboardComponent
-        }
+    {
+        path: 'navigate',
+        canActivate: [ThreatReportNavigateGuard],
+    },
+    {
+        path: 'view/:id', component: ThreatDashboardComponent
+    }
 ];
 
 export const routing = RouterModule.forChild(routes);

--- a/src/app/threat-dashboard/threat-report-navigate.guard.ts
+++ b/src/app/threat-dashboard/threat-report-navigate.guard.ts
@@ -12,6 +12,8 @@ import { LastModifiedThreatReport } from './models/last-modified-threat-report';
 @Injectable()
 export class ThreatReportNavigateGuard implements CanActivate {
 
+    private readonly CREATE_URL = '/threat-dashboard/create';
+
     constructor(
         private router: Router,
         private store: Store<AppState>,
@@ -39,7 +41,7 @@ export class ThreatReportNavigateGuard implements CanActivate {
                     map((data) => {
                         if (data === undefined || data.length === 0) {
                             // nothing found, navigate to creation page
-                            this.router.navigate(['/threat-dashboard/create']);
+                            this.router.navigate([this.CREATE_URL]);
                             return false;
                         } else {
                             // has results,
@@ -48,6 +50,11 @@ export class ThreatReportNavigateGuard implements CanActivate {
                             this.router.navigate(['/threat-dashboard/view', lastMod.workproductId]);
                             return true;
                         }
+                    })
+                    .catch((err) => {
+                        console.log('error in route gaurd, routing to create page', err);
+                        this.router.navigate([this.CREATE_URL]);
+                        return Observable.of(false);
                     });
             });
     }

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -60,6 +60,7 @@ export const Constance = {
   SIGHTING_TYPE: 'sighting',
   SIGHTING_ICON: 'assets/icon/stix-icons/svg/campaign-b.svg',
 
+  THREAT_DASHBOARD_NAVIGATE_URL: 'threat-dashboard/navigate',
   LATEST_THREAT_REPORTS_URL: `api/latest/threat-reports`,
 
   MALWARE_URL: 'api/malwares',
@@ -80,6 +81,7 @@ export const Constance = {
   // TODO change icon
   X_UNFETTER_SENSOR_ICON: 'assets/icon/stix-icons/svg/tool-b.svg',
 
+  X_UNFETTER_ASSESSMENT_NAVIGATE_URL: 'assess/navigate',
   X_UNFETTER_ASSESSMENT_URL: 'api/x-unfetter-assessments',
   X_UNFETTER_ASSESSMENT_TYPE: 'x-unfetter-assessment',
   // TODO change icon

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -60,6 +60,8 @@ export const Constance = {
   SIGHTING_TYPE: 'sighting',
   SIGHTING_ICON: 'assets/icon/stix-icons/svg/campaign-b.svg',
 
+  LATEST_THREAT_REPORTS_URL: `api/latest/threat-reports`,
+
   MALWARE_URL: 'api/malwares',
   MALWARE_TYPE: 'malware',
   MALWARE_ICON: 'assets/icon/stix-icons/svg/malware-b.svg',


### PR DESCRIPTION
supports unfetter-discover/unfetter#692 

This PR requires unfetter-discover/unfetter-store#84

## To Test
* Pull this PR
* Navigate to the threat report or assessments icon in the app header
* verify the create or last modified object is routed to
* if it is a create page, click cancel verify the page routes back to previous
* `npm run lint && npm run build:dev && npm test && npm run coverage`