### PR TITLE
styles for navigation in assessment results

### DIFF
--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -23,29 +23,33 @@
           </div>
         </div>
         <div class="phases-list">
-          <mat-list-item *ngFor="let phase of assessGroupMain.riskByAttackPattern.phases; trackBy:trackByFn">
-            <div class="phases-list-item">
-              <span class="flex">
-                <span class="phase-name cursor-pointer flex-grow" (click)="assessGroupMain.setPhase(phase._id)">
-                  <b>
-                    {{phase._id | capitalize}}
-                  </b>
-                </span>
-                <span class="align-right">{{assessGroupMain.getRiskByPhase(phase._id) | percent:'2.1-1'}}</span>
+          <div class="phases-list-item cursor-pointer" 
+            *ngFor="let phase of assessGroupMain.riskByAttackPattern.phases; trackBy:trackByFn" 
+            [ngClass]="{'highlightPhase': isCurrentPhase(phase._id)}"
+            (click)="assessGroupMain.setPhase(phase._id)">
+            <div class="item-content flex">
+              <span class="phase-name flex-grow">
+                <b>{{phase._id | capitalize}}</b>
               </span>
-              <span>Attack Patterns {{ phase.attackPatterns.length }}/{{ assessGroupMain.getNumAttackPatterns(phase._id) }}
-              </span>
+              <span class="align-right">{{assessGroupMain.getRiskByPhase(phase._id) | percent:'2.1-1'}}</span>
             </div>
-          </mat-list-item>
-          <div *ngIf="assessGroupMain.unassessedPhases && assessGroupMain.unassessedPhases.length > 0">
-            <hr>
-            <h5 class="text-muted">
-              <small>Unassessed Kill Chain Phases</small>
-            </h5>
-            <div class="attackPatternListItem" *ngFor="let unassessedPhase of assessGroupMain.unassessedPhases">
-              <small>
-                <a (click)="assessGroupMain.setPhase(unassessedPhase)">{{unassessedPhase | capitalize}}</a>
-              </small>
+            <div class="item-content">Attack Patterns {{ phase.attackPatterns.length }}/{{ assessGroupMain.getNumAttackPatterns(phase._id) }}</div>
+          </div>
+        </div>
+        <div class="divider-wrapper">
+        </div>
+        <div *ngIf="assessGroupMain.unassessedPhases && assessGroupMain.unassessedPhases.length > 0">
+          <div class="header">Unassessed Kill Chain Phases</div>
+          <div class="unassessed-phases-list">
+            <div class="unassessed-phases-list-item cursor-pointer" 
+              *ngFor="let phase of assessGroupMain.unassessedPhases; trackBy:trackByFn"
+              [ngClass]="{'highlightPhase': isCurrentPhase(phase)}"
+              (click)="assessGroupMain.setPhase(phase)">
+              <div class="item-content">
+                <span class="phase-name">
+                  <b>{{phase | capitalize}}</b>
+                </span>
+              </div>
             </div>
           </div>
         </div>
@@ -54,7 +58,7 @@
     <mat-sidenav-content>
       <div class="main-panel">
         <result-header [rollupId]="rollupId" [created]="assessment?.created"></result-header>
-        <unf-assess-group #assessGroupMain [assessment]="assessment"></unf-assess-group>
+        <unf-assess-group #assessGroupMain [assessment]="assessment" (phaseChanged)="onPhaseChanged($event)"></unf-assess-group>
       </div>
     </mat-sidenav-content>
   </mat-sidenav-container>

--- a/src/app/assess/result/full/full.component.scss
+++ b/src/app/assess/result/full/full.component.scss
@@ -1,6 +1,16 @@
 @import '../../../../styles/_variables.scss';
 @import './_assess.common.scss';
 
+@mixin with-divider() {
+    border-bottom: 1px solid $assessments-primary-lightest;
+}
+
+@mixin header() {
+    @include with-margin-centered();
+    padding-bottom: 4px;
+    margin-bottom: 4px;
+}
+
 .side-panel {
     width: 320px;
     font-size: 12px;
@@ -11,23 +21,23 @@
         }
     }
 
+    .align-right {
+        text-align: right;
+    }
+
+    .divider-wrapper {
+        @include with-divider();
+    }
+
     .risk-header-wrapper {
-        border-bottom: 1px solid $assessments-primary-lightest;
+        @include with-divider();
 
         .risk-header {
-            @include with-margin-centered();
-            padding-bottom: 4px;
-            margin-bottom: 4px;
-    
-            .align-right {
-                text-align: right;
-            }
+            @include header();
         }
     }
 
     .phases-list {
-        @include with-margin-centered();
-
         .phases-list-item {
             padding-top: 8px;
             padding-bottom: 16px;
@@ -36,7 +46,28 @@
 
     }
 
-    
+    .header {
+        @include header();
+        margin-top: 8px;
+    }
+
+    .item-content {
+        @include with-margin-centered();
+    }
+
+    .unassessed-phases-list {
+        margin-bottom: 12px;
+        
+        .unassessed-phases-list-item {
+            padding-top: 8px;
+            height: 36px;
+        }
+
+    }
+
+    .highlightPhase {
+        background-color: $assessments-primary-subtle !important;
+    }
 }
 
 .main-panel {

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -42,6 +42,7 @@ export class FullComponent implements OnInit, OnDestroy {
     modifyRoute: this.baseAssessUrl,
     createRoute: this.baseAssessUrl + '/create',
   };
+  activePhase: string;
 
   private readonly subscriptions: Subscription[] = [];
 
@@ -258,5 +259,29 @@ export class FullComponent implements OnInit, OnDestroy {
    */
   public trackByFn(index: number, item: any): number {
     return item.id || index;
+  }
+
+  /**
+   * @description the child component assessments group contains the current phase, capture a change to phases
+   *  so we can highlight the currently selected
+   * @param {string} event optional
+   * @return {void}
+   */
+  public onPhaseChanged(event?: string): void {
+    if (!event) {
+      return;
+    }
+
+    this.activePhase = event;
+  }
+
+  /**
+   * @description determines if this components current phase is the same as the given phase
+   *  Used to highlight the selected phase
+   * @param {string} phase
+   * @return {boolean} true if the given phase is selected
+   */
+  public isCurrentPhase(phase = ''): boolean {
+    return this.activePhase ? this.activePhase === phase : false;
   }
 }

--- a/src/app/assess/result/full/group/assessments-group.component.html
+++ b/src/app/assess/result/full/group/assessments-group.component.html
@@ -4,7 +4,7 @@
             <div class="phase-header">{{activePhase | capitalize}}</div>
             <div *ngIf="attackPatternsByPhase && attackPatternsByPhase.length">
                 <span class="fs-12">Attack Patterns</span>
-                <div *ngFor="let ap of attackPatternsByPhase" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAp': isCurrentAp(ap.attackPatternId) }" (click)="setAttackPattern(ap.attackPatternId)">
+                <div *ngFor="let ap of attackPatternsByPhase" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(ap.attackPatternId) }" (click)="setAttackPattern(ap.attackPatternId)">
                     <risk-icon [risk]="getRiskByAttackPatternId(ap.attackPatternId)" [showTooltip]="true" showTextShadow="false"></risk-icon>&nbsp;
                     <span>{{ ap.attackPatternName }}</span>
                 </div>
@@ -14,9 +14,9 @@
             </div>
             <div *ngIf="unassessedAttackPatterns && unassessedAttackPatterns.length > 0">
                 <span class="fs-12">Unassessed Attack Patterns</span>
-                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)" [ngClass]="{'highlightAp': isCurrentAp(unassessedAttackPattern.id)
+                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)
                 }">
-                    <span>{{ unassessedAttackPattern.attributes.name }}</span>
+                    <span>{{ unassessedAttackPattern.name }}</span>
                 </div>
             </div>
         </div>

--- a/src/app/assess/result/full/group/assessments-group.component.scss
+++ b/src/app/assess/result/full/group/assessments-group.component.scss
@@ -68,6 +68,7 @@
     }
 }
 
-.highlightAp {
+.highlightAttackPattern {
     background-color: $assessments-primary-subtle !important;
 }
+

--- a/src/app/assess/services/assess.service.ts
+++ b/src/app/assess/services/assess.service.ts
@@ -20,11 +20,32 @@ export class AssessService {
      * @description call generic api GET request, with given route
      * @param route
      */
-    public genericGet(route: string) {
+    public genericGet(route = '') {
         if (!route) {
             return Observable.empty();
         }
         return this.genericApi.get(route);
+    }
+
+    /**
+     * @description
+     * @param {string} url
+     * @return {Observable<T>}
+     */
+    public getAs<T>(url = ''): Observable<T|T[]> {
+        if (!url) {
+            return Observable.empty();
+        }
+
+        return this.genericApi
+            .getAs<JsonApiData<T>>(url)
+            .map((data) => {
+                if (Array.isArray(data)) {
+                    return data.map((el) => el.attributes);
+                } else {
+                    return data.attributes;
+                }
+            });
     }
 
     /**

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -37,7 +37,7 @@ export class HeaderNavigationComponent {
     },
     {
       url: Constance.X_UNFETTER_ASSESSMENT_NAVIGATE_URL,
-      title: 'Assessments 3.0',
+      title: 'Assessments 2.0',
       icon: Constance.LOGO_IMG_ASSESSMENTS
     },
     {


### PR DESCRIPTION
supports unfetter-discover/unfetter#644

##To Test
* `git checkout` this PR
* navigate to assessments / full results
* click across the phases and attack patterns notice the styles
* verify no errors
* `npm run lint && npm run build:dev && npm run test`