### PR TITLE
Issue 700/report deletion

### DIFF
--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
@@ -77,7 +77,11 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
         const loadReports$ = this.service.loadAllReports();
         let loadAll$ = Observable.combineLatest(loadReports$)
             .withLatestFrom((results) => {
-                return results[0];
+                let filter = [];
+                if (this.data && this.data.reports) {
+                    filter = this.data.reports;
+                }
+                return results[0].filter(report => !filter.some(have => this.areSameReport(have, report)));
             });
         loadAll$ = loadAll$
             .do(() => {

--- a/src/app/threat-report-overview/editor/threat-report-editor.component.spec.ts
+++ b/src/app/threat-report-overview/editor/threat-report-editor.component.spec.ts
@@ -436,29 +436,6 @@ describe('ThreatReportEditorComponent', () => {
         expect(component.threatReport.reports[0]).toBe(newReport);
     });
 
-    it('should import reports', () => {
-        if (!component.reportsDataSource) {
-            component.reportsDataSource = new MatTableDataSource([]);
-            component.reportsDataSource.data = [];
-        }
-
-        // import a report
-        const newReport = new Report();
-        newReport.attributes.id = '1';
-        newReport.attributes.name = 'new report';
-        component.importReport([newReport]);
-        expect(component.threatReport.reports.length).toBe(1);
-        expect(component.threatReport.reports[0]).toBe(newReport);
-
-        // import another but leave out the first
-        const newerReport = new Report();
-        newerReport.attributes.name = 'newer report';
-        component.importReport([newerReport]);
-        expect(newReport.attributes.created).toBeTruthy();
-        expect(component.threatReport.reports.length).toBe(1);
-        expect(component.threatReport.reports[0]).toBe(newerReport);
-    });
-
     it('should share reports', () => {
         // Not yet implemented
     });


### PR DESCRIPTION
fixes unfetter-discover/unfetter#700

TL;DR: Prevents reports from being deleted until the user hits save. If the user hits Cancel, no reports are lost.

1. Edit an existing work product and, remove a report, but then hit Cancel. Work product should still contain the report.

2. Edit an existing work product and hit import button. Reports that are already on the work product should not appear in the Option 2 table. Select an Option 2 report to add to the work product, and hit Save. Open the import dialog again, and the new report should no longer appear there. Cancel. Remove that report from the work product, and it should again appear on the Option 2 list.
