### PR TITLE
Adds tooltips to attack patterns on the threat dashboard

### DIFF
--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
@@ -7,8 +7,8 @@
     </div>
 
     <!--  numVisible="5" -->
-    <p-carousel *ngIf="intrusionSetsDashboard && intrusionSetsDashboard.killChainPhases" [value]="intrusionSetsDashboard.killChainPhases"
-        headerText="Kill Chain Phases Used">
+    <p-carousel *ngIf="intrusionSetsDashboard && intrusionSetsDashboard.killChainPhases"
+            [value]="intrusionSetsDashboard.killChainPhases" headerText="Kill Chain Phases Used">
         <ng-template let-killChainPhase pTemplate="killChainPhase">
             <div class="ui-grid ui-grid-responsive">
                 <div class="ui-grid-row carouselSubheadingRow">
@@ -22,8 +22,10 @@
                         <div class="carousel-content-wrapper">
                             <div class="ui-grid ui-grid-responsive">
                                 <div class="ui-grid-row" *ngFor="let attack_pattern of killChainPhase.attack_patterns">
-                                    <div class="ui-grid-col-12 attack-pattern-div" [style.color]="attack_pattern.foregroundColor" [style.background-color]="attack_pattern.backgroundColor">
-                                        <div class="flexCenter">
+                                    <div class="ui-grid-col-12 attack-pattern-div"
+                                            [style.color]="attack_pattern.foregroundColor"
+                                            [style.background-color]="attack_pattern.backgroundColor">
+                                        <div class="flexCenter" (click)="showAttackPatternTooltip(attack_pattern, $event)">
                                             {{attack_pattern.name}}
                                         </div>
                                     </div>
@@ -48,4 +50,35 @@
             <mat-icon class="mat-24" aria-hidden="true" aria-label="view full table">view_comfy</mat-icon>
         </button>
     </div>
+
+    <ng-template #apTooltipTemplate>
+        <div class="col-md-12 attack-pattern-tooltip">
+            <mat-card>
+                <mat-card-subtitle>
+                    <div class="flex1"><label>{{attackPattern.attributes.name}}</label></div>
+                    <div>
+                        <button mat-button type="button" class="mat-primary">
+                            <a target="_blank" href="/#/stix/attack-patterns/{{attackPattern.id}}">Details</a>
+                        </button>
+                        <button mat-button type="button" (click)="hideAttackPatternTooltip(attackPattern)">Close</button>
+                    </div>
+                </mat-card-subtitle>
+                <mat-card-content>
+                    <div class="row">
+                        <div class="col-md-3"><label>Description</label></div>
+                        <div class="col-md-8 attack-pattern-desc" [innerHTML]="attackPattern.attributes.description"></div>
+                    </div>
+                    <div class="row" *ngIf="attackPattern.attributes.x_mitre_data_sources">
+                        <div class="col-md-3"><label>Data Sources</label></div>
+                        <div class="col-md-9 attack-pattern-sources">{{attackPattern.attributes.x_mitre_data_sources.join(', ')}}</div>
+                    </div>
+                    <div class="row" *ngIf="attackPattern.attributes.x_mitre_platforms">
+                        <div class="col-md-3"><label>Platforms</label></div>
+                        <div class="col-md-9 attack-pattern-platforms">{{attackPattern.attributes.x_mitre_platforms.join(', ')}}</div>
+                    </div>
+                </mat-card-content>
+            </mat-card>
+        </div>
+    </ng-template>
+
 </div>

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
@@ -25,7 +25,8 @@
                                     <div class="ui-grid-col-12 attack-pattern-div"
                                             [style.color]="attack_pattern.foregroundColor"
                                             [style.background-color]="attack_pattern.backgroundColor">
-                                        <div class="flexCenter" (click)="showAttackPatternTooltip(attack_pattern, $event)">
+                                        <div class="flexCenter attack-pattern-clicker"
+                                                (click)="showAttackPatternTooltip(attack_pattern, $event)">
                                             {{attack_pattern.name}}
                                         </div>
                                     </div>

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
@@ -118,6 +118,11 @@ $white: #FFFFFF;
     }
 }
 
+.attack-pattern-clicker:hover {
+    cursor: pointer;
+    text-decoration: underline;
+}
+
 .attack-pattern-tooltip {
 
     padding: 10px;

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
@@ -117,3 +117,55 @@ $white: #FFFFFF;
         }
     }
 }
+
+.attack-pattern-tooltip {
+
+    padding: 10px;
+
+    .mat-card {
+        padding: 12px;
+        background-color: #f0f0f0;
+    }
+
+    .mat-card-subtitle {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0;
+
+        label {
+            color: $dark-text-default;
+        }
+    }
+
+    div.row {
+        margin-bottom: 4px;
+    }
+
+    .attack-pattern-desc {
+        max-height: 60px;
+        overflow: hidden;
+    }
+
+    .attack-pattern-desc:after {
+        content: "";
+        text-align: right;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        top: 40px;
+        width: 70%;
+        height: 20px;
+        background: linear-gradient(to right, rgba(240, 240, 240, 0), rgba(240, 240, 240, 1) 80%);
+    }
+
+    .attack-pattern-sources {
+        max-height: 40px;
+        overflow: hidden;
+    }
+
+    .attack-pattern-platforms {
+        max-height: 20px;
+        overflow: hidden;
+    }
+
+}

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -231,7 +231,10 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
   public loadAttackPatterns(): Observable<AttackPattern[]> {
     const url = Constance.ATTACK_PATTERN_URL + '?' + this.filter + '&project=' + encodeURI(JSON.stringify({
       'stix.name': 1,
+      'stix.description': 1,
       'stix.kill_chain_phases': 1,
+      'extendedProperties.x_mitre_data_sources': 1,
+      'extendedProperties.x_mitre_platforms': 1,
       'stix.id': 1
     }));
     return this.genericApi.get(url)

--- a/src/app/threat-dashboard/threat-dashboard.module.ts
+++ b/src/app/threat-dashboard/threat-dashboard.module.ts
@@ -18,6 +18,8 @@ import { MatSelectModule } from '@angular/material';
 import { MatSlideToggleModule } from '@angular/material';
 import { MatTabsModule } from '@angular/material';
 import { MatTooltipModule } from '@angular/material';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PlatformModule } from '@angular/cdk/platform';
 
 import { CarouselModule } from 'primeng/primeng';
 
@@ -67,6 +69,8 @@ const materialModules = [
   MatSlideToggleModule,
   MatTabsModule,
   MatTooltipModule,
+  OverlayModule,
+  PlatformModule,
 ];
 
 const primengModules = [CarouselModule];


### PR DESCRIPTION
Not married to the style of these tooltips, so any suggestions are welcome.

I also made the tooltips only appear when the attack pattern was clicked, not hovered over. The ADG sketches made it appear as though the graph could have a tooltip open at the same time as the attack patterns, so this did not appear to be an on-hover feature... Again, opinions welcome.