### PR TITLE
fixes unfetter-discover/unfetter#712, updated demo mode and banner

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,6 +6,7 @@
   <header-navigation [title]="title"></header-navigation>
   
   <div id="routerWrapper">
+    <div *ngIf="showBanner" id="showBannerSpacer"></div>
     <router-outlet></router-outlet>
   </div>
   

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,6 +29,10 @@
   padding-top: $navbar-height + px;
 }
 
+#showBannerSpacer {
+  height: 17px;
+}
+
 @media screen and (max-width: 600px) {
   #routerWrapper {
     padding-top: 56px;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,6 +24,7 @@ export class AppComponent implements OnInit {
   public readonly showBanner = environment.showBanner || false;
   public readonly securityMarkingLabel = environment.bannerText || '';
   public readonly runMode = environment.runMode;
+  public readonly demoMode: boolean = (environment.runMode === 'DEMO');
   public theme: Themes = Themes.DEFAULT;
   public title;
 
@@ -47,11 +48,28 @@ export class AppComponent implements OnInit {
     }
 
     if (this.authService.loggedIn()) {
-      const user = this.authService.getUser();
-      const token = this.authService.getToken();
-      this.store.dispatch(new userActions.LoginUser({ userData: user, token }));
-      this.store.dispatch(new configActions.FetchConfig());
-      this.store.dispatch(new notificationsActions.FetchNotificationStore());
+      if (!this.demoMode) {
+        const user = this.authService.getUser();
+        const token = this.authService.getToken();
+        this.store.dispatch(new userActions.LoginUser({ userData: user, token }));
+        this.store.dispatch(new notificationsActions.FetchNotificationStore());
+      } else {
+        this.store.dispatch(new userActions.LoginUser({
+          userData: {
+            _id: '1234',
+            userName: 'Demo-User',
+            firstName: 'Demo',
+            lastName: 'User',
+            organizations: [
+              {
+                'id': 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                'approved': true,
+                'role': 'STANDARD_USER'
+              }
+            ],
+          }, token: '1234' }));
+      }
+      this.store.dispatch(new configActions.FetchConfig());      
     }
 
     const bodyElement: HTMLElement = document.getElementsByTagName('body')[0];

--- a/src/app/core/services/auth.guard.spec.ts
+++ b/src/app/core/services/auth.guard.spec.ts
@@ -43,6 +43,7 @@ describe('Auth guard should', () => {
     // synchronous beforeEach
     beforeEach(() => {
         authGuard = TestBed.get(AuthGuard);
+        authGuard.demoMode = false;
         userStore = authGuard.store.select('users');
     });
 

--- a/src/app/core/services/auth.guard.ts
+++ b/src/app/core/services/auth.guard.ts
@@ -6,9 +6,11 @@ import { Observable } from 'rxjs/Observable';
 
 import * as fromUsers from '../../root-store/users/users.reducers';
 import * as fromApp from '../../root-store/app.reducers';
+import { environment } from '../../../environments/environment';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
+    private readonly demoMode: boolean = (environment.runMode === 'DEMO');
 
     constructor(
         private router: Router,
@@ -19,27 +21,31 @@ export class AuthGuard implements CanActivate {
         const allowedRoles = route.data['ROLES'];
         return this.store.select('users')
             .take(1)
-            .map((userState: fromUsers.UserState) => {               
-                if (allowedRoles !== undefined && allowedRoles.length) {
-
-                    if (this.loggedIn(userState) && this.hasRole(allowedRoles, userState.role)) {
-                        return true;
-                    } else {
-                        this.router.navigate(['/']);
-                        return false;
-                    }
-
-                    // No specific role is required
+            .map((userState: fromUsers.UserState) => { 
+                if (this.demoMode) {
+                    return true;
                 } else {
+                    if (allowedRoles !== undefined && allowedRoles.length) {
 
-                    if (this.loggedIn(userState)) {
-                        return true;
+                        if (this.loggedIn(userState) && this.hasRole(allowedRoles, userState.role)) {
+                            return true;
+                        } else {
+                            this.router.navigate(['/']);
+                            return false;
+                        }
+
+                        // No specific role is required
                     } else {
-                        this.router.navigate(['/']);
-                        return false;
-                    }
 
-                }   
+                        if (this.loggedIn(userState)) {
+                            return true;
+                        } else {
+                            this.router.navigate(['/']);
+                            return false;
+                        }
+
+                    } 
+                }             
             });
     }
 

--- a/src/app/core/services/auth.guard.ts
+++ b/src/app/core/services/auth.guard.ts
@@ -10,7 +10,7 @@ import { environment } from '../../../environments/environment';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-    private readonly demoMode: boolean = (environment.runMode === 'DEMO');
+    public demoMode: boolean = (environment.runMode === 'DEMO');
 
     constructor(
         private router: Router,

--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar color="primary" id="navComponent" class="mat-elevation-z4">
+<mat-toolbar color="primary" id="navComponent" class="mat-elevation-z4" [ngClass]="{ 'demoMode': demoMode === true }" [style.top]="topPx">
   <a [routerLink]=" ['./'] " routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="flex">
     <div [ngSwitch]="title">
       <img src="assets/icon/logos/unfetter_mini_logo-assessments.svg" alt="Unfetter Logo" class="logo" *ngSwitchCase="'assessments'">
@@ -56,11 +56,11 @@
     </div>
   </span>
 
-  <span id="notificationContainer" class="navButton" *ngIf="authService.loggedIn()">
+  <span id="notificationContainer" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
     <notification-window></notification-window>
   </span>
 
-  <span id="accountWrapper" class="navButton" *ngIf="authService.loggedIn()">
+  <span id="accountWrapper" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
     <div class="cursor-pointer" (click)="showAccountMenu = !showAccountMenu">
       <img src="{{ (user$ | async).userProfile.github.avatar_url }}" alt="User" id="avatar" *ngIf="(user$ | async).userProfile !== null && (user$ | async).userProfile.github.avatar_url !== undefined" class="smallAvatar">
       <button mat-icon-button *ngIf="(user$ | async).userProfile.github.avatar_url === undefined" id="accountBtn">

--- a/src/app/global/components/header-navigation/header-navigation.component.scss
+++ b/src/app/global/components/header-navigation/header-navigation.component.scss
@@ -78,6 +78,10 @@
     right: -98px;
     color: $dark-text-default;
     padding: 25px;
+
+    .demoMode & {
+        right: 10px !important;
+    }
 }
 
 #accountMenuTriangle {

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -62,8 +62,8 @@ export class HeaderNavigationComponent {
 
   public readonly runMode = environment.runMode;
   public readonly showBanner = environment.showBanner;
+  public readonly demoMode: boolean = (environment.runMode === 'DEMO');
   public collapsed: boolean = true;
-  public demoMode: boolean = false;
   public showAppMenu: boolean = false;
   public showAccountMenu: boolean = false;
   public topPx = '0px';
@@ -80,9 +80,7 @@ export class HeaderNavigationComponent {
     private el: ElementRef
   ) {
     this.user$ = this.store.select('users');
-    if (this.runMode && this.runMode === 'DEMO') {
-      this.demoMode = true;
-    }
+    
     if (this.showBanner && this.showBanner === true) {
       this.topPx = '17px';
     }

--- a/src/app/threat-dashboard/threat-report-navigate.guard.ts
+++ b/src/app/threat-dashboard/threat-report-navigate.guard.ts
@@ -8,10 +8,12 @@ import { UserState } from '../root-store/users/users.reducers';
 import { UserProfile } from '../models/user/user-profile';
 import { ThreatReportOverviewService } from './services/threat-report-overview.service';
 import { LastModifiedThreatReport } from './models/last-modified-threat-report';
+import { environment } from '../../environments/environment';
 
 @Injectable()
 export class ThreatReportNavigateGuard implements CanActivate {
 
+    public readonly demoMode: boolean = (environment.runMode === 'DEMO');
     private readonly CREATE_URL = '/threat-dashboard/create';
 
     constructor(
@@ -31,7 +33,7 @@ export class ThreatReportNavigateGuard implements CanActivate {
             .pluck('userProfile')
             .switchMap((user: UserProfile) => {
                 let o$: Observable<Partial<LastModifiedThreatReport>[]>;
-                if (user && user._id) {
+                if (!this.demoMode && user && user._id) {
                     o$ = this.fetchWithCreatorId(user._id);
                 } else {
                     o$ = this.routeNoCreatorId();

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,8 +4,8 @@
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 export const environment = {
     production: false,
-    showBanner: true,
-    bannerText: 'EMPLOYEES ONLY',
+    showBanner: false,
+    bannerText: '',
     runMode: 'DEMO',
     hmr: true
 };


### PR DESCRIPTION
Requirements:
- issue-712 on both `unfetter-ui` and `unfetter-store`
- https://github.com/unfetter-discover/unfetter-store/pull/88

Instructions:
- Stop stack
- Make the following edits to `unfetter/docker-compose.development.yml`:
- Change `RUN_MODE=UAC` to `RUN_MODE=DEMO` (unfetter-discover-api)
- Change `serve:docker:dev:uac` to `serve:docker:dev:demo` (unfetter-ui)
- Confirm app works as expected, baring in mind that features heavily tied to UAC won't work in `DEMO` mode
- Change back to uac mode and confirms app works as normal