### PR TITLE
Bug 721/report pagination

### DIFF
--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.html
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.html
@@ -109,8 +109,9 @@
                 <mat-header-row *matHeaderRowDef="displayColumns"></mat-header-row>
                 <mat-row *matRowDef="let report; columns: displayColumns;"></mat-row>
             </mat-table>
+            <!-- [showFirstLastButtons]="true" property caused error in tests and webapp? is this a new property and our lib is old? --> 
             <mat-paginator #paginator [length]="curDisplayLen | async" [pageIndex]="0"
-                    [pageSize]="5" [pageSizeOptions]="[5, 10, 25, 100]" [showFirstLastButtons]="true"
+                    [pageSize]="5" [pageSizeOptions]="[5, 10, 25, 100]"
                     (page)="onPage($event)">
             </mat-paginator>
         </div>

--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.html
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.html
@@ -108,10 +108,11 @@
                 </ng-container>
                 <mat-header-row *matHeaderRowDef="displayColumns"></mat-header-row>
                 <mat-row *matRowDef="let report; columns: displayColumns;"></mat-row>
-                <mat-paginator #paginator [length]="curDisplayLen | async" [pageIndex]="0"
-                        [pageSize]="10" [pageSizeOptions]="[5, 10, 25, 100]" (page)="onPage($event)">
-                </mat-paginator>
             </mat-table>
+            <mat-paginator #paginator [length]="curDisplayLen | async" [pageIndex]="0"
+                    [pageSize]="5" [pageSizeOptions]="[5, 10, 25, 100]" [showFirstLastButtons]="true"
+                    (page)="onPage($event)">
+            </mat-paginator>
         </div>
 
         <ng-template #loadingBlock>

--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.scss
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.scss
@@ -64,3 +64,7 @@
         text-align: right;
     }
 }
+
+#current-reports-table {
+    height: 35vh;
+}

--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
@@ -46,7 +46,6 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
 
     @ViewChild('fileUpload') public fileUpload: ElementRef;
 
-    @ViewChild('paginator') public paginator: MatPaginator;
     public curDisplayLen: Observable<number>;
 
     @ViewChildren('filter') public filters: QueryList<ElementRef>;
@@ -64,7 +63,22 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
     ) { }
 
     ngOnInit() {
+    }
+
+    /**
+     * @description initalization after view children are set
+     */
+    public ngAfterViewInit(): void {
         this.load();
+
+        if (this.data && this.data.reports) {
+            this.data.reports.forEach((report) => this.onSelectReport(report));
+        }
+
+        const sub$ = this.filters.changes.subscribe(
+            (comps) => this.initFilter(comps.first),
+            (err) => console.log(err));
+        this.subscriptions.push(sub$);
     }
 
     /**
@@ -95,32 +109,10 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
                 requestAnimationFrame(() => {
                     this.curDisplayLen = this.currents.curDisplayLen$;
                 });
-            })
-            .do(() => {
-                // have to set pager after the table is rendered, pager is used by
-                // datasource to calculate what to display
-                if (this.paginator && this.currents && !this.currents.paginator) {
-                    console.log('setting paginator');
-                    this.currents.paginator = this.paginator;
-                }
             });
 
-        this.currents = new ReportsDataSource(loadAll$, this.paginator);
+        this.currents = new ReportsDataSource(loadAll$);
         return loadReports$;
-    }
-
-    /**
-     * @description initalization after view children are set
-     */
-    public ngAfterViewInit(): void {
-        if (this.data && this.data.reports) {
-            this.data.reports.forEach((report) => this.onSelectReport(report));
-        }
-
-        const sub$ = this.filters.changes.subscribe(
-            (comps) => this.initFilter(comps.first),
-            (err) => console.log(err));
-        this.subscriptions.push(sub$);
     }
 
     /**

--- a/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
+++ b/src/app/threat-report-overview/editor/report-importer/report-importer.component.ts
@@ -63,22 +63,7 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
     ) { }
 
     ngOnInit() {
-    }
-
-    /**
-     * @description initalization after view children are set
-     */
-    public ngAfterViewInit(): void {
         this.load();
-
-        if (this.data && this.data.reports) {
-            this.data.reports.forEach((report) => this.onSelectReport(report));
-        }
-
-        const sub$ = this.filters.changes.subscribe(
-            (comps) => this.initFilter(comps.first),
-            (err) => console.log(err));
-        this.subscriptions.push(sub$);
     }
 
     /**
@@ -113,6 +98,20 @@ export class ReportImporterComponent implements OnInit, AfterViewInit, OnDestroy
 
         this.currents = new ReportsDataSource(loadAll$);
         return loadReports$;
+    }
+
+    /**
+     * @description initalization after view children are set
+     */
+    public ngAfterViewInit(): void {
+        if (this.data && this.data.reports) {
+            this.data.reports.forEach((report) => this.onSelectReport(report));
+        }
+
+        const sub$ = this.filters.changes.subscribe(
+            (comps) => this.initFilter(comps.first),
+            (err) => console.log(err));
+        this.subscriptions.push(sub$);
     }
 
     /**

--- a/src/app/threat-report-overview/editor/report-importer/reports.datasource.ts
+++ b/src/app/threat-report-overview/editor/report-importer/reports.datasource.ts
@@ -20,12 +20,13 @@ export class ReportsDataSource extends DataSource<Report> {
 
     protected readonly filterChange$ = new BehaviorSubject('');
 
-    protected readonly pageChange$ = new BehaviorSubject<PageEvent>(undefined);
+    protected readonly pageChange$ = new BehaviorSubject<PageEvent>({
+        pageIndex: 0,
+        pageSize: 5,
+        length: 0
+    });
 
-    constructor(
-            public reports$: Observable<Report[]>,
-            public paginator?: MatPaginator
-    ) {
+    constructor(public reports$: Observable<Report[]>) {
         super();
         const co = reports$.multicast(this.dataChange$);
         co.connect();

--- a/src/app/threat-report-overview/editor/threat-report-editor.component.ts
+++ b/src/app/threat-report-overview/editor/threat-report-editor.component.ts
@@ -383,7 +383,7 @@ export class ThreatReportEditorComponent implements OnInit, OnDestroy {
         this.dialog
             .open(ReportImporterComponent, {
                 width: '100%',
-                height: 'calc(100vh - 160px)',
+                height: '70vh',
                 data: {
                     reports: this.reportsDataSource.data,
                 }


### PR DESCRIPTION
fixes unfetter-discover/unfetter#721

pagination should now work on the work product editor -> import reports dialog, defaults it to display five reports at a time (due to size of dialog)

The default database setup only includes four reports, so create and save a few reports first to test out  the paging functionality (unless your name is mushinlogit and you have, like, billions of them already).