### PR TITLE
New assessments summary

### DIFF
--- a/src/app/assess/assess.guard.ts
+++ b/src/app/assess/assess.guard.ts
@@ -48,7 +48,7 @@ export class AssessGuard implements CanActivate {
                             // has assessments,
                             //  navigate to the last modified
                             const lastModAssessment = data[0];
-                            this.router.navigate(['assess/result/summary', lastModAssessment.rollupId]);
+                            this.router.navigate(['assess/result/summary', lastModAssessment.id]);
                             return true;
                         }
                     })

--- a/src/app/assess/assess.guard.ts
+++ b/src/app/assess/assess.guard.ts
@@ -48,7 +48,7 @@ export class AssessGuard implements CanActivate {
                             // has assessments,
                             //  navigate to the last modified
                             const lastModAssessment = data[0];
-                            this.router.navigate(['assess/result/summary', lastModAssessment.id]);
+                            this.router.navigate(['/assess/result/summary', lastModAssessment.rollupId, lastModAssessment.id]);
                             return true;
                         }
                     })

--- a/src/app/assess/assess.routing.ts
+++ b/src/app/assess/assess.routing.ts
@@ -20,8 +20,9 @@ const routes = [
             // { path: 'wizard/edit/:type/:id', loadChildren: 'app/assess/wizard/wizard.module#WizardModule' },
         ]
     },
-    { path: 'result/summary/:rollupId', component: SummaryComponent },
-    { path: 'result/full/:rollupId', component: FullComponent },
+    // { path: 'result/summary/:rollupId', component: SummaryComponent },
+    { path: 'result/summary/:rollupId/:assessmentId', component: SummaryComponent },
+    // { path: 'result/full/:rollupId', component: FullComponent },
     { path: 'result/full/:rollupId/:assessmentId', component: FullComponent },
     { path: 'result/full/:rollupId/:assessmentId/phase/:phase', component: FullComponent },
     { path: 'result/full/:rollupId/:assessmentId/phase/:phase/attackPattern/:attackPattern', component: FullComponent },

--- a/src/app/assess/layout/assess-layout.component.scss
+++ b/src/app/assess/layout/assess-layout.component.scss
@@ -1,7 +1,7 @@
 @import '../../../styles/_variables.scss';
 
 .titleWrapper {
-    background: $assessments-primary-light;
+    background: $assessments-primary-lightest;
     height: 128px;
     position: relative;
 }

--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -57,7 +57,7 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [rollupId]="rollupId" [created]="assessment?.created"></result-header>
+        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="assessment?.created"></result-header>
         <unf-assess-group #assessGroupMain [activePhase]="phase" [rollupId]="rollupId" [assessment]="assessment" (phaseChanged)="onPhaseChanged($event)"></unf-assess-group>
       </div>
     </mat-sidenav-content>

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -18,8 +18,6 @@ import { SummaryDataSource } from '../summary/summary.datasource';
 import { UserProfile } from '../../../models/user/user-profile';
 import { FullAssessmentResultState } from '../store/full-result.reducers';
 import { AssessedByAttackPattern } from './group/models/assessed-by-attack-pattern';
-import { GroupAttackPattern } from './group/models/group-attack-pattern';
-import { GroupPhase } from './group/models/group-phase';
 import { Constance } from '../../../utils/constance';
 
 @Component({

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -32,6 +32,7 @@ export class FullComponent implements OnInit, OnDestroy {
   assessment: Assessment;
   assessmentName: Observable<string>;
   rollupId: string;
+  assessmentId: string;
   phase: string;
   attackPatternId: string;
   finishedLoading = false;
@@ -63,6 +64,7 @@ export class FullComponent implements OnInit, OnDestroy {
     const idParamSub$ = this.route.params
       .subscribe((params) => {
         this.rollupId = params.rollupId || '';
+        this.assessmentId = params.assessmentId || '';
         this.phase = params.phase || '';
         this.attackPatternId = params.attackPatternId || '';
 
@@ -240,7 +242,7 @@ export class FullComponent implements OnInit, OnDestroy {
       return;
     }
 
-    return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId]);
+    return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId, assessment.id]);
   }
 
   /**

--- a/src/app/assess/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/result/full/group/assessments-group.component.ts
@@ -12,15 +12,13 @@ import { AssessmentObject } from '../../../../models/assess/assessment-object';
 import { AttackPattern } from '../../../../models/attack-pattern';
 import { Constance } from '../../../../utils/constance';
 import { DisplayedAssessmentObject } from './models/displayed-assessment-object';
-import { GroupAttackPattern } from './models/group-attack-pattern';
-import { GroupPhase } from './models/group-phase';
 import { FormatHelpers } from '../../../../global/static/format-helpers';
 import { Stix } from '../../../../models/stix/stix';
 import { SortHelper } from '../../../../global/static/sort-helper';
 import { FullAssessmentResultState } from '../../store/full-result.reducers';
 import { Store } from '@ngrx/store';
-import { RiskByAttackPattern } from './models/risk-by-attack-pattern';
 import { LoadGroupData, LoadGroupCurrentAttackPattern, PushUrl } from '../../store/full-result.actions';
+import { RiskByAttack } from '../../../../models/assess/risk-by-attack';
 
 @Component({
   selector: 'unf-assess-group',
@@ -55,7 +53,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public courseOfAction: any;
   public xUnfetterSensor: any;
 
-  public riskByAttackPattern: RiskByAttackPattern;
+  public riskByAttackPattern: RiskByAttack;
   public assessedObjects: AssessmentObject[];
   public unassessedPhases: string[];
   public currentAttackPattern: Stix;

--- a/src/app/assess/result/full/group/models/group-attack-pattern.ts
+++ b/src/app/assess/result/full/group/models/group-attack-pattern.ts
@@ -1,6 +1,0 @@
-import { AttackPattern } from '../../../../../models/attack-pattern';
-
-export class GroupAttackPattern {
-  attackPatterns: AttackPattern[];
-  _id: string;
-}

--- a/src/app/assess/result/full/group/models/group-phase.ts
+++ b/src/app/assess/result/full/group/models/group-phase.ts
@@ -1,6 +1,0 @@
-
-export class GroupPhase {
-    _id: string;
-    assessedObjects: any[];
-    attackPatterns: any[];
-}

--- a/src/app/assess/result/full/group/models/risk-by-attack-pattern.ts
+++ b/src/app/assess/result/full/group/models/risk-by-attack-pattern.ts
@@ -1,9 +1,0 @@
-import { AssessedByAttackPattern } from './assessed-by-attack-pattern';
-import { GroupAttackPattern } from './group-attack-pattern';
-import { GroupPhase } from './group-phase';
-
-export class RiskByAttackPattern {
-    assessedByAttackPattern: AssessedByAttackPattern[];
-    attackPatternsByKillChain: GroupAttackPattern[];
-    phases: GroupPhase[];
-}

--- a/src/app/assess/result/result-header/result-header.component.html
+++ b/src/app/assess/result/result-header/result-header.component.html
@@ -15,7 +15,7 @@
           Published &bull; {{ created | date:'medium' }}
         </div>
         <ng-template #notPublished>
-            <button mat-raised-button id="publishButton">PUBLISH</button>
+            <button id="publishButton">PUBLISH</button>
         </ng-template>
       </div>
     </div>

--- a/src/app/assess/result/result-header/result-header.component.ts
+++ b/src/app/assess/result/result-header/result-header.component.ts
@@ -8,7 +8,9 @@ import { Component, OnInit, Input } from '@angular/core';
 export class ResultHeaderComponent implements OnInit {
 
   @Input()
-  public rollupId: string;
+  rollupId: string;
+  @Input()
+  assessmentId: string;
 
   @Input()
   public created: Date;
@@ -23,8 +25,9 @@ export class ResultHeaderComponent implements OnInit {
    * @return {void}
    */
   public ngOnInit(): void {
-    this.summaryLink = `../../summary/${this.rollupId}`;
-    this.resultsLink = `../../full/${this.rollupId}`;
+    const base = '/assess/result/';
+    this.summaryLink = `${base}/summary/${this.rollupId}/${this.assessmentId}`;
+    this.resultsLink = `${base}/full/${this.rollupId}/${this.assessmentId}`;
   }
 
 }

--- a/src/app/assess/result/result.module.ts
+++ b/src/app/assess/result/result.module.ts
@@ -27,6 +27,7 @@ import { AssessGroupComponent } from './full/group/assessments-group.component';
 import { AddAssessedObjectComponent } from './full/group/add-assessed-object/add-assessed-object.component';
 import { SummaryCalculationService } from './summary/summary-calculation.service';
 import { SophisticationBreakdownComponent } from './summary/summary-report/sophistication-breakdown/sophistication-breakdown.component';
+import { TechniquesChartComponent } from './summary/summary-report/techniques-chart/techniques-chart.component';
 
 const materialModules = [
   MatCardModule,
@@ -52,34 +53,23 @@ const moduleComponents = [
     CommonModule,
     FormsModule,
     RouterModule,
-<<<<<<< HEAD
     ...materialModules,
-=======
-    MatSidenavModule,
-    MatProgressSpinnerModule,
-    MatTabsModule,
-    MatCardModule,
-    MatSliderModule,
-    MatTableModule,
-    ChartsModule,
->>>>>>> still working, 1/3 of charts works, but only for a single assessment, slider does not yet work
     GlobalModule,
+    ChartsModule,
     StoreModule.forFeature('summary', summaryReducer),
     StoreModule.forFeature('fullAssessment', fullAssessmentResultReducer),
     StoreModule.forFeature('riskByAttackPattern', riskByAttackPatternReducer),
     EffectsModule.forFeature([SummaryEffects, FullResultEffects, RiskByAttackPatternEffects]),
   ],
-<<<<<<< HEAD
   declarations: [
     ...moduleComponents,
     SummaryComponent,
     FullComponent,
     ResultHeaderComponent,
     SummaryHeaderComponent,
-    SummaryReportComponent],
-=======
-  declarations: [SummaryComponent, FullComponent, ResultHeaderComponent, SummaryHeaderComponent, SummaryReportComponent, SophisticationBreakdownComponent],
->>>>>>> still working, 1/3 of charts works, but only for a single assessment, slider does not yet work
+    SummaryReportComponent,
+    SophisticationBreakdownComponent,
+    TechniquesChartComponent],
   providers: [SummaryCalculationService]
 })
 export class ResultModule { }

--- a/src/app/assess/result/result.module.ts
+++ b/src/app/assess/result/result.module.ts
@@ -9,18 +9,21 @@ import { EffectsModule } from '@ngrx/effects';
 
 import { GlobalModule } from '../../global/global.module';
 
+import { SummaryEffects } from './store/summary.effects';
+import { summaryReducer } from './store/summary.reducers';
+import { RiskByAttackPatternEffects } from './store/riskbyattackpattern.effects';
+import { riskByAttackPatternReducer } from './store/riskbyattackpattern.reducers';
 import { SummaryComponent } from './summary/summary.component';
 import { FullComponent } from './full/full.component';
 import { ResultHeaderComponent } from './result-header/result-header.component';
 import { SummaryHeaderComponent } from './summary/summary-header/summary-header.component';
 import { SummaryReportComponent } from './summary/summary-report/summary-report.component';
 import { AssessmentsSummaryComponent } from '../../assessments/assessments-summary/assessments-summary.component';
-import { SummaryEffects } from './store/summary.effects';
-import { summaryReducer } from './store/summary.reducers';
 import { FullResultEffects } from './store/full-result.effects';
 import { fullAssessmentResultReducer } from './store/full-result.reducers';
 import { AssessGroupComponent } from './full/group/assessments-group.component';
 import { AddAssessedObjectComponent } from './full/group/add-assessed-object/add-assessed-object.component';
+import { SummaryCalculationService } from './summary/summary-calculation.service';
 
 const materialModules = [
   MatCardModule,
@@ -50,10 +53,16 @@ const moduleComponents = [
     GlobalModule,
     StoreModule.forFeature('summary', summaryReducer),
     StoreModule.forFeature('fullAssessment', fullAssessmentResultReducer),
-    EffectsModule.forFeature([SummaryEffects, FullResultEffects]),
+    StoreModule.forFeature('riskByAttackPattern', riskByAttackPatternReducer),
+    EffectsModule.forFeature([SummaryEffects, FullResultEffects, RiskByAttackPatternEffects]),
   ],
   declarations: [
     ...moduleComponents,
-  ],
+    SummaryComponent,
+    FullComponent,
+    ResultHeaderComponent,
+    SummaryHeaderComponent,
+    SummaryReportComponent],
+  providers: [SummaryCalculationService]
 })
 export class ResultModule { }

--- a/src/app/assess/result/result.module.ts
+++ b/src/app/assess/result/result.module.ts
@@ -7,6 +7,8 @@ import { MatProgressSpinnerModule, MatTabsModule, MatCardModule, MatSliderModule
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 
+import { ChartsModule } from 'ng2-charts';
+
 import { GlobalModule } from '../../global/global.module';
 
 import { SummaryEffects } from './store/summary.effects';
@@ -24,6 +26,7 @@ import { fullAssessmentResultReducer } from './store/full-result.reducers';
 import { AssessGroupComponent } from './full/group/assessments-group.component';
 import { AddAssessedObjectComponent } from './full/group/add-assessed-object/add-assessed-object.component';
 import { SummaryCalculationService } from './summary/summary-calculation.service';
+import { SophisticationBreakdownComponent } from './summary/summary-report/sophistication-breakdown/sophistication-breakdown.component';
 
 const materialModules = [
   MatCardModule,
@@ -49,13 +52,24 @@ const moduleComponents = [
     CommonModule,
     FormsModule,
     RouterModule,
+<<<<<<< HEAD
     ...materialModules,
+=======
+    MatSidenavModule,
+    MatProgressSpinnerModule,
+    MatTabsModule,
+    MatCardModule,
+    MatSliderModule,
+    MatTableModule,
+    ChartsModule,
+>>>>>>> still working, 1/3 of charts works, but only for a single assessment, slider does not yet work
     GlobalModule,
     StoreModule.forFeature('summary', summaryReducer),
     StoreModule.forFeature('fullAssessment', fullAssessmentResultReducer),
     StoreModule.forFeature('riskByAttackPattern', riskByAttackPatternReducer),
     EffectsModule.forFeature([SummaryEffects, FullResultEffects, RiskByAttackPatternEffects]),
   ],
+<<<<<<< HEAD
   declarations: [
     ...moduleComponents,
     SummaryComponent,
@@ -63,6 +77,9 @@ const moduleComponents = [
     ResultHeaderComponent,
     SummaryHeaderComponent,
     SummaryReportComponent],
+=======
+  declarations: [SummaryComponent, FullComponent, ResultHeaderComponent, SummaryHeaderComponent, SummaryReportComponent, SophisticationBreakdownComponent],
+>>>>>>> still working, 1/3 of charts works, but only for a single assessment, slider does not yet work
   providers: [SummaryCalculationService]
 })
 export class ResultModule { }

--- a/src/app/assess/result/store/full-result.actions.ts
+++ b/src/app/assess/result/store/full-result.actions.ts
@@ -2,8 +2,8 @@ import { Action } from '@ngrx/store';
 
 import { Assessment } from '../../../models/assess/assessment';
 import { AssessmentObject } from '../../../models/assess/assessment-object';
-import { RiskByAttackPattern } from '../full/group/models/risk-by-attack-pattern';
 import { Stix } from '../../../models/stix/stix';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 
 // For effects
 export const LOAD_ASSESSMENT_RESULT_DATA = '[Assess Result] LOAD_ASSESSMENT_RESULT_DATA';
@@ -55,7 +55,7 @@ export class SetGroupRiskByAttackPattern implements Action {
     public readonly type = SET_GROUP_RISK_BY_ATTACK_PATTERN;
 
     // individual assessment id, ie not the rollup
-    constructor(public payload: RiskByAttackPattern) { }
+    constructor(public payload: RiskByAttack) { }
 }
 
 export class LoadGroupCurrentAttackPattern implements Action {
@@ -70,7 +70,7 @@ export class SetGroupCurrentAttackPattern implements Action {
 export class SetGroupData implements Action {
     public readonly type = SET_GROUP_DATA;
 
-    constructor(public payload: { assessedObjects: AssessmentObject[], riskByAttackPattern: RiskByAttackPattern }) { }
+    constructor(public payload: { assessedObjects: AssessmentObject[], riskByAttackPattern: RiskByAttack }) { }
 }
 
 export class PushUrl implements Action {

--- a/src/app/assess/result/store/full-result.effects.ts
+++ b/src/app/assess/result/store/full-result.effects.ts
@@ -11,6 +11,8 @@ import { LOAD_ASSESSMENT_RESULT_DATA, SetAssessments, FinishedLoading, SetGroupA
 import { fullAssessmentResultReducer } from './full-result.reducers';
 import { Constance } from '../../../utils/constance';
 import { Stix } from '../../../models/stix/stix';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+// import { RiskByAttackPattern } from '../full/group/models/risk-by-attack-pattern';
 
 
 @Injectable()
@@ -40,7 +42,7 @@ export class FullResultEffects {
             return Observable.forkJoin(getAssessedObjects$, getRiskByAttackPattern$);
         })
         .map(([assessedObjects, riskByAttackPattern]) => {
-            riskByAttackPattern = riskByAttackPattern || {};
+            riskByAttackPattern = riskByAttackPattern || new RiskByAttack;
             return new SetGroupData({ assessedObjects, riskByAttackPattern });
         });
 

--- a/src/app/assess/result/store/full-result.reducers.ts
+++ b/src/app/assess/result/store/full-result.reducers.ts
@@ -4,9 +4,8 @@ import { AssessmentObject } from '../../../models/assess/assessment-object';
 import { AssessedByAttackPattern } from '../full/group/models/assessed-by-attack-pattern';
 import { DisplayedAssessmentObject } from '../full/group/models/displayed-assessment-object';
 import { FullAssessmentResultActions, LOAD_ASSESSMENT_RESULT_DATA } from './full-result.actions';
-import { GroupAttackPattern } from '../full/group/models/group-attack-pattern';
-import { GroupPhase } from '../full/group/models/group-phase';
 import { Stix } from '../../../models/stix/stix';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 
 export interface FullAssessmentResultState {
     fullAssessment: Assessment;
@@ -18,11 +17,7 @@ export interface FullAssessmentResultState {
 export interface FullAssessmentGroupState {
     finishedLoadingGroupData: boolean;
     currentAttackPattern: Stix;
-    riskByAttackPattern: {
-        assessedByAttackPattern: AssessedByAttackPattern[],
-        attackPatternsByKillChain: GroupAttackPattern[],
-        phases: GroupPhase[],
-    };
+    riskByAttackPattern: RiskByAttack;
     assessedObjects: AssessmentObject[];
     unassessedPhases: string[];
     displayedAssessedObjects: DisplayedAssessmentObject[];

--- a/src/app/assess/result/store/riskbyattackpattern.actions.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.actions.ts
@@ -1,0 +1,44 @@
+import { Action } from '@ngrx/store';
+import { Stix } from '../../models/stix/stix';
+import { JsonApiData } from '../../../models/json/jsonapi-data';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+
+// For effects
+export const LOAD_RISK_BY_ATTACK_PATTERN_DATA = '[Assess Risk By Attack Pattern] LOAD_RISK_BY_ATTACK_PATTERN_DATA';
+export const LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA = '[Assess Risk By Attack Pattern] LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA';
+
+// For reducers
+export const SET_RISK_BY_ATTACK_PATTERNS = '[Assess Risk By Attack Pattern] SET_RISK_BY_ATTACK_PATTERN_DATA';
+export const FINISHED_LOADING = '[Assess Risk By Attack Pattern] FINISHED_LOADING';
+
+export class LoadSingleAssessmentRiskByAttackPatternData implements Action {
+    public readonly type = LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA;
+
+    // individual assessment id
+    constructor(public payload: string) { }
+}
+
+export class LoadAssessmentRiskByAttackPatternData implements Action {
+    public readonly type = LOAD_RISK_BY_ATTACK_PATTERN_DATA;
+
+    // assessment rollup id
+    constructor(public payload: string) { }
+}
+
+export class SetRiskByAttackPattern implements Action {
+    public readonly type = SET_RISK_BY_ATTACK_PATTERNS;
+
+    constructor(public payload: RiskByAttack[]) { }
+}
+
+export class FinishedLoading implements Action {
+    public readonly type = FINISHED_LOADING;
+
+    constructor(public payload: boolean) { }
+}
+
+export type RiskByAttackPatternActions =
+    SetRiskByAttackPattern |
+    LoadAssessmentRiskByAttackPatternData |
+    LoadSingleAssessmentRiskByAttackPatternData |
+    FinishedLoading;

--- a/src/app/assess/result/store/riskbyattackpattern.effects.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.effects.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+
+import { Actions, Effect } from '@ngrx/effects';
+import { Observable } from 'rxjs/Observable';
+
+import { AssessmentSummaryService } from '../../services/assessment-summary.service';
+
+import { LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA, LOAD_RISK_BY_ATTACK_PATTERN_DATA, FinishedLoading, SetRiskByAttackPattern } from './riskbyattackpattern.actions';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { JsonApi } from '../../models/json/jsonapi';
+import { JsonApiData } from '../../../models/json/jsonapi-data';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+
+@Injectable()
+export class RiskByAttackPatternEffects {
+
+    public constructor(
+        private router: Router,
+        private location: Location,
+        private actions$: Actions,
+        protected genericServiceApi: GenericApi,
+        protected assessmentSummaryService: AssessmentSummaryService,
+    ) { }
+
+    @Effect()
+    public fetchSingleAssessmentRiskByAttackPatternData = this.actions$
+        .ofType(LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA)
+        .pluck('payload')
+        .switchMap((assessmentId: string) => this.assessmentSummaryService.getRiskPerAttackPattern(assessmentId))
+        .mergeMap((data: RiskByAttack) => [new SetRiskByAttackPattern([data]), new FinishedLoading(true)])
+
+    @Effect()
+    public fetchAssessmentRiskByAttackPatternData = this.actions$
+        .ofType(LOAD_RISK_BY_ATTACK_PATTERN_DATA)
+        .pluck('payload')
+        .switchMap((rollupId: string) => this.assessmentSummaryService.getRiskPerAttackPatternByRollupId(rollupId))
+        .mergeMap((data: RiskByAttack[]) => [ new SetRiskByAttackPattern(data), new FinishedLoading(true)])
+}

--- a/src/app/assess/result/store/riskbyattackpattern.effects.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.effects.ts
@@ -5,7 +5,7 @@ import { Location } from '@angular/common';
 import { Actions, Effect } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
 
-import { AssessmentSummaryService } from '../../services/assessment-summary.service';
+import { AssessService } from '../../services/assess.service';
 
 import { LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA, LOAD_RISK_BY_ATTACK_PATTERN_DATA, FinishedLoading, SetRiskByAttackPattern } from './riskbyattackpattern.actions';
 import { GenericApi } from '../../../core/services/genericapi.service';
@@ -21,20 +21,20 @@ export class RiskByAttackPatternEffects {
         private location: Location,
         private actions$: Actions,
         protected genericServiceApi: GenericApi,
-        protected assessmentSummaryService: AssessmentSummaryService,
+        protected assessService: AssessService,
     ) { }
 
     @Effect()
     public fetchSingleAssessmentRiskByAttackPatternData = this.actions$
         .ofType(LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA)
         .pluck('payload')
-        .switchMap((assessmentId: string) => this.assessmentSummaryService.getRiskPerAttackPattern(assessmentId))
+        .switchMap((assessmentId: string) => this.assessService.getRiskPerAttackPattern(assessmentId))
         .mergeMap((data: RiskByAttack) => [new SetRiskByAttackPattern([data]), new FinishedLoading(true)])
 
     @Effect()
     public fetchAssessmentRiskByAttackPatternData = this.actions$
         .ofType(LOAD_RISK_BY_ATTACK_PATTERN_DATA)
         .pluck('payload')
-        .switchMap((rollupId: string) => this.assessmentSummaryService.getRiskPerAttackPatternByRollupId(rollupId))
+        .switchMap((rollupId: string) => this.assessService.getRiskPerAttackPatternByRollupId(rollupId))
         .mergeMap((data: RiskByAttack[]) => [ new SetRiskByAttackPattern(data), new FinishedLoading(true)])
 }

--- a/src/app/assess/result/store/riskbyattackpattern.reducers.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.reducers.ts
@@ -1,0 +1,47 @@
+import * as riskByAttackPatternActions from './riskbyattackpattern.actions';
+import { JsonApiData } from '../../models/json/jsonapi-data';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+
+export interface RiskByAttackPatternState {
+    riskByAttackPattern: RiskByAttack;
+    riskByAttackPatterns: RiskByAttack[];
+    finishedLoading: boolean;
+};
+
+const genState = (state?: Partial<RiskByAttackPatternState>) => {
+    const tmp = {
+        riskByAttackPattern: new RiskByAttack(),
+        riskByAttackPatterns: [],
+        finishedLoading: false,
+    };
+    if (state) {
+        Object.assign(tmp, state);
+    }
+    return tmp;
+};
+const initialState: RiskByAttackPatternState = genState();
+
+export function riskByAttackPatternReducer(state = initialState, action: riskByAttackPatternActions.RiskByAttackPatternActions): RiskByAttackPatternState {
+    switch (action.type) {
+        case riskByAttackPatternActions.LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA:
+            return genState({
+                ...state,
+            });
+        case riskByAttackPatternActions.LOAD_RISK_BY_ATTACK_PATTERN_DATA:
+            return genState({
+                ...state,
+            });
+        case riskByAttackPatternActions.SET_RISK_BY_ATTACK_PATTERNS:
+            return genState({
+                ...state,
+                riskByAttackPatterns: [...action.payload],
+            });
+        case riskByAttackPatternActions.FINISHED_LOADING:
+            return genState({
+                ...state,
+                finishedLoading: action.payload
+            });
+        default:
+            return state;
+    }
+}

--- a/src/app/assess/result/store/summary.actions.ts
+++ b/src/app/assess/result/store/summary.actions.ts
@@ -1,18 +1,24 @@
 import { Action } from '@ngrx/store';
 import { Assessment } from '../../../models/assess/assessment';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
+import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
 
 // For effects
 export const LOAD_ASSESSMENT_SUMMARY_DATA = '[Assess Summary] LOAD_ASSESSMENT_SUMMARY_DATA';
 export const LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA = '[Assess Summary] LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA';
 export const LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA = '[Assess Summary] LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA';
 export const LOAD_RISK_PER_KILL_CHAIN_DATA = '[Assess Summary] LOAD_RISK_PER_KILL_CHAIN_DATA';
+export const LOAD_SINGLE_SUMMARY_AGGREGATION_DATA = '[Assess Summary] LOAD_SINGLE_SUMMARY_AGGREGATION_DATA';
+export const LOAD_SUMMARY_AGGREGATION_DATA = '[Assess Summary] LOAD_SUMMARY_AGGREGATION_DATA';
 
 // For reducers
 export const SET_ASSESSMENTS = '[Assess Summary] SET_ASSESSMENTS';
 export const FINISHED_LOADING = '[Assess Summary] FINISHED_LOADING';
 export const SET_KILL_CHAIN_DATA = '[Assess Summary] SET_KILL_CHAIN_DATA';
 export const FINISHED_LOADING_KILL_CHAIN_DATA = '[Assess Summary] FINISHED_LOADING_KILL_CHAIN_DATA';
+export const SET_SUMMARY_AGGREGATION_DATA = '[Assess Summary] SET_SUMMARY_AGGREGATION_DATA';
+export const FINISHED_LOADING_SUMMARY_AGGREGATION_DATA = '[Assess Summary] FINISHED_LOADING_SUMMARY_AGGREGATION_DATA';
+
 
 export class LoadSingleAssessmentSummaryData implements Action {
     public readonly type = LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA;
@@ -66,6 +72,32 @@ export class FinishedLoadingKillChainData implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class LoadSingleSummaryAggregationData implements Action {
+    public readonly type = LOAD_SINGLE_SUMMARY_AGGREGATION_DATA;
+
+    // individual assessment id
+    constructor(public payload: string) { }
+}
+
+export class LoadSummaryAggregationData implements Action {
+    public readonly type = LOAD_SUMMARY_AGGREGATION_DATA;
+
+    // individual assessment id
+    constructor(public payload: string) { }
+}
+
+export class SetSummaryAggregationData implements Action {
+    public readonly type = SET_SUMMARY_AGGREGATION_DATA;
+
+    constructor(public payload: SummaryAggregation[]) { }
+}
+
+export class FinishedLoadingSummaryAggregationData implements Action {
+    public readonly type = FINISHED_LOADING_SUMMARY_AGGREGATION_DATA;
+
+    constructor(public payload: boolean) { }
+}
+
 export type SummaryActions =
     SetAssessments |
     LoadAssessmentSummaryData |
@@ -74,5 +106,9 @@ export type SummaryActions =
     SetKillChainData |
     LoadSingleRiskPerKillChainData |
     LoadRiskPerKillChainData |
-    FinishedLoadingKillChainData;
+    FinishedLoadingKillChainData |
+    SetSummaryAggregationData |
+    LoadSingleSummaryAggregationData |
+    LoadSummaryAggregationData |
+    FinishedLoadingSummaryAggregationData;
 

--- a/src/app/assess/result/store/summary.actions.ts
+++ b/src/app/assess/result/store/summary.actions.ts
@@ -1,13 +1,18 @@
 import { Action } from '@ngrx/store';
 import { Assessment } from '../../../models/assess/assessment';
+import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 
 // For effects
 export const LOAD_ASSESSMENT_SUMMARY_DATA = '[Assess Summary] LOAD_ASSESSMENT_SUMMARY_DATA';
 export const LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA = '[Assess Summary] LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA';
+export const LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA = '[Assess Summary] LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA';
+export const LOAD_RISK_PER_KILL_CHAIN_DATA = '[Assess Summary] LOAD_RISK_PER_KILL_CHAIN_DATA';
 
 // For reducers
 export const SET_ASSESSMENTS = '[Assess Summary] SET_ASSESSMENTS';
 export const FINISHED_LOADING = '[Assess Summary] FINISHED_LOADING';
+export const SET_KILL_CHAIN_DATA = '[Assess Summary] SET_KILL_CHAIN_DATA';
+export const FINISHED_LOADING_KILL_CHAIN_DATA = '[Assess Summary] FINISHED_LOADING_KILL_CHAIN_DATA';
 
 export class LoadSingleAssessmentSummaryData implements Action {
     public readonly type = LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA;
@@ -35,9 +40,39 @@ export class FinishedLoading implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class LoadSingleRiskPerKillChainData implements Action {
+    public readonly type = LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA;
+
+    // individual assessment id
+    constructor(public payload: string) { }
+}
+
+export class LoadRiskPerKillChainData implements Action {
+    public readonly type = LOAD_RISK_PER_KILL_CHAIN_DATA;
+
+    // individual assessment id
+    constructor(public payload: string) { }
+}
+
+export class SetKillChainData implements Action {
+    public readonly type = SET_KILL_CHAIN_DATA;
+
+    constructor(public payload: RiskByKillChain[]) { }
+}
+
+export class FinishedLoadingKillChainData implements Action {
+    public readonly type = FINISHED_LOADING_KILL_CHAIN_DATA;
+
+    constructor(public payload: boolean) { }
+}
+
 export type SummaryActions =
     SetAssessments |
     LoadAssessmentSummaryData |
     LoadSingleAssessmentSummaryData |
-    FinishedLoading;
+    FinishedLoading |
+    SetKillChainData |
+    LoadSingleRiskPerKillChainData |
+    LoadRiskPerKillChainData |
+    FinishedLoadingKillChainData;
 

--- a/src/app/assess/result/store/summary.effects.ts
+++ b/src/app/assess/result/store/summary.effects.ts
@@ -7,8 +7,12 @@ import { Observable } from 'rxjs/Observable';
 
 import { AssessService } from '../../services/assess.service';
 
-import { LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA, LOAD_ASSESSMENT_SUMMARY_DATA, FinishedLoading, SetAssessments } from './summary.actions';
+import { LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA, LOAD_ASSESSMENT_SUMMARY_DATA, FinishedLoading, SetAssessments, LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA, LOAD_RISK_PER_KILL_CHAIN_DATA, FinishedLoadingKillChainData, SetKillChainData } from './summary.actions';
 import { Assessment } from '../../../models/assess/assessment';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { JsonApi } from '../../models/json/jsonapi';
+import { JsonApiData } from '../../../models/json/jsonapi-data';
+import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 
 @Injectable()
 export class SummaryEffects {
@@ -25,7 +29,7 @@ export class SummaryEffects {
         .ofType(LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA)
         .pluck('payload')
         .switchMap((assessmentId: string) => this.assessService.getById(assessmentId))
-        .map((data: Assessment) => new SetAssessments([data]));
+        .mergeMap((data: Assessment) => [new SetAssessments([data]), new FinishedLoading(true)])
 
     @Effect()
     public fetchAssessmentSummaryData = this.actions$
@@ -34,4 +38,17 @@ export class SummaryEffects {
         .switchMap((rollupId: string) => this.assessService.getByRollupId(rollupId))
         .mergeMap((data: Assessment[]) => [new SetAssessments(data), new FinishedLoading(true)]);
 
+    @Effect()
+    public fetchSingleRiskPerKillChainData = this.actions$
+        .ofType(LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA)
+        .pluck('payload')
+        .switchMap((assessmentId: string) => this.assessService.getRiskPerKillChain(assessmentId))
+        .mergeMap((data: RiskByKillChain) => [new SetKillChainData([data]), new FinishedLoadingKillChainData(true)])
+
+    @Effect()
+    public fetchRiskPerKillChainData = this.actions$
+        .ofType(LOAD_RISK_PER_KILL_CHAIN_DATA)
+        .pluck('payload')
+        .switchMap((rollupId: string) => this.assessService.getRiskPerKillChainByRollupId(rollupId))
+        .mergeMap((data: RiskByKillChain[]) => [ new SetKillChainData(data), new FinishedLoadingKillChainData(true)])
 }

--- a/src/app/assess/result/store/summary.effects.ts
+++ b/src/app/assess/result/store/summary.effects.ts
@@ -7,12 +7,17 @@ import { Observable } from 'rxjs/Observable';
 
 import { AssessService } from '../../services/assess.service';
 
-import { LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA, LOAD_ASSESSMENT_SUMMARY_DATA, FinishedLoading, SetAssessments, LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA, LOAD_RISK_PER_KILL_CHAIN_DATA, FinishedLoadingKillChainData, SetKillChainData } from './summary.actions';
+import {
+    LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA, LOAD_ASSESSMENT_SUMMARY_DATA, FinishedLoading, SetAssessments, LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA,
+    LOAD_RISK_PER_KILL_CHAIN_DATA, FinishedLoadingKillChainData, SetKillChainData, LOAD_SINGLE_SUMMARY_AGGREGATION_DATA, SetSummaryAggregationData,
+    FinishedLoadingSummaryAggregationData, LOAD_SUMMARY_AGGREGATION_DATA
+} from './summary.actions';
 import { Assessment } from '../../../models/assess/assessment';
 import { GenericApi } from '../../../core/services/genericapi.service';
 import { JsonApi } from '../../models/json/jsonapi';
 import { JsonApiData } from '../../../models/json/jsonapi-data';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
+import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
 
 @Injectable()
 export class SummaryEffects {
@@ -50,5 +55,19 @@ export class SummaryEffects {
         .ofType(LOAD_RISK_PER_KILL_CHAIN_DATA)
         .pluck('payload')
         .switchMap((rollupId: string) => this.assessService.getRiskPerKillChainByRollupId(rollupId))
-        .mergeMap((data: RiskByKillChain[]) => [ new SetKillChainData(data), new FinishedLoadingKillChainData(true)])
+        .mergeMap((data: RiskByKillChain[]) => [new SetKillChainData(data), new FinishedLoadingKillChainData(true)])
+
+    @Effect()
+    public fetchSingleSummaryAggregationData = this.actions$
+        .ofType(LOAD_SINGLE_SUMMARY_AGGREGATION_DATA)
+        .pluck('payload')
+        .switchMap((assessmentId: string) => this.assessService.getSummaryAggregation(assessmentId))
+        .mergeMap((data: SummaryAggregation) => [new SetSummaryAggregationData([data]), new FinishedLoadingSummaryAggregationData(true)])
+
+    @Effect()
+    public fetchSummaryAggregationData = this.actions$
+        .ofType(LOAD_SUMMARY_AGGREGATION_DATA)
+        .pluck('payload')
+        .switchMap((rollupId: string) => this.assessService.getSummaryAggregationByRollup(rollupId))
+        .mergeMap((data: SummaryAggregation[]) => [new SetSummaryAggregationData(data), new FinishedLoadingSummaryAggregationData(true)])
 }

--- a/src/app/assess/result/store/summary.reducers.ts
+++ b/src/app/assess/result/store/summary.reducers.ts
@@ -1,14 +1,16 @@
 import * as summaryActions from './summary.actions';
 import { Assessment } from '../../../models/assess/assessment';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
+import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
 
 export interface SummaryState {
     summary: Assessment;
     summaries: Assessment[];
     finishedLoading: boolean;
-    killChainDatum: RiskByKillChain;
     killChainData: RiskByKillChain[];
     finishedLoadingKillChainData: boolean;
+    summaryAggregations: SummaryAggregation[];
+    finishedLoadingSummaryAggregationData: boolean;
 };
 
 
@@ -18,9 +20,10 @@ const genState = (state?: Partial<SummaryState>) => {
         summary: new Assessment(),
         summaries: [],
         finishedLoading: false,
-        killChainDatum: new RiskByKillChain(),
         killChainData: [],
         finishedLoadingKillChainData: false,
+        summaryAggregations: [],
+        finishedLoadingSummaryAggregationData: false
     };
     if (state) {
         Object.assign(tmp, state);
@@ -66,6 +69,25 @@ export function summaryReducer(state = initialState, action: summaryActions.Summ
             return genState({
                 ...state,
                 killChainData: [...action.payload],
+            });
+        case summaryActions.LOAD_SINGLE_SUMMARY_AGGREGATION_DATA:
+
+            return genState({
+                ...state,
+            });
+        case summaryActions.LOAD_SUMMARY_AGGREGATION_DATA:
+            return genState({
+                ...state,
+            });
+        case summaryActions.FINISHED_LOADING_SUMMARY_AGGREGATION_DATA:
+            return genState({
+                ...state,
+                finishedLoadingSummaryAggregationData: action.payload,
+            });
+        case summaryActions.SET_SUMMARY_AGGREGATION_DATA:
+            return genState({
+                ...state,
+                summaryAggregations: [...action.payload],
             });
         default:
             return state;

--- a/src/app/assess/result/store/summary.reducers.ts
+++ b/src/app/assess/result/store/summary.reducers.ts
@@ -1,17 +1,26 @@
 import * as summaryActions from './summary.actions';
 import { Assessment } from '../../../models/assess/assessment';
+import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 
 export interface SummaryState {
     summary: Assessment;
     summaries: Assessment[];
     finishedLoading: boolean;
+    killChainDatum: RiskByKillChain;
+    killChainData: RiskByKillChain[];
+    finishedLoadingKillChainData: boolean;
 };
+
+
 
 const genState = (state?: Partial<SummaryState>) => {
     const tmp = {
         summary: new Assessment(),
         summaries: [],
         finishedLoading: false,
+        killChainDatum: new RiskByKillChain(),
+        killChainData: [],
+        finishedLoadingKillChainData: false,
     };
     if (state) {
         Object.assign(tmp, state);
@@ -22,6 +31,10 @@ const initialState: SummaryState = genState();
 
 export function summaryReducer(state = initialState, action: summaryActions.SummaryActions): SummaryState {
     switch (action.type) {
+        case summaryActions.LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA:
+            return genState({
+                ...state,
+            });
         case summaryActions.LOAD_ASSESSMENT_SUMMARY_DATA:
             return genState({
                 ...state,
@@ -35,6 +48,24 @@ export function summaryReducer(state = initialState, action: summaryActions.Summ
             return genState({
                 ...state,
                 finishedLoading: action.payload
+            });
+        case summaryActions.LOAD_SINGLE_RISK_PER_KILL_CHAIN_DATA:
+            return genState({
+                ...state,
+            });
+        case summaryActions.LOAD_RISK_PER_KILL_CHAIN_DATA:
+            return genState({
+                ...state,
+            });
+        case summaryActions.FINISHED_LOADING_KILL_CHAIN_DATA:
+            return genState({
+                ...state,
+                finishedLoadingKillChainData: action.payload
+            });
+        case summaryActions.SET_KILL_CHAIN_DATA:
+            return genState({
+                ...state,
+                killChainData: [...action.payload],
             });
         default:
             return state;

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -68,6 +68,18 @@ fdescribe('SummaryCalculationService', () => {
     service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: null, external_references: null, id: null, kill_chain_phases: null, name: null}],
       _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
     expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: null, external_references: null, id: null, kill_chain_phases: null, name: null}],
+      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: undefined, external_references: null, id: null, kill_chain_phases: null, name: null}],
+      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: '', external_references: null, id: null, kill_chain_phases: null, name: null}],
+      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: 'apple', external_references: null, id: null, kill_chain_phases: null, name: null}],
+      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('apple');
 
   }));
 

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -124,11 +124,85 @@ fdescribe('SummaryCalculationService', () => {
     expect(service.topRisks).toEqual([]);
     service.calculateTopRisks({ courseOfActions: [], indicators: [], sensors: [] });
     expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({ courseOfActions: [{ risk: null, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
-    expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
-    // expect(service.topRisks).toEqual([{risk: .7324, questions: null, objects: null, phaseName: null}]);
+  }));
 
+  it('should calculate top risks for kill chains', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.calculateTopRisks({ courseOfActions: [{ risk: null, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: null, questions: null, objects: [], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{}], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{}], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: null }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: null }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: null }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: null }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: null }, { risk: 1 }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: null }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: 0 }, {}], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: 0 }, {}], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: 0 }, { risk: 2 }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 2 }, { risk: 1 }, { risk: 0 }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: 5 }, { risk: 2 }, { risk: 0 }, { risk: 1 }], phaseName: null }], indicators: null, sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 5 }, { risk: 2 }, { risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: null, indicators: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }], sensors: null });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks({ courseOfActions: null, indicators: null, sensors: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }] });
+    expect(service.topRisks).toEqual([{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks(
+      {
+        courseOfActions: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        indicators: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        sensors: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]
+      }
+    );
+    expect(service.topRisks).toEqual(
+      [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null },
+      { risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null },
+      { risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks(
+      {
+        courseOfActions:
+          [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null },
+          { risk: .32, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        indicators: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        sensors: [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]
+      }
+    );
+    expect(service.topRisks).toEqual(
+      [{ risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null },
+      { risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null },
+      { risk: .7324, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks(
+      {
+        courseOfActions:
+          [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }, { risk: 0 }], phaseName: null },
+          { risk: .32, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        indicators: [{ risk: .7321, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        sensors: [{ risk: .7320, questions: null, objects: [{ risk: 1 }], phaseName: null }]
+      }
+    );
+    expect(service.topRisks).toEqual(
+      [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }], phaseName: null },
+      { risk: .7321, questions: null, objects: [{ risk: 1 }], phaseName: null },
+      { risk: .7320, questions: null, objects: [{ risk: 1 }], phaseName: null }]);
+    service.calculateTopRisks(
+      {
+        courseOfActions:
+          [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }, { risk: 0 }], phaseName: null },
+          { risk: .32, questions: null, objects: [{ risk: 1 }], phaseName: null }],
+        indicators: [{ risk: .7321, questions: null, objects: [{ risk: .1 }, { risk: .2 }, { risk: 0 }, { risk: .3 }], phaseName: null }],
+        sensors: [{ risk: .7320, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }, { risk: 0 }], phaseName: null }]
+      }
+    );
+    expect(service.topRisks).toEqual(
+      [{ risk: .7324, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }], phaseName: null },
+      { risk: .7321, questions: null, objects: [{ risk: .3 }, { risk: .2 }, { risk: .1 }], phaseName: null },
+      { risk: .7320, questions: null, objects: [{ risk: 1 }, { risk: .3 }, { risk: .2 }], phaseName: null }]);
   }));
 
   it('should retrieve default risk objects from a kill chain object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 
 import { SummaryCalculationService } from './summary-calculation.service';
 
-fdescribe('SummaryCalculationService', () => {
+describe('SummaryCalculationService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [SummaryCalculationService]

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -53,32 +53,52 @@ fdescribe('SummaryCalculationService', () => {
   }));
 
   it('should calculate correct weakness', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: null, phases: null});
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: null, phases: null });
     expect(service.weakness).toEqual('');
     service.calculateWeakness(undefined);
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: [], attackPatternsByKillChain: [], phases: []});
+    service.calculateWeakness({ assessedByAttackPattern: [], attackPatternsByKillChain: [], phases: [] });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [], phases: [{assessedObjects: null, attackPatterns: null, _id: null}]});
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [], phases: [{ assessedObjects: null, attackPatterns: null, _id: null }] });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: null, _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{ attackPatterns: null, _id: 'description' }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }] });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [], _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{ attackPatterns: [], _id: 'description' }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }] });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: null, external_references: null, id: null, kill_chain_phases: null, name: null}],
-      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({
+      assessedByAttackPattern: null, attackPatternsByKillChain: [{
+        attackPatterns: [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null }],
+        _id: 'description'
+      }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }]
+    });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: null, external_references: null, id: null, kill_chain_phases: null, name: null}],
-      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({
+      assessedByAttackPattern: null, attackPatternsByKillChain: [{
+        attackPatterns: [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null }],
+        _id: 'description'
+      }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }]
+    });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: undefined, external_references: null, id: null, kill_chain_phases: null, name: null}],
-      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({
+      assessedByAttackPattern: null, attackPatternsByKillChain: [{
+        attackPatterns: [{ description: undefined, external_references: null, id: null, kill_chain_phases: null, name: null }],
+        _id: 'description'
+      }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }]
+    });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: '', external_references: null, id: null, kill_chain_phases: null, name: null}],
-      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({
+      assessedByAttackPattern: null, attackPatternsByKillChain: [{
+        attackPatterns: [{ description: '', external_references: null, id: null, kill_chain_phases: null, name: null }],
+        _id: 'description'
+      }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }]
+    });
     expect(service.weakness).toEqual('');
-    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: 'apple', external_references: null, id: null, kill_chain_phases: null, name: null}],
-      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    service.calculateWeakness({
+      assessedByAttackPattern: null, attackPatternsByKillChain: [{
+        attackPatterns: [{ description: 'apple', external_references: null, id: null, kill_chain_phases: null, name: null }],
+        _id: 'description'
+      }], phases: [{ assessedObjects: null, attackPatterns: null, _id: 'description' }]
+    });
     expect(service.weakness).toEqual('apple');
 
   }));
@@ -86,13 +106,13 @@ fdescribe('SummaryCalculationService', () => {
   it('should calculate default average risk for a phase', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
     expect(service.calculateAvgRiskPerPhase(null)).toEqual(0);
     expect(service.calculateAvgRiskPerPhase(undefined)).toEqual(0);
-    expect(service.calculateAvgRiskPerPhase({assessedObjects: null, attackPatterns: null, _id: null})).toEqual(0);
-    expect(service.calculateAvgRiskPerPhase({assessedObjects: [], attackPatterns: null, _id: null})).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({ assessedObjects: null, attackPatterns: null, _id: null })).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({ assessedObjects: [], attackPatterns: null, _id: null })).toEqual(0);
   }));
 
   it('should calculate average risk for a phase', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
-    expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 0}], attackPatterns: null, _id: null})).toEqual(0);
-    expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 1}], attackPatterns: null, _id: null})).toEqual(1);
+    expect(service.calculateAvgRiskPerPhase({ assessedObjects: [{ questions: null, risk: 0 }], attackPatterns: null, _id: null })).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({ assessedObjects: [{ questions: null, risk: 1 }], attackPatterns: null, _id: null })).toEqual(1);
   }));
 
   it('should calculate default top risks for kill chains', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
@@ -100,20 +120,52 @@ fdescribe('SummaryCalculationService', () => {
     expect(service.topRisks).toEqual([]);
     service.calculateTopRisks(undefined)
     expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({courseOfActions: null, indicators: null, sensors: null});
+    service.calculateTopRisks({ courseOfActions: null, indicators: null, sensors: null });
     expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({courseOfActions: [], indicators: [], sensors: []});
+    service.calculateTopRisks({ courseOfActions: [], indicators: [], sensors: [] });
     expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({courseOfActions: [{risk: null, questions: null, objects: null, phaseName: null}], indicators: null, sensors: null});
+    service.calculateTopRisks({ courseOfActions: [{ risk: null, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
     expect(service.topRisks).toEqual([]);
-    service.calculateTopRisks({courseOfActions: [{risk: .7324, questions: null, objects: null, phaseName: null}], indicators: null, sensors: null});
-    expect(service.topRisks).toEqual([{risk: .7324, questions: null, objects: null, phaseName: null}]);
+    service.calculateTopRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }], indicators: null, sensors: null });
+    // expect(service.topRisks).toEqual([{risk: .7324, questions: null, objects: null, phaseName: null}]);
 
   }));
 
-  it('should retrieve all risks from a kill chain object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+  it('should retrieve default risk objects from a kill chain object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
     expect(service.retrieveAssessmentRisks(null)).toEqual([]);
-    
+    expect(service.retrieveAssessmentRisks(undefined)).toEqual([]);
+    expect(service.retrieveAssessmentRisks({ courseOfActions: null, indicators: null, sensors: null })).toEqual([]);
+    expect(service.retrieveAssessmentRisks({ courseOfActions: [], indicators: [], sensors: [] })).toEqual([]);
+  }));
 
+  it('should retrieve calculated risk objects from a kill chain object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.retrieveAssessmentRisks({ courseOfActions: [{ risk: null, questions: null, objects: null, phaseName: null }], indicators: [], sensors: [] }))
+      .toEqual([{ risk: null, questions: null, objects: null, phaseName: null }]);
+    expect(service.retrieveAssessmentRisks({ courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }], indicators: [], sensors: [] }))
+      .toEqual([{ risk: .7324, questions: null, objects: null, phaseName: null }]);
+    expect(service.retrieveAssessmentRisks({
+      courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }],
+      indicators: [{ risk: .7324, questions: null, objects: null, phaseName: null }],
+      sensors: [{ risk: .7324, questions: null, objects: null, phaseName: null }]
+    }))
+      .toEqual([{ risk: .7324, questions: null, objects: null, phaseName: null },
+      { risk: .7324, questions: null, objects: null, phaseName: null },
+      { risk: .7324, questions: null, objects: null, phaseName: null }]);
+    expect(service.retrieveAssessmentRisks({
+      courseOfActions: [{ risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null }],
+      indicators: [{ risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null }],
+      sensors: [{ risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null }]
+    }))
+      .toEqual([{ risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null },
+      { risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null },
+      { risk: .7324, questions: null, objects: null, phaseName: null }, { risk: .1224, questions: null, objects: null, phaseName: null }]);
+    expect(service.retrieveAssessmentRisks({
+      courseOfActions: [{ risk: .1, questions: null, objects: null, phaseName: null }, { risk: .2, questions: null, objects: null, phaseName: null }],
+      indicators: [{ risk: .3, questions: null, objects: null, phaseName: null }, { risk: .4, questions: null, objects: null, phaseName: null }],
+      sensors: [{ risk: .5, questions: null, objects: null, phaseName: null }, { risk: .6, questions: null, objects: null, phaseName: null }]
+    }))
+      .toEqual([{ risk: .1, questions: null, objects: null, phaseName: null }, { risk: .2, questions: null, objects: null, phaseName: null },
+      { risk: .3, questions: null, objects: null, phaseName: null }, { risk: .4, questions: null, objects: null, phaseName: null },
+      { risk: .5, questions: null, objects: null, phaseName: null }, { risk: .6, questions: null, objects: null, phaseName: null }]);
   }));
 });

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { SummaryCalculationService } from './summary-calculation.service';
+
+fdescribe('SummaryCalculationService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SummaryCalculationService]
+    });
+  });
+
+  it('should be created', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should return default numeric risk', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.numericRisk).toEqual(0);
+  }));
+
+  it('should return default risk text', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.getRiskText()).toEqual('0');
+  }));
+
+  it('should return set numeric risk', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.numericRisk = 1;
+    expect(service.numericRisk).toEqual(1);
+  }));
+
+  it('should return set risk text', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.numericRisk = 1;
+    expect(service.getRiskText()).toEqual('100');
+  }));
+
+  it('should set default average risk per assessed object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.setAverageRiskPerAssessedObject(null);
+    expect(service.numericRisk).toEqual(0);
+    service.setAverageRiskPerAssessedObject([]);
+    expect(service.numericRisk).toEqual(0);
+  }));
+
+  it('should set average risk per assessed object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.setAverageRiskPerAssessedObject([{ risk: 3, questions: null }]);
+    expect(service.numericRisk).toEqual(3);
+    service.setAverageRiskPerAssessedObject([{ risk: 3, questions: null }, { risk: 0, questions: null }]);
+    expect(service.numericRisk).toEqual(1.5);
+  }));
+
+  it('should calculate default weakness', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.calculateWeakness(null);
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness(undefined);
+    expect(service.weakness).toEqual('');
+  }));
+
+  it('should calculate correct weakness', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: null, phases: null});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness(undefined);
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: [], attackPatternsByKillChain: [], phases: []});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [], phases: [{assessedObjects: null, attackPatterns: null, _id: null}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: null, _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [], _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+    service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: [{attackPatterns: [{description: null, external_references: null, id: null, kill_chain_phases: null, name: null}],
+      _id: 'description'}], phases: [{assessedObjects: null, attackPatterns: null, _id: 'description'}]});
+    expect(service.weakness).toEqual('');
+
+  }));
+
+  it('should calculate default average risk for a phase', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.calculateAvgRiskPerPhase(null)).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase(undefined)).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({assessedObjects: null, attackPatterns: null, _id: null})).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({assessedObjects: [], attackPatterns: null, _id: null})).toEqual(0);
+  }));
+
+  it('should calculate average risk for a phase', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 0}], attackPatterns: null, _id: null})).toEqual(0);
+    expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 1}], attackPatterns: null, _id: null})).toEqual(1);
+  }));
+});

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -94,4 +94,26 @@ fdescribe('SummaryCalculationService', () => {
     expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 0}], attackPatterns: null, _id: null})).toEqual(0);
     expect(service.calculateAvgRiskPerPhase({assessedObjects: [{questions: null, risk: 1}], attackPatterns: null, _id: null})).toEqual(1);
   }));
+
+  it('should calculate default top risks for kill chains', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.calculateTopRisks(null);
+    expect(service.topRisks).toEqual([]);
+    service.calculateTopRisks(undefined)
+    expect(service.topRisks).toEqual([]);
+    service.calculateTopRisks({courseOfActions: null, indicators: null, sensors: null});
+    expect(service.topRisks).toEqual([]);
+    service.calculateTopRisks({courseOfActions: [], indicators: [], sensors: []});
+    expect(service.topRisks).toEqual([]);
+    service.calculateTopRisks({courseOfActions: [{risk: null, questions: null, objects: null, phaseName: null}], indicators: null, sensors: null});
+    expect(service.topRisks).toEqual([]);
+    service.calculateTopRisks({courseOfActions: [{risk: .7324, questions: null, objects: null, phaseName: null}], indicators: null, sensors: null});
+    expect(service.topRisks).toEqual([{risk: .7324, questions: null, objects: null, phaseName: null}]);
+
+  }));
+
+  it('should retrieve all risks from a kill chain object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.retrieveAssessmentRisks(null)).toEqual([]);
+    
+
+  }));
 });

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -102,11 +102,11 @@ export class SummaryCalculationService {
   public calculateTopRisks(riskByKillChain: RiskByKillChain): void {
     let topRisks: AssessKillChainType[] = [];
     const risks: AssessKillChainType[] = this.retrieveAssessmentRisks(riskByKillChain);
-    this.topRisks = risks; // .sort(SummarySortHelper.sortByRiskDesc());
-    this.topRisks = this.topRisks.slice(0, this.topNRisks);
-    this.topRisks.forEach((el) => {
+    risks.sort(SummarySortHelper.sortByRiskDesc())
+    topRisks = risks.slice(0, this.topNRisks);
+    topRisks.forEach((el) => {
       const objects = el.objects || [];
-      el.objects = objects; // .sort(SummarySortHelper.sortByRiskDesc());
+      el.objects = objects.sort(SummarySortHelper.sortByRiskDesc());
       el.objects = el.objects.slice(0, this.topNRisks);
     });
 

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -14,7 +14,7 @@ export class SummaryCalculationService {
   public readonly topNRisks: number;
   numericRiskValue: number;
   weaknessValue: string;
-  topRisksValue: AssessKillChainType [];
+  topRisksValue: AssessKillChainType[];
 
   constructor() {
     this.numericRisk = 0;
@@ -30,7 +30,7 @@ export class SummaryCalculationService {
     this.weaknessValue = newWeakness;
   }
 
-  public set topRisks(newTopRisks: AssessKillChainType []) {
+  public set topRisks(newTopRisks: AssessKillChainType[]) {
     this.topRisksValue = newTopRisks;
   }
 
@@ -42,7 +42,7 @@ export class SummaryCalculationService {
     return this.weaknessValue;
   }
 
-  public get topRisks(): AssessKillChainType [] {
+  public get topRisks(): AssessKillChainType[] {
     return this.topRisksValue;
   }
 
@@ -100,23 +100,32 @@ export class SummaryCalculationService {
   }
 
   public calculateTopRisks(riskByKillChain: RiskByKillChain): void {
-    let topRisks: AssessKillChainType [] = [];
-    const risks: AssessKillChainType [] = this.retrieveAssessmentRisks(riskByKillChain);
+    let topRisks: AssessKillChainType[] = [];
+    const risks: AssessKillChainType[] = this.retrieveAssessmentRisks(riskByKillChain);
     this.topRisks = risks; // .sort(SummarySortHelper.sortByRiskDesc());
     this.topRisks = this.topRisks.slice(0, this.topNRisks);
     this.topRisks.forEach((el) => {
-        const objects = el.objects || [];
-        el.objects = objects; // .sort(SummarySortHelper.sortByRiskDesc());
-        el.objects = el.objects.slice(0, this.topNRisks);
+      const objects = el.objects || [];
+      el.objects = objects; // .sort(SummarySortHelper.sortByRiskDesc());
+      el.objects = el.objects.slice(0, this.topNRisks);
     });
 
     this.topRisks = topRisks;
   }
 
-  public retrieveAssessmentRisks(riskByKillChain: RiskByKillChain[]): AssessKillChainType[] {
-    let risks: AssessKillChainType [] = [];
-    
-
+  public retrieveAssessmentRisks(riskByKillChain: RiskByKillChain): AssessKillChainType[] {
+    let risks: AssessKillChainType[] = [];
+    if (riskByKillChain) {
+      if (riskByKillChain.courseOfActions && riskByKillChain.courseOfActions.length > 0) {
+        risks = risks.concat(riskByKillChain.courseOfActions);
+      }
+      if (riskByKillChain.indicators && riskByKillChain.indicators.length > 0) {
+        risks = risks.concat(riskByKillChain.indicators);
+      }
+      if (riskByKillChain.sensors && riskByKillChain.sensors.length > 0) {
+        risks = risks.concat(riskByKillChain.sensors);
+      }
+    }
     return risks;
   }
 }

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -6,15 +6,20 @@ import { AttackPattern } from '../../../models/attack-pattern';
 import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
 import { SummarySortHelper } from './summary-sort-helper';
 import { Stix } from '../../../models/stix/stix';
+import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
+import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 
 @Injectable()
 export class SummaryCalculationService {
+  public readonly topNRisks: number;
   numericRiskValue: number;
   weaknessValue: string;
+  topRisksValue: AssessKillChainType [];
 
   constructor() {
     this.numericRisk = 0;
     this.weakness = '';
+    this.topNRisks = 3;
   }
 
   public set numericRisk(newRisk: number) {
@@ -25,12 +30,20 @@ export class SummaryCalculationService {
     this.weaknessValue = newWeakness;
   }
 
-  public get numericRisk() {
+  public set topRisks(newTopRisks: AssessKillChainType []) {
+    this.topRisksValue = newTopRisks;
+  }
+
+  public get numericRisk(): number {
     return this.numericRiskValue;
   }
 
-  public get weakness() {
+  public get weakness(): string {
     return this.weaknessValue;
+  }
+
+  public get topRisks(): AssessKillChainType [] {
+    return this.topRisksValue;
   }
 
   public getRiskText(): string {
@@ -65,7 +78,7 @@ export class SummaryCalculationService {
     return risk;
   }
 
-  public calculateWeakness(riskByAttackPattern: RiskByAttack) {
+  public calculateWeakness(riskByAttackPattern: RiskByAttack): void {
     let weakness: string = '';
     if (riskByAttackPattern && riskByAttackPattern.phases && riskByAttackPattern.phases.length > 0) {
       const phases: Phase[] = riskByAttackPattern.phases;
@@ -84,5 +97,26 @@ export class SummaryCalculationService {
       }
     }
     this.weakness = weakness;
+  }
+
+  public calculateTopRisks(riskByKillChain: RiskByKillChain): void {
+    let topRisks: AssessKillChainType [] = [];
+    const risks: AssessKillChainType [] = this.retrieveAssessmentRisks(riskByKillChain);
+    this.topRisks = risks; // .sort(SummarySortHelper.sortByRiskDesc());
+    this.topRisks = this.topRisks.slice(0, this.topNRisks);
+    this.topRisks.forEach((el) => {
+        const objects = el.objects || [];
+        el.objects = objects; // .sort(SummarySortHelper.sortByRiskDesc());
+        el.objects = el.objects.slice(0, this.topNRisks);
+    });
+
+    this.topRisks = topRisks;
+  }
+
+  public retrieveAssessmentRisks(riskByKillChain: RiskByKillChain[]): AssessKillChainType[] {
+    let risks: AssessKillChainType [] = [];
+    
+
+    return risks;
   }
 }

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -8,6 +8,8 @@ import { SummarySortHelper } from './summary-sort-helper';
 import { Stix } from '../../../models/stix/stix';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
+import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
+import { Constance } from '../../../utils/constance';
 
 @Injectable()
 export class SummaryCalculationService {
@@ -15,11 +17,21 @@ export class SummaryCalculationService {
   numericRiskValue: number;
   weaknessValue: string;
   topRisksValue: AssessKillChainType[];
+  summaryAggregationValue: SummaryAggregation;
+  barColorsValue: any[];
 
   constructor() {
     this.numericRisk = 0;
     this.weakness = '';
     this.topNRisks = 3;
+    this.barColors = [
+      {
+          backgroundColor: Constance.MAT_COLORS['lightblue']['800']
+      },
+      {
+          backgroundColor: Constance.MAT_COLORS['lightblue']['100']
+      }
+  ];
   }
 
   public set numericRisk(newRisk: number) {
@@ -34,6 +46,14 @@ export class SummaryCalculationService {
     this.topRisksValue = newTopRisks;
   }
 
+  public set summaryAggregation (newSummaryAggregation: SummaryAggregation) {
+    this.summaryAggregationValue = newSummaryAggregation;
+  }
+
+  public set barColors(newBarColors: any[]) {
+    this.barColorsValue = newBarColors;
+  }
+
   public get numericRisk(): number {
     return this.numericRiskValue;
   }
@@ -44,6 +64,13 @@ export class SummaryCalculationService {
 
   public get topRisks(): AssessKillChainType[] {
     return this.topRisksValue;
+  }
+  public get barColors(): any[] {
+    return this.barColorsValue;
+  }
+
+  public get summaryAggregation() {
+    return this.summaryAggregationValue;
   }
 
   public getRiskText(): string {
@@ -128,4 +155,24 @@ export class SummaryCalculationService {
     }
     return risks;
   }
+
+  public sophisticationNumberToWord(num: string): string {
+    const val = parseInt(num, 10);
+    return this.sophisticationValueToWord(val);
+}
+
+public sophisticationValueToWord(num: number): string {
+    switch (num) {
+        case 0:
+            return 'Novice';
+        case 1:
+            return 'Practitioner';
+        case 2:
+            return 'Expert';
+        case 3:
+            return 'Innovator';
+        default:
+            return num.toString();
+    }
+}
 }

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@angular/core';
+import { AssessmentObject } from '../../../models/assess/assessment-object';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+import { Phase } from '../../../models/assess/phase';
+import { AttackPattern } from '../../../models/attack-pattern';
+import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
+import { SummarySortHelper } from './summary-sort-helper';
+import { Stix } from '../../../models/stix/stix';
+
+@Injectable()
+export class SummaryCalculationService {
+  numericRiskValue: number;
+  weaknessValue: string;
+
+  constructor() {
+    this.numericRisk = 0;
+    this.weakness = '';
+  }
+
+  public set numericRisk(newRisk: number) {
+    this.numericRiskValue = newRisk;
+  }
+
+  public set weakness(newWeakness: string) {
+    this.weaknessValue = newWeakness;
+  }
+
+  public get numericRisk() {
+    return this.numericRiskValue;
+  }
+
+  public get weakness() {
+    return this.weaknessValue;
+  }
+
+  public getRiskText(): string {
+    return Number((this.numericRisk) * 100).toFixed(0);
+  }
+
+  public setAverageRiskPerAssessedObject(assessments: Array<AssessmentObject>): void {
+    this.numericRisk = this.calculateAvgRiskPerAssessedObject(assessments);
+  }
+
+  public calculateAvgRiskPerAssessedObject(assessments: Array<AssessmentObject<Stix>>): number {
+    let aggregateRisk = 0;
+    let length = 1;
+    if (assessments) {
+      assessments.forEach((assessment) => {
+        if (assessment.risk && typeof assessment.risk === 'number') {
+          aggregateRisk += assessment.risk;
+        }
+      });
+      if (assessments.length > 0) {
+        length = assessments.length;
+      }
+    }
+    return aggregateRisk / length;
+  }
+
+  public calculateAvgRiskPerPhase(phase: Phase): number {
+    let risk = 0;
+    if (phase && phase.assessedObjects && phase.assessedObjects.length > 0) {
+      risk = this.calculateAvgRiskPerAssessedObject(phase.assessedObjects);
+    }
+    return risk;
+  }
+
+  public calculateWeakness(riskByAttackPattern: RiskByAttack) {
+    let weakness: string = '';
+    if (riskByAttackPattern && riskByAttackPattern.phases && riskByAttackPattern.phases.length > 0) {
+      const phases: Phase[] = riskByAttackPattern.phases;
+      for (let phase of phases) {
+        phase.avgRisk = this.calculateAvgRiskPerPhase(phase);
+      }
+      const weakestPhaseId = phases.sort(SummarySortHelper.sortByAvgRiskDesc())[0]._id || '';
+      const attackPatternsByKillChain = riskByAttackPattern.attackPatternsByKillChain;
+      const riskiestAttackPattern = attackPatternsByKillChain.find((el) => el._id === weakestPhaseId);
+      if (riskiestAttackPattern && riskiestAttackPattern.attackPatterns && riskiestAttackPattern.attackPatterns.length > 0) {
+        const attackPatterns = riskiestAttackPattern.attackPatterns;
+        let weakestAttackPatterns: AssessAttackPattern[] = attackPatterns.sort(SummarySortHelper.sortBySophisticationAsc()) || [];
+        weakestAttackPatterns = weakestAttackPatterns.slice(0, 1);
+        weakness = weakestAttackPatterns[0].description;
+        if (!weakness || weakness.length === 0) {
+          weakness = '';
+        }
+      }
+    }
+    this.weakness = weakness;
+  }
+}

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -77,11 +77,9 @@ export class SummaryCalculationService {
       const riskiestAttackPattern = attackPatternsByKillChain.find((el) => el._id === weakestPhaseId);
       if (riskiestAttackPattern && riskiestAttackPattern.attackPatterns && riskiestAttackPattern.attackPatterns.length > 0) {
         const attackPatterns = riskiestAttackPattern.attackPatterns;
-        let weakestAttackPatterns: AssessAttackPattern[] = attackPatterns.sort(SummarySortHelper.sortBySophisticationAsc()) || [];
-        weakestAttackPatterns = weakestAttackPatterns.slice(0, 1);
-        weakness = weakestAttackPatterns[0].description;
-        if (!weakness || weakness.length === 0) {
-          weakness = '';
+        const weakestAttackPatternDescription: string = attackPatterns.sort(SummarySortHelper.sortBySophisticationAsc())[0].description || '';
+        if (weakestAttackPatternDescription && weakestAttackPatternDescription.length > 0) {
+          weakness = weakestAttackPatternDescription;
         }
       }
     }

--- a/src/app/assess/result/summary/summary-report/chart-data.ts
+++ b/src/app/assess/result/summary/summary-report/chart-data.ts
@@ -1,0 +1,5 @@
+export interface ChartData {
+    label: string;
+    data: number[];
+    borderWidth?: number;
+}

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.html
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.html
@@ -1,0 +1,9 @@
+<div id="sophisticationBreakdownComponent">
+  <canvas baseChart
+  [datasets]="barChartData" 
+  [labels]="barChartLabels" 
+  [options]="barChartOptions" 
+  [legend]="barChartLegend" 
+  [chartType]="barChartType"
+  [colors]="colors"></canvas>
+</div>

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
@@ -1,25 +1,47 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { ChartsModule } from 'ng2-charts';
 
 import { SophisticationBreakdownComponent } from './sophistication-breakdown.component';
+import { SummaryCalculationService } from '../../summary-calculation.service';
 
-describe('SophisticationBreakdownComponent', () => {
+@Component({
+  template: '<sophistication-breakdown [assessedAttackPatterns]="assessedAttackPatternCountBySophisticationLevel"' +
+            '[allAttackPatterns]="totalAttackPatternCountBySophisticationLevel"></sophistication-breakdown>'
+})
+class TestHostComponent {
+  assessedAttackPatternCountBySophisticationLevel = {0: 16, 1: 13, 2: 16, 3: 2};
+  totalAttackPatternCountBySophisticationLevel = {0: 29, 1: 30, 2: 34, 3: 4};
+}
+
+fdescribe('SophisticationBreakdownComponent', () => {
   let component: SophisticationBreakdownComponent;
   let fixture: ComponentFixture<SophisticationBreakdownComponent>;
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let testHostComponent: TestHostComponent;
 
+  const serviceMock = { barColors: ['color'], sophisticationNumberToWord: number => 'word'};
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SophisticationBreakdownComponent ]
+      declarations: [ SophisticationBreakdownComponent, TestHostComponent ],
+      imports: [ChartsModule],
+      providers: [
+        {
+          provide: SummaryCalculationService,
+          useValue: serviceMock
+        }
+      ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SophisticationBreakdownComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    testHostComponent = hostFixture.componentInstance;
+    hostFixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(testHostComponent).toBeTruthy();
   });
 });

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SophisticationBreakdownComponent } from './sophistication-breakdown.component';
+
+describe('SophisticationBreakdownComponent', () => {
+  let component: SophisticationBreakdownComponent;
+  let fixture: ComponentFixture<SophisticationBreakdownComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SophisticationBreakdownComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SophisticationBreakdownComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
@@ -14,7 +14,7 @@ class TestHostComponent {
   totalAttackPatternCountBySophisticationLevel = {0: 29, 1: 30, 2: 34, 3: 4};
 }
 
-fdescribe('SophisticationBreakdownComponent', () => {
+describe('SophisticationBreakdownComponent', () => {
   let component: SophisticationBreakdownComponent;
   let fixture: ComponentFixture<SophisticationBreakdownComponent>;
   let hostFixture: ComponentFixture<TestHostComponent>;

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { AssessAttackPatternCount } from '../../../../../models/assess/assess-attack-pattern-count';
+import { ChartData } from '../chart-data';
+import { SummaryCalculationService } from '../../summary-calculation.service';
+
+@Component({
+  selector: 'sophistication-breakdown',
+  templateUrl: './sophistication-breakdown.component.html',
+  styleUrls: ['./sophistication-breakdown.component.scss']
+})
+export class SophisticationBreakdownComponent implements OnInit {
+  @Input('assessedAttackPatterns') public assessedAttackPatterns: AssessAttackPatternCount;
+  @Input('allAttackPatterns') public allAttackPatterns: AssessAttackPatternCount;
+  public readonly barChartData: ChartData[];
+  public barChartLabels: string[];
+  public barChartOptions: any;
+  public barChartLegend: any;
+  public readonly barChartType: string;
+  public colors: any; // TODO specify? Prob not
+  constructor(private summaryCalculationService: SummaryCalculationService) {
+    this.barChartData = [
+      {
+        data: [],
+        label: 'Assessed Attack Patterns',
+        borderWidth: 0,
+      },
+      {
+        data: [],
+        label: 'Unassessed Attack Patterns',
+        borderWidth: 0,
+      }
+    ]
+    this.barChartType = 'bar';
+  }
+
+  ngOnInit() {
+    this.barChartLabels = [];
+    this.barChartOptions = {
+      scaleShowVerticalLines: false,
+      responsive: true,
+      scales: {
+        xAxes: [{
+          stacked: true
+        }],
+        yAxes: [{
+          stacked: true
+        }]
+      },
+      tooltips: {
+        mode: 'index',
+        callbacks: {
+          label: (tooltipItem, data) => {
+            const dataset = data.datasets[tooltipItem.datasetIndex];
+            return dataset.data[tooltipItem.index] || 0;
+          }
+        }
+      },
+      legend: {
+        display: true,
+        position: 'top',
+        labels: {
+          fontSize: 10,
+        }
+      }
+
+    };
+    this.barChartLegend = true;
+    this.colors = this.summaryCalculationService.barColors;
+    this.barChartLabels = Object.keys(this.allAttackPatterns)
+      .map((level) => this.summaryCalculationService.sophisticationNumberToWord(level));
+
+    for (const prop in Object.keys(this.assessedAttackPatterns)) {
+      this.barChartData[0].data.push(this.assessedAttackPatterns[prop]);
+    }
+
+    for (const prop in Object.keys(this.allAttackPatterns)) {
+      this.barChartData[1].data.push(this.allAttackPatterns[prop]);
+    }
+  }
+
+}

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -1,26 +1,24 @@
 <div id="report">
   <div class="container-fluid">
     <summary-header></summary-header>
-    <div id="summaryTitle">
+    <div class="row" id="summaryTitle">
       <span>Assessment Report Overview</span>
     </div>
     <div class="row">
-      <div class="flex flexItemsCenter">
-        <mat-card color="primary" class="card uf-mat-card" id="riskCard">
+      <div class="flex matchHeight">
+        <mat-card color="primary" class="uf-mat-card card" id="riskCard">
           <mat-card-title>Overall Implementation Risk {{totalRiskValue}}%</mat-card-title>
-          <mat-card-subtitle>Weaknesses</mat-card-subtitle>
+          <mat-card-subtitle>Weakness</mat-card-subtitle>
           <mat-card-content>
-            <ul *ngIf="weakestAttackPatterns && weakestAttackPatterns.length > 0; else noWeakestAttackPatterns">
-              <li *ngFor="let attackPattern of weakestAttackPatterns">
-                {{attackPattern.description}}
-              </li>
-            </ul>
+            <p *ngIf="weakness && weakness.length > 0; else noWeakestAttackPatterns">
+                {{weakness}}
+            </p>
             <ng-template #noWeakestAttackPatterns>
               No Weaknesses found? Either we messed up or you are good!
             </ng-template>
           </mat-card-content>
         </mat-card>
-        <mat-card class="card uf-mat-card" id="vulnerabilityCard">
+        <mat-card class="uf-mat-card card" id="vulnerabilityCard">
           <mat-card-title>Where you are most vulnerable</mat-card-title>
           <mat-card-content>
             <mat-table #table>
@@ -58,12 +56,12 @@
       </div>
     </div>
     <div class="row">
-      <div class="flex flexItemsCenter">
-        <mat-card class="card uf-mat-card" id="riskCard">
+      <div class="flex matchHeight">
+        <mat-card class="uf-mat-card card" id="riskCard">
           <mat-card-title>Sophistication Breakdown</mat-card-title>
           <mat-card-content>Test</mat-card-content>
         </mat-card>
-        <mat-card class="card uf-mat-card" id="vulnerabilityCard">
+        <mat-card class="uf-mat-card card" id="vulnerabilityCard">
           <mat-card-title>% Techniques Detected by Skill</mat-card-title>
           <mat-card-content>Test</mat-card-content>
         </mat-card>
@@ -71,7 +69,7 @@
     </div>
     <div class="row">
       <div class="flex flexItemsCenter">
-        <mat-card class="card uf-mat-card flex1">
+        <mat-card class="uf-mat-card card flex1">
           <mat-card-title>% of Assessments Better than Mitigation Threshold</mat-card-title>
           <mat-card-content>Test</mat-card-content>
         </mat-card>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -6,8 +6,8 @@
     </div>
     <div class="row">
       <div class="flex matchHeight">
-        <mat-card color="primary" class="uf-mat-card card" id="riskCard">
-          <mat-card-title>Overall Implementation Risk {{totalRiskValue}}%</mat-card-title>
+        <mat-card color="primary" class="uf-mat-card card left-card" id="riskCard">
+          <mat-card-title>Overall implementation risk: {{totalRiskValue}}%</mat-card-title>
           <mat-card-subtitle>Weakness</mat-card-subtitle>
           <mat-card-content>
             <p *ngIf="weakness && weakness.length > 0; else noWeakestAttackPatterns">
@@ -18,15 +18,15 @@
             </ng-template>
           </mat-card-content>
         </mat-card>
-        <mat-card class="uf-mat-card card" id="vulnerabilityCard">
+        <mat-card class="uf-mat-card card right-card" id="vulnerabilityCard">
           <mat-card-title>Where you are most vulnerable</mat-card-title>
           <mat-card-content>
             <mat-table #table [dataSource]="topRisks">
-              <ng-container matColumnDef="kca">
+              <ng-container matColumnDef="{{columnIds[0]}}">
                 <mat-header-cell *matHeaderCellDef>KILL CHAIN AFFECTED</mat-header-cell>
                 <mat-cell *matCellDef="let risk">{{risk.phaseName | capitalize }}</mat-cell>
               </ng-container>
-              <ng-container matColumnDef="item">
+              <ng-container matColumnDef="{{columnIds[1]}}">
                 <mat-header-cell *matHeaderCellDef>ASSESSED ITEM</mat-header-cell>
                 <mat-cell *matCellDef="let risk">
                   <ul *ngIf="risk.objects; else noObjects">
@@ -38,16 +38,15 @@
                     No objects found!
                   </ng-template>
                 </mat-cell>
-                <!-- ; else noObjects"> -->
               </ng-container>
-              <ng-container matColumnDef="risk">
+              <ng-container matColumnDef="{{columnIds[2]}}">
                 <mat-header-cell *matHeaderCellDef>RISK</mat-header-cell>
                 <mat-cell *matCellDef="let risk">
                   <span class="label label-warning">{{calculateRisk(risk.objects)}}</span>
                 </mat-cell>
               </ng-container>
-              <mat-header-row *matHeaderRowDef="['kca','item','risk']"></mat-header-row>
-              <mat-row *matRowDef="let row; columns: ['kca','item','risk'];"></mat-row>
+              <mat-header-row class="table-header-row" *matHeaderRowDef="columnIds"></mat-header-row>
+              <mat-row *matRowDef="let row; columns: columnIds;"></mat-row>
             </mat-table>
           </mat-card-content>
         </mat-card>
@@ -69,11 +68,16 @@
     </div>
     <div class="row">
       <div class="flex matchHeight">
-        <mat-card class="uf-mat-card card" id="riskCard">
+        <mat-card class="uf-mat-card card left-card" id="sophisticationCard">
           <mat-card-title>Sophistication Breakdown</mat-card-title>
-          <mat-card-content>Test</mat-card-content>
+          <mat-card-content>
+            <div *ngIf="summaryAggregation && summaryAggregation.assessedAttackPatternCountBySophisicationLevel && summaryAggregation.totalAttackPatternCountBySophisicationLevel; else noSophisticationData">
+              <sophistication-breakdown [assessedAttackPatterns]="summaryAggregation.assessedAttackPatternCountBySophisicationLevel" [allAttackPatterns]="summaryAggregation.totalAttackPatternCountBySophisicationLevel"></sophistication-breakdown>
+            </div>
+            <ng-template #noSophisticationData>No data to load chart!</ng-template>
+          </mat-card-content>
         </mat-card>
-        <mat-card class="uf-mat-card card" id="vulnerabilityCard">
+        <mat-card class="uf-mat-card card right-card">
           <mat-card-title>% Techniques Detected by Skill</mat-card-title>
           <mat-card-content>Test</mat-card-content>
         </mat-card>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -11,7 +11,7 @@
           <mat-card-subtitle>Weakness</mat-card-subtitle>
           <mat-card-content>
             <p *ngIf="weakness && weakness.length > 0; else noWeakestAttackPatterns">
-                {{weakness}}
+              {{weakness}}
             </p>
             <ng-template #noWeakestAttackPatterns>
               No Weaknesses found? Either we messed up or you are good!
@@ -21,18 +21,30 @@
         <mat-card class="uf-mat-card card" id="vulnerabilityCard">
           <mat-card-title>Where you are most vulnerable</mat-card-title>
           <mat-card-content>
-            <mat-table #table>
+            <mat-table #table [dataSource]="topRisks">
               <ng-container matColumnDef="kca">
                 <mat-header-cell *matHeaderCellDef>KILL CHAIN AFFECTED</mat-header-cell>
-                <mat-cell *matCellDef>I am a KCA</mat-cell>
+                <mat-cell *matCellDef="let risk">{{risk.phaseName | capitalize }}</mat-cell>
               </ng-container>
               <ng-container matColumnDef="item">
                 <mat-header-cell *matHeaderCellDef>ASSESSED ITEM</mat-header-cell>
-                <mat-cell *matCellDef>I am an item</mat-cell>
+                <mat-cell *matCellDef="let risk">
+                  <ul *ngIf="risk.objects; else noObjects">
+                    <li *ngFor="let obj of risk.objects">
+                      <a href="#stix/{{obj.type}}s/{{obj.id}}">{{obj.name}}</a>
+                    </li>
+                  </ul>
+                  <ng-template #noObjects>
+                    No objects found!
+                  </ng-template>
+                </mat-cell>
+                <!-- ; else noObjects"> -->
               </ng-container>
               <ng-container matColumnDef="risk">
                 <mat-header-cell *matHeaderCellDef>RISK</mat-header-cell>
-                <mat-cell *matCellDef>Risk Value</mat-cell>
+                <mat-cell *matCellDef="let risk">
+                  <span class="label label-warning">{{calculateRisk(risk.objects)}}</span>
+                </mat-cell>
               </ng-container>
               <mat-header-row *matHeaderRowDef="['kca','item','risk']"></mat-header-row>
               <mat-row *matRowDef="let row; columns: ['kca','item','risk'];"></mat-row>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -7,11 +7,11 @@
     <div class="row">
       <div class="flex matchHeight">
         <mat-card color="primary" class="uf-mat-card card left-card" id="riskCard">
-          <mat-card-title>Overall implementation risk: {{totalRiskValue}}%</mat-card-title>
+          <mat-card-title>Overall implementation risk: {{summaryCalculationService.getRiskText()}}%</mat-card-title>
           <mat-card-subtitle>Weakness</mat-card-subtitle>
           <mat-card-content>
-            <p *ngIf="weakness && weakness.length > 0; else noWeakestAttackPatterns">
-              {{weakness}}
+            <p *ngIf="summaryCalculationService.weakness && summaryCalculationService.weakness.length > 0; else noWeakestAttackPatterns">
+              {{summaryCalculationService.weakness}}
             </p>
             <ng-template #noWeakestAttackPatterns>
               No Weaknesses found? Either we messed up or you are good!
@@ -21,7 +21,7 @@
         <mat-card class="uf-mat-card card right-card" id="vulnerabilityCard">
           <mat-card-title>Where you are most vulnerable</mat-card-title>
           <mat-card-content>
-            <mat-table #table [dataSource]="topRisks">
+            <mat-table #table [dataSource]="summaryCalculationService.topRisks">
               <ng-container matColumnDef="{{columnIds[0]}}">
                 <mat-header-cell *matHeaderCellDef>KILL CHAIN AFFECTED</mat-header-cell>
                 <mat-cell *matCellDef="let risk">{{risk.phaseName | capitalize }}</mat-cell>
@@ -71,15 +71,22 @@
         <mat-card class="uf-mat-card card left-card" id="sophisticationCard">
           <mat-card-title>Sophistication Breakdown</mat-card-title>
           <mat-card-content>
-            <div *ngIf="summaryAggregation && summaryAggregation.assessedAttackPatternCountBySophisicationLevel && summaryAggregation.totalAttackPatternCountBySophisicationLevel; else noSophisticationData">
-              <sophistication-breakdown [assessedAttackPatterns]="summaryAggregation.assessedAttackPatternCountBySophisicationLevel" [allAttackPatterns]="summaryAggregation.totalAttackPatternCountBySophisicationLevel"></sophistication-breakdown>
+            <div *ngIf="summaryCalculationService.isSummaryAggregationValid(); else noSophisticationData">
+              <sophistication-breakdown [assessedAttackPatterns]="summaryCalculationService.summaryAggregation.assessedAttackPatternCountBySophisicationLevel"
+                [allAttackPatterns]="summaryCalculationService.summaryAggregation.totalAttackPatternCountBySophisicationLevel"></sophistication-breakdown>
             </div>
             <ng-template #noSophisticationData>No data to load chart!</ng-template>
           </mat-card-content>
         </mat-card>
         <mat-card class="uf-mat-card card right-card">
           <mat-card-title>% Techniques Detected by Skill</mat-card-title>
-          <mat-card-content>Test</mat-card-content>
+          <mat-card-content>
+            <div *ngIf="summaryCalculationService.techniqueBreakdown;else noTechinquesData">
+              <!-- <techniques-chart #techniquesChart [riskThreshold]="selectedRisk" [riskLabelOptions]="thresholdOptions" [techniqueBreakdown]="techniqueBreakdown">
+              </techniques-chart> -->
+            </div>
+            <ng-template #noTechinquesData>No data to load chart!</ng-template>
+          </mat-card-content>
         </mat-card>
       </div>
     </div>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -59,7 +59,7 @@
       <div class="flex flexItemsCenter">
         <div class="flex flexItemsCenter" id="sliderContainer">
           <mat-icon color="primary" class="mat-24 icon-people-1" aria-hidden="false" aria-label="Least sophisticated mitigation"></mat-icon>
-          <mat-slider min="0" max="4" step="1" value="2" id="sophisticationSlider" color="primary">
+          <mat-slider disabled min="0" max="4" step="1" value="2" id="sophisticationSlider" color="primary">
           </mat-slider>
           <mat-icon color="primary" class="mat-24 icon-people" aria-hidden="false" aria-label="Most sophisticated mitigation"></mat-icon>
         </div>
@@ -81,11 +81,12 @@
         <mat-card class="uf-mat-card card right-card">
           <mat-card-title>% Techniques Detected by Skill</mat-card-title>
           <mat-card-content>
-            <div *ngIf="summaryCalculationService.techniqueBreakdown;else noTechinquesData">
-              <!-- <techniques-chart #techniquesChart [riskThreshold]="selectedRisk" [riskLabelOptions]="thresholdOptions" [techniqueBreakdown]="techniqueBreakdown">
-              </techniques-chart> -->
+            <div *ngIf="summaryCalculationService.techniqueBreakdown;else noTechniquesData">
+              <!-- [riskLabelOptions]="thresholdOptions" -->
+              <techniques-chart #techniquesChart [riskThreshold]="summaryCalculationService.selectedRisk" [techniqueBreakdown]="summaryCalculationService.techniqueBreakdown">
+              </techniques-chart>
             </div>
-            <ng-template #noTechinquesData>No data to load chart!</ng-template>
+            <ng-template #noTechniquesData>No data to load chart!</ng-template>
           </mat-card-content>
         </mat-card>
       </div>
@@ -94,7 +95,7 @@
       <div class="flex flexItemsCenter">
         <mat-card class="uf-mat-card card flex1">
           <mat-card-title>% of Assessments Better than Mitigation Threshold</mat-card-title>
-          <mat-card-content>Test</mat-card-content>
+          <mat-card-content>COMING SOON</mat-card-content>
         </mat-card>
       </div>
     </div>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -21,7 +21,12 @@
         <mat-card class="uf-mat-card card right-card" id="vulnerabilityCard">
           <mat-card-title>Where you are most vulnerable</mat-card-title>
           <mat-card-content>
-            <mat-table #table [dataSource]="summaryCalculationService.topRisks">
+            <div style="display:flex; height: 192px;">
+              <div class="text-muted" style="margin: auto auto">
+                Coming soon...
+              </div>
+            </div>
+            <!-- <mat-table #table [dataSource]="summaryCalculationService.topRisks">
               <ng-container matColumnDef="{{columnIds[0]}}">
                 <mat-header-cell *matHeaderCellDef>KILL CHAIN AFFECTED</mat-header-cell>
                 <mat-cell *matCellDef="let risk">{{risk.phaseName | capitalize }}</mat-cell>
@@ -47,7 +52,7 @@
               </ng-container>
               <mat-header-row class="table-header-row" *matHeaderRowDef="columnIds"></mat-header-row>
               <mat-row *matRowDef="let row; columns: columnIds;"></mat-row>
-            </mat-table>
+            </mat-table> -->
           </mat-card-content>
         </mat-card>
       </div>

--- a/src/app/assess/result/summary/summary-report/summary-report.component.scss
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.scss
@@ -43,24 +43,76 @@
     .mat-card-subtitle {
         color: black;
         font-size: 20px;
-        font-weight: 500;
+        font-weight: 600;
         margin-bottom: 6px;
     }
 
     .mat-card-content {
         overflow-y: auto;
-        max-height: 162px;
+        max-height: 192px;
     }
 }
 
-#riskCard {
+.mat-column-kca {
+    min-width: 57%;
+}
+
+.mat-column-item {
+    min-width: 32%;
+    ul {
+        list-style-type: none;
+        -webkit-padding-start: 0px;
+    }
+}
+
+.table-header-row {
+    min-height: 0px;
+    border-top-style: solid;
+    border-top-width: 1px;
+    border-top-color: rgba(0, 0, 0, 0.12);
+    padding: 0px;
+
+    .mat-header-cell {
+        color: black;
+        font-weight: 600;
+    }
+}
+
+.left-card {
     flex-grow: .5;
     margin-right: 10px;
 }
 
-#vulnerabilityCard {
+.right-card {
     flex-grow: .5;
     margin-left: 10px;
+}
+
+#riskCard {
+    .mat-card-content {
+        max-height: 162px;
+    }
+}
+
+#sophisticationCard {
+    .mat-card-title {
+        margin-bottom: 6px;
+    }
+
+    .mat-card-content {
+        max-height: 198px;
+    }
+}
+
+#vulnerabilityCard {
+    .mat-row {
+        padding: 0px;
+        align-items: normal;
+
+        .mat-cell {
+            font-size: 11px;
+        }
+    }
 }
 
 @font-face {

--- a/src/app/assess/result/summary/summary-report/summary-report.component.scss
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.scss
@@ -24,11 +24,33 @@
     margin-left: 8px;
 }
 
+.matchHeight {
+    align-items: stretch;
+    -webkit-box-align: stretch;
+    -ms-flex-align: stretch;
+}
+
 .card {
-    min-height: 315px;
+    min-height: 289px;
     margin-bottom: 20px;
     width: 50%;
     min-width: 215px;
+    padding-top: 25px;
+    padding-left: 15px;
+    padding-right: 18px;
+    padding-bottom: 6px;
+
+    .mat-card-subtitle {
+        color: black;
+        font-size: 20px;
+        font-weight: 500;
+        margin-bottom: 6px;
+    }
+
+    .mat-card-content {
+        overflow-y: auto;
+        max-height: 162px;
+    }
 }
 
 #riskCard {
@@ -55,7 +77,6 @@
 [class^="icon-"], [class*=" icon-"] {
     /* use !important to prevent issues with browser extensions that change fonts */
     font-family: 'icomoon' !important;
-    speak: none;
     font-style: normal;
     font-weight: normal;
     font-variant: normal;

--- a/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
@@ -2,18 +2,19 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatTableModule } from '@angular/material';
 
+import { CapitalizePipe } from '../../../../global/pipes/capitalize.pipe';
 import { SummaryReportComponent } from './summary-report.component';
 import { SummaryCalculationService } from '../summary-calculation.service';
 
-describe('SummaryReportComponent', () => {
+fdescribe('SummaryReportComponent', () => {
   let component: SummaryReportComponent;
   let fixture: ComponentFixture<SummaryReportComponent>;
 
-  const serviceMock = {weakness: 'weeeeeeeak', getRiskText: string => 'risk'};
+  const serviceMock = { weakness: 'weeeeeeeak', getRiskText: string => 'risk', calculateAvgRiskPerAssessedObject: number => .33 };
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      declarations: [SummaryReportComponent],
+      declarations: [SummaryReportComponent, CapitalizePipe],
       imports: [MatTableModule],
       providers: [
         {
@@ -33,5 +34,16 @@ describe('SummaryReportComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should format a risk value appropriately for the summary report component', () => {
+    expect(component.formatRisk(null)).toBe('0.00');
+    expect(component.formatRisk(undefined)).toBe('0.00');
+    expect(component.formatRisk(3 / 0)).toBe('100.00');
+  });
+
+  it('should calculate average risk per object and format the result', () => {
+    expect(component.calculateRisk(null)).toBe('0.00');
+    expect(component.calculateRisk([{ risk: .33 }, { risk: .33 }, { risk: .33 }])).toBe('33.00');
   });
 });

--- a/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
@@ -3,16 +3,24 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { MatTableModule } from '@angular/material';
 
 import { SummaryReportComponent } from './summary-report.component';
+import { SummaryCalculationService } from '../summary-calculation.service';
 
 describe('SummaryReportComponent', () => {
   let component: SummaryReportComponent;
   let fixture: ComponentFixture<SummaryReportComponent>;
 
+  const serviceMock = {weakness: 'weeeeeeeak', getRiskText: string => 'risk'};
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       declarations: [SummaryReportComponent],
-      imports: [MatTableModule]
+      imports: [MatTableModule],
+      providers: [
+        {
+          provide: SummaryCalculationService,
+          useValue: serviceMock
+        }
+      ]
     })
       .compileComponents();
   }));

--- a/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
@@ -10,7 +10,11 @@ fdescribe('SummaryReportComponent', () => {
   let component: SummaryReportComponent;
   let fixture: ComponentFixture<SummaryReportComponent>;
 
-  const serviceMock = { weakness: 'weeeeeeeak', getRiskText: string => 'risk', calculateAvgRiskPerAssessedObject: number => .33 };
+  const serviceMock = { weakness: 'weeeeeeeak', getRiskText: string => 'risk', calculateAvgRiskPerAssessedObject: number => .33,
+                        summaryAggregation: { assessedAttackPatternCountBySophisicationLevel: {0: 16, 1: 13, 2: 16, 3: 2},
+                        totalAttackPatternCountBySophisicationLevel: {0: 29, 1: 30, 2: 34, 3: 4} },
+                        techniqueBreakdown: {},
+                        isSummaryAggregationValid: boolean => true};
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],

--- a/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.spec.ts
@@ -6,7 +6,7 @@ import { CapitalizePipe } from '../../../../global/pipes/capitalize.pipe';
 import { SummaryReportComponent } from './summary-report.component';
 import { SummaryCalculationService } from '../summary-calculation.service';
 
-fdescribe('SummaryReportComponent', () => {
+describe('SummaryReportComponent', () => {
   let component: SummaryReportComponent;
   let fixture: ComponentFixture<SummaryReportComponent>;
 

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { SummaryCalculationService } from '../summary-calculation.service';
+
 @Component({
   selector: 'summary-report',
   templateUrl: './summary-report.component.html',
@@ -7,15 +9,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SummaryReportComponent implements OnInit {
 
-  totalRiskValue: number;
-  // TODO fix
-  weakestAttackPatterns: any;
+  totalRiskValue: string;
+  weakness: string;
 
-  constructor() {
+  constructor(private summaryCalculationService: SummaryCalculationService) {
   }
 
   ngOnInit() {
-    // TODO fix
-    this.totalRiskValue = 78;
+    this.totalRiskValue = this.summaryCalculationService.getRiskText();
+    this.weakness = this.summaryCalculationService.weakness;
   }
 }

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import { SummaryCalculationService } from '../summary-calculation.service';
+import { AssessKillChainType } from '../../../../models/assess/assess-kill-chain-type';
 
 @Component({
   selector: 'summary-report',
@@ -8,9 +9,10 @@ import { SummaryCalculationService } from '../summary-calculation.service';
   styleUrls: ['./summary-report.component.scss']
 })
 export class SummaryReportComponent implements OnInit {
-
   totalRiskValue: string;
   weakness: string;
+  topRisks: AssessKillChainType[];
+
 
   constructor(private summaryCalculationService: SummaryCalculationService) {
   }
@@ -18,5 +20,6 @@ export class SummaryReportComponent implements OnInit {
   ngOnInit() {
     this.totalRiskValue = this.summaryCalculationService.getRiskText();
     this.weakness = this.summaryCalculationService.weakness;
+    this.topRisks = this.summaryCalculationService.topRisks;
   }
 }

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -13,7 +13,6 @@ export class SummaryReportComponent implements OnInit {
   weakness: string;
   topRisks: AssessKillChainType[];
 
-
   constructor(private summaryCalculationService: SummaryCalculationService) {
   }
 
@@ -21,5 +20,17 @@ export class SummaryReportComponent implements OnInit {
     this.totalRiskValue = this.summaryCalculationService.getRiskText();
     this.weakness = this.summaryCalculationService.weakness;
     this.topRisks = this.summaryCalculationService.topRisks;
+  }
+  public calculateRisk(riskArr: any[]): string {
+    const risk = this.summaryCalculationService.calculateAvgRiskPerAssessedObject(riskArr);
+    return this.formatRisk(risk);
+  }
+
+  /**
+   * @param risk
+   * @return {string} formatted
+   */
+  public formatRisk(risk: number): string {
+    return Number((risk) * 100).toFixed(2);
   }
 }

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -10,21 +10,13 @@ import { SummaryAggregation } from '../../../../models/assess/summary-aggregatio
   styleUrls: ['./summary-report.component.scss']
 })
 export class SummaryReportComponent implements OnInit {
-  totalRiskValue: string;
-  weakness: string;
-  topRisks: AssessKillChainType[];
   readonly columnIds: string[];
-  summaryAggregation: SummaryAggregation;
 
-  constructor(private summaryCalculationService: SummaryCalculationService) {
+  constructor(public summaryCalculationService: SummaryCalculationService) {
     this.columnIds = ['kca', 'item', 'risk'];
   }
 
   ngOnInit() {
-    this.totalRiskValue = this.summaryCalculationService.getRiskText();
-    this.weakness = this.summaryCalculationService.weakness;
-    this.topRisks = this.summaryCalculationService.topRisks;
-    this.summaryAggregation = this.summaryCalculationService.summaryAggregation;
   }
   public calculateRisk(riskArr: any[]): string {
     let risk = 0;

--- a/src/app/assess/result/summary/summary-report/summary-report.component.ts
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { SummaryCalculationService } from '../summary-calculation.service';
 import { AssessKillChainType } from '../../../../models/assess/assess-kill-chain-type';
+import { SummaryAggregation } from '../../../../models/assess/summary-aggregation';
 
 @Component({
   selector: 'summary-report',
@@ -12,17 +13,24 @@ export class SummaryReportComponent implements OnInit {
   totalRiskValue: string;
   weakness: string;
   topRisks: AssessKillChainType[];
+  readonly columnIds: string[];
+  summaryAggregation: SummaryAggregation;
 
   constructor(private summaryCalculationService: SummaryCalculationService) {
+    this.columnIds = ['kca', 'item', 'risk'];
   }
 
   ngOnInit() {
     this.totalRiskValue = this.summaryCalculationService.getRiskText();
     this.weakness = this.summaryCalculationService.weakness;
     this.topRisks = this.summaryCalculationService.topRisks;
+    this.summaryAggregation = this.summaryCalculationService.summaryAggregation;
   }
   public calculateRisk(riskArr: any[]): string {
-    const risk = this.summaryCalculationService.calculateAvgRiskPerAssessedObject(riskArr);
+    let risk = 0;
+    if (riskArr) {
+      risk = this.summaryCalculationService.calculateAvgRiskPerAssessedObject(riskArr);
+    }
     return this.formatRisk(risk);
   }
 
@@ -31,6 +39,13 @@ export class SummaryReportComponent implements OnInit {
    * @return {string} formatted
    */
   public formatRisk(risk: number): string {
-    return Number((risk) * 100).toFixed(2);
+    let formattedRisk = '0.00';
+    if (risk) {
+      formattedRisk = Number((risk) * 100).toFixed(2)
+    }
+    if (formattedRisk === 'Infinity') {
+      formattedRisk = '100.00';
+    }
+    return formattedRisk;
   }
 }

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.html
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.html
@@ -1,3 +1,9 @@
-<p>
-  techniques-chart works!
-</p>
+<div style="display: block">
+  <canvas baseChart 
+    [datasets]="barChartData" 
+    [labels]="barChartLabels" 
+    [options]="barChartOptions"
+    [legend]="showLegend"
+    [chartType]="barChartType"
+    [colors]="colors"></canvas>
+</div>

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.html
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.html
@@ -1,0 +1,3 @@
+<p>
+  techniques-chart works!
+</p>

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TechniquesChartComponent } from './techniques-chart.component';
+
+fdescribe('TechniquesChartComponent', () => {
+  let component: TechniquesChartComponent;
+  let fixture: ComponentFixture<TechniquesChartComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TechniquesChartComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TechniquesChartComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
@@ -1,14 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChartsModule } from 'ng2-charts';
 
 import { TechniquesChartComponent } from './techniques-chart.component';
+import { SummaryCalculationService } from '../../summary-calculation.service';
 
-fdescribe('TechniquesChartComponent', () => {
+describe('TechniquesChartComponent', () => {
   let component: TechniquesChartComponent;
   let fixture: ComponentFixture<TechniquesChartComponent>;
 
+  const serviceMock = { barColors: ['color'], sophisticationNumberToWord: number => 'word'};
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TechniquesChartComponent ]
+      declarations: [ TechniquesChartComponent ],
+      imports: [ ChartsModule ],
+      providers: [
+        {
+          provide: SummaryCalculationService,
+          useValue: serviceMock
+        }
+      ]
     })
     .compileComponents();
   }));
@@ -16,6 +26,7 @@ fdescribe('TechniquesChartComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TechniquesChartComponent);
     component = fixture.componentInstance;
+    component.techniqueBreakdown = [];
     fixture.detectChanges();
   });
 

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'techniques-chart',
+  templateUrl: './techniques-chart.component.html',
+  styleUrls: ['./techniques-chart.component.scss']
+})
+export class TechniquesChartComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { ChartData } from '../chart-data';
+import { SummaryCalculationService } from '../../summary-calculation.service';
 
 @Component({
   selector: 'techniques-chart',
@@ -6,10 +8,123 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./techniques-chart.component.scss']
 })
 export class TechniquesChartComponent implements OnInit {
+  @Input()
+  public riskThreshold: number;
+  public readonly riskThresholdDefault = 0.0;
+  @Input()
+  public techniqueBreakdown: number[];
+  @Input()
+  public showLabels: boolean;
+  public readonly showLabelsDefault = true;
+  @Input()
+  public showLegend: boolean;
+  public readonly showLegendDefault = true;
+  public barChartData: ChartData[] = [
+    { data: [], label: '', borderWidth: 0 },
+    { data: [], label: '', borderWidth: 0 }
+  ];
+  public barChartLabels: string[] = [];
 
-  constructor() { }
+  public readonly barChartOptions: any = {
+    scaleShowVerticalLines: false,
+    responsive: true,
+    scales: {
+      xAxes: [{
+        stacked: true
+      }],
+      yAxes: [{
+        stacked: true,
+        ticks: {
+          suggestedMin: 0,
+          suggestedMax: 100,
+          stepSize: 10
+        }
+      }]
+    },
+    tooltips: {
+      mode: 'index',
+      callbacks: {
+        label: (tooltipItem, data) => {
+          const dataset = data.datasets[tooltipItem.datasetIndex];
+          const val = dataset.data[tooltipItem.index] || 0;
+          const percentage = val;
+          return `${percentage}%`;
+        }
+      }
+    },
+    legend: {
+      display: true,
+      position: 'top',
+      labels: {
+        fontSize: 10,
+      }
+    }
+  };
+  public readonly barChartType: string = 'bar';
+  public colors: any[];
+  @Input()
+  public riskLabelOptions = '';
+
+  public constructor(private summaryCalculationService: SummaryCalculationService) { }
 
   ngOnInit() {
+    this.colors = this.summaryCalculationService.barColors;
+    this.showLabels = this.showLabels || this.showLabelsDefault;
+    this.showLegend = this.showLegend || this.showLegendDefault;
+    this.riskThreshold = this.riskThreshold || this.riskThresholdDefault;
+    this.renderChart();
+  }
+
+  public renderChart(selectedRisk?: number): void {
+    if (selectedRisk) {
+      this.riskThreshold = selectedRisk;
+    }
+    this.renderLabels();
+    this.renderLegend();
+    this.initDataArray();
+
+    const breakdown = Object.keys(this.techniqueBreakdown);
+    let index = 0;
+    breakdown.forEach((key) => {
+      const val = this.techniqueBreakdown[key];
+      const complement = 1.0 - val;
+      this.barChartData[0].data[index] = Math.round(val * 100);
+      this.barChartData[1].data[index] = Math.round(complement * 100);
+      index = index + 1;
+    });
+  }
+
+  public renderLabels(): void {
+    this.barChartLabels = Object.keys(this.techniqueBreakdown)
+      .map((level) => this.summaryCalculationService.sophisticationNumberToWord(level));
+  }
+
+  /**
+   * @description
+   *  render legend at top of graph
+   * @returns {void}
+   */
+  public renderLegend(): void {
+    this.barChartData[0].label = 'At Or Above Mitigation Threshold';
+    this.barChartData[1].label = 'Below Mitigation Threshold';
+    // TODO
+    // if (this.riskLabelOptions) {
+    //   const option = this.riskLabelOptions.find((opt) => opt.risk === this.riskThreshold);
+    //   const name = option.name;
+    //   this.barChartData[0].label = 'At Or Above ' + name;
+    //   this.barChartData[1].label = 'Below ' + name;
+    // }
+  }
+
+  protected initDataArray(): void {
+    const size = this.barChartLabels.length || 0;
+    // init data array
+    this.barChartData[0].data = [];
+    this.barChartData[1].data = [];
+    for (let i = 0; i < size; i++) {
+      this.barChartData[0].data[i] = 0;
+      this.barChartData[1].data[i] = 0;
+    }
   }
 
 }

--- a/src/app/assess/result/summary/summary-sort-helper.spec.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.spec.ts
@@ -9,6 +9,17 @@ fdescribe('SummarySortHelper', () => {
     expect(new SummarySortHelper()).toBeTruthy();
   });
 
+  it('should check if the first of two values is unset, but not zero', () => {
+    expect(SummarySortHelper.isFirstValueOnlyUnset(null, null)).toEqual(false);
+    expect(SummarySortHelper.isFirstValueOnlyUnset(null, {})).toEqual(true);
+    expect(SummarySortHelper.isFirstValueOnlyUnset({}, null)).toEqual(false);
+    expect(SummarySortHelper.isFirstValueOnlyUnset({}, {})).toEqual(false);
+    expect(SummarySortHelper.isFirstValueOnlyUnset(0, {})).toEqual(false);
+    expect(SummarySortHelper.isFirstValueOnlyUnset(0, null)).toEqual(false);
+    expect(SummarySortHelper.isFirstValueOnlyUnset(null, 0)).toEqual(true);
+    expect(SummarySortHelper.isFirstValueOnlyUnset({}, 0)).toEqual(false);
+  });
+
   it('should sort killchain risk objects by risk decending', () => {
     let riskObjects: AssessKillChainType[] = [];
     let expected: AssessKillChainType[] = [];
@@ -22,6 +33,11 @@ fdescribe('SummarySortHelper', () => {
 
     riskObjects = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: .5, questions: null, objects: null, phaseName: null }];
     expected = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: .5, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: null, questions: null, objects: null, phaseName: null }, { risk: 0, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: 0, questions: null, objects: null, phaseName: null }, { risk: null, questions: null, objects: null, phaseName: null }];
     riskObjects.sort(SummarySortHelper.sortByRiskDesc());
     expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
 
@@ -64,6 +80,11 @@ fdescribe('SummarySortHelper', () => {
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
     expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 0 }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 0 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
     phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
@@ -187,4 +208,6 @@ fdescribe('SummarySortHelper', () => {
     patterns.sort(SummarySortHelper.sortBySophisticationAsc());
     expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
   });
+
+
 });

--- a/src/app/assess/result/summary/summary-sort-helper.spec.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.spec.ts
@@ -4,7 +4,7 @@ import { AttackPattern } from '../../../models/attack-pattern';
 import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
 import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 
-fdescribe('SummarySortHelper', () => {
+describe('SummarySortHelper', () => {
   it('should create an instance', () => {
     expect(new SummarySortHelper()).toBeTruthy();
   });

--- a/src/app/assess/result/summary/summary-sort-helper.spec.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.spec.ts
@@ -1,0 +1,135 @@
+import { SummarySortHelper } from './summary-sort-helper';
+import { Phase } from '../../../models/assess/phase';
+import { AttackPattern } from '../../../models/attack-pattern';
+import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
+
+describe('SummarySortHelper', () => {
+  it('should create an instance', () => {
+    expect(new SummarySortHelper()).toBeTruthy();
+  });
+
+  it('should sort phases by average risk decending', () => {
+    let phases: Phase[] = [];
+    let expected: Phase[] = [];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
+    // Note that null and missing avgRisk ordering is arbitrary, but that doesn't matter as long as they all end up at the end
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
+    { assessedObjects: null, attackPatterns: null, _id: null },
+    { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+  });
+
+  it('should sort attack patterns by sophistication level ascending', () => {
+    let patterns: AssessAttackPattern[] = []
+    let expected: AssessAttackPattern[] = [];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: undefined }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: undefined }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    // Note that null and missing sophistication_level ordering is arbitrary, but that doesn't matter as long as they all end up at the end
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 2 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: null }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+  });
+});

--- a/src/app/assess/result/summary/summary-sort-helper.spec.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.spec.ts
@@ -2,36 +2,84 @@ import { SummarySortHelper } from './summary-sort-helper';
 import { Phase } from '../../../models/assess/phase';
 import { AttackPattern } from '../../../models/attack-pattern';
 import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
+import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 
-describe('SummarySortHelper', () => {
+fdescribe('SummarySortHelper', () => {
   it('should create an instance', () => {
     expect(new SummarySortHelper()).toBeTruthy();
+  });
+
+  it('should sort killchain risk objects by risk decending', () => {
+    let riskObjects: AssessKillChainType[] = [];
+    let expected: AssessKillChainType[] = [];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: null, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: null, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: .5, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: .5, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: .5, questions: null, objects: null, phaseName: null }, { risk: 1, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: .5, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: null, questions: null, objects: null, phaseName: null }, { risk: 1, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: 1, questions: null, objects: null, phaseName: null }, { risk: null, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
+
+    riskObjects = [{ risk: null, questions: null, objects: null, phaseName: null },
+    { risk: .5, questions: null, objects: null, phaseName: null },
+    { risk: .5, questions: null, objects: null, phaseName: null },
+    { risk: 1, questions: null, objects: null, phaseName: null },
+    { risk: null, questions: null, objects: null, phaseName: null },
+    { risk: 1, questions: null, objects: null, phaseName: null }];
+    expected = [{ risk: 1, questions: null, objects: null, phaseName: null },
+    { risk: 1, questions: null, objects: null, phaseName: null },
+    { risk: .5, questions: null, objects: null, phaseName: null },
+    { risk: .5, questions: null, objects: null, phaseName: null },
+    { risk: null, questions: null, objects: null, phaseName: null },
+    { risk: null, questions: null, objects: null, phaseName: null }];
+    riskObjects.sort(SummarySortHelper.sortByRiskDesc());
+    expect(JSON.stringify(riskObjects)).toEqual(JSON.stringify(expected));
   });
 
   it('should sort phases by average risk decending', () => {
     let phases: Phase[] = [];
     let expected: Phase[] = [];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
     expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
     expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: undefined }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
+    expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
+
+    phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }];
+    expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }];
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
     expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }];
     expected = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: 1 }, { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
@@ -46,7 +94,7 @@ describe('SummarySortHelper', () => {
     { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: .5 },
     { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
     { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
 
     phases = [{ assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
@@ -62,7 +110,7 @@ describe('SummarySortHelper', () => {
     { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null },
     { assessedObjects: null, attackPatterns: null, _id: null },
     { assessedObjects: null, attackPatterns: null, _id: null, avgRisk: null }];
-    phases.sort(SummarySortHelper.sortByAvgRiskDesc())
+    phases.sort(SummarySortHelper.sortByAvgRiskDesc());
     expect(JSON.stringify(phases)).toEqual(JSON.stringify(expected));
   });
 
@@ -89,6 +137,13 @@ describe('SummarySortHelper', () => {
 
     patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 },
     { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 }];
+    expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
+    patterns.sort(SummarySortHelper.sortBySophisticationAsc());
+    expect(JSON.stringify(patterns)).toEqual(JSON.stringify(expected));
+
+    patterns = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 },
+    { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
     expected = [{ description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 0 },
     { description: null, external_references: null, id: null, kill_chain_phases: null, name: null, x_unfetter_sophistication_level: 1 }];
     patterns.sort(SummarySortHelper.sortBySophisticationAsc());

--- a/src/app/assess/result/summary/summary-sort-helper.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.ts
@@ -3,23 +3,34 @@ import { AssessAttackPattern } from '../../../models/assess/assess-attack-patter
 import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 
 export class SummarySortHelper {
+
+    public static isFirstValueOnlyUnset(firstValue: any, otherValue: any) {
+        let firstValueOnlyIsUnset = false;
+        if (firstValue !== 0) {
+            if (!firstValue && (otherValue || otherValue === 0)) {
+                firstValueOnlyIsUnset = true;
+            }
+        }
+        return firstValueOnlyIsUnset;
+    }
+
     public static sortByRiskDesc(): (a: AssessKillChainType, b: AssessKillChainType) => number {
         const sorter = (a: AssessKillChainType, b: AssessKillChainType) => {
-            if ((!b.risk && a.risk) || (a.risk > b.risk)) {
+            if (this.isFirstValueOnlyUnset(b.risk, a.risk) || b.risk < a.risk) {
                 return -1;
-            } else if ((!a.risk && b.risk) || (a.risk < b.risk)) {
+            } else if (this.isFirstValueOnlyUnset(a.risk, b.risk) || (a.risk < b.risk)) {
                 return 1;
             }
             return 0;
         };
         return sorter;
     }
-    
+
     public static sortByAvgRiskDesc(): (a: Phase, b: Phase) => number {
         const sorter = (a: Phase, b: Phase) => {
-            if ((!b.avgRisk && a.avgRisk) || (a.avgRisk > b.avgRisk)) {
+            if (this.isFirstValueOnlyUnset(b.avgRisk, a.avgRisk) || b.avgRisk < a.avgRisk) {
                 return -1;
-            } else if ((!a.avgRisk && b.avgRisk) || (a.avgRisk < b.avgRisk)) {
+            } else if (this.isFirstValueOnlyUnset(a.avgRisk, b.avgRisk) || a.avgRisk < b.avgRisk) {
                 return 1;
             }
             return 0;
@@ -29,11 +40,11 @@ export class SummarySortHelper {
 
     public static sortBySophisticationAsc(): (a: AssessAttackPattern, b: AssessAttackPattern) => number {
         const sorter = (a: AssessAttackPattern, b: AssessAttackPattern) => {
-            if ((!a.x_unfetter_sophistication_level && b.x_unfetter_sophistication_level) || 
-                (a.x_unfetter_sophistication_level > b.x_unfetter_sophistication_level)) {
+            if (this.isFirstValueOnlyUnset(a.x_unfetter_sophistication_level, b.x_unfetter_sophistication_level) ||
+                a.x_unfetter_sophistication_level > b.x_unfetter_sophistication_level) {
                 return 1;
-            } else if ((!b.x_unfetter_sophistication_level && a.x_unfetter_sophistication_level) || 
-                (a.x_unfetter_sophistication_level < b.x_unfetter_sophistication_level)) {
+            } else if (this.isFirstValueOnlyUnset(b.x_unfetter_sophistication_level, a.x_unfetter_sophistication_level) ||
+                b.x_unfetter_sophistication_level > a.x_unfetter_sophistication_level) {
                 return -1;
             }
             return 0;

--- a/src/app/assess/result/summary/summary-sort-helper.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.ts
@@ -1,0 +1,32 @@
+import { Phase } from '../../../models/assess/phase';
+import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
+
+export class SummarySortHelper {
+    public static sortByAvgRiskDesc(): (a: Phase, b: Phase) => number {
+        const sorter = (a: Phase, b: Phase) => {
+            if ((!b.avgRisk && a.avgRisk) || (a.avgRisk > b.avgRisk)) {
+                return -1;
+            } else if ((!a.avgRisk && b.avgRisk) || (a.avgRisk < b.avgRisk)) {
+                return 1;
+            }
+            return 0;
+        };
+        return sorter;
+    }
+
+    public static sortBySophisticationAsc(): (a: AssessAttackPattern, b: AssessAttackPattern) => number {
+        const sorter = (a: AssessAttackPattern, b: AssessAttackPattern) => {
+            if ((!a.x_unfetter_sophistication_level && b.x_unfetter_sophistication_level) || 
+                (a.x_unfetter_sophistication_level > b.x_unfetter_sophistication_level)) {
+                return 1;
+            } else if ((!b.x_unfetter_sophistication_level && a.x_unfetter_sophistication_level) || 
+                (a.x_unfetter_sophistication_level < b.x_unfetter_sophistication_level)) {
+                return -1;
+            }
+            return 0;
+        };
+        return sorter;
+    }
+}
+
+

--- a/src/app/assess/result/summary/summary-sort-helper.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.ts
@@ -1,7 +1,20 @@
 import { Phase } from '../../../models/assess/phase';
 import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
+import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 
 export class SummarySortHelper {
+    public static sortByRiskDesc(): (a: AssessKillChainType, b: AssessKillChainType) => number {
+        const sorter = (a: AssessKillChainType, b: AssessKillChainType) => {
+            if ((!b.risk && a.risk) || (a.risk > b.risk)) {
+                return -1;
+            } else if ((!a.risk && b.risk) || (a.risk < b.risk)) {
+                return 1;
+            }
+            return 0;
+        };
+        return sorter;
+    }
+    
     public static sortByAvgRiskDesc(): (a: Phase, b: Phase) => number {
         const sorter = (a: Phase, b: Phase) => {
             if ((!b.avgRisk && a.avgRisk) || (a.avgRisk > b.avgRisk)) {

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -25,7 +25,7 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [rollupId]="rollupId"></result-header>
+        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId"></result-header>
         <summary-report></summary-report>
       </div>
     </mat-sidenav-content>

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -1,4 +1,4 @@
-<div id="newAssessmentsSummary" *ngIf="finishedLoading === true; else loadingBlock" class="fadeIn">
+<div id="newAssessmentsSummary" *ngIf="finishedLoading && finishedLoadingRBAP && finishedLoadingKCD === true; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="summary !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
@@ -28,6 +28,8 @@
         <result-header [rollupId]="rollupId"></result-header>
         <summary-report></summary-report>
       </div>
+      <br><br>
+      <div>{{riskByKillChain|json}}</div>
     </mat-sidenav-content>
   </mat-sidenav-container>
 </div>

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -1,4 +1,4 @@
-<div id="newAssessmentsSummary" *ngIf="finishedLoading && finishedLoadingRBAP && finishedLoadingKCD === true; else loadingBlock" class="fadeIn">
+<div id="newAssessmentsSummary" *ngIf="finishedLoading && finishedLoadingRBAP && finishedLoadingKCD && finishedLoadingSAD === true; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="summary !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
@@ -28,8 +28,6 @@
         <result-header [rollupId]="rollupId"></result-header>
         <summary-report></summary-report>
       </div>
-      <br><br>
-      <div>{{riskByKillChain|json}}</div>
     </mat-sidenav-content>
   </mat-sidenav-container>
 </div>

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -13,7 +13,7 @@ import { MatDialogModule } from '@angular/material';
 import { AssessService } from '../../services/assess.service';
 import { SummaryCalculationService } from './summary-calculation.service';
 
-describe('SummaryComponent', () => {
+fdescribe('SummaryComponent', () => {
   let component: SummaryComponent;
   let fixture: ComponentFixture<SummaryComponent>;
 

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -13,7 +13,7 @@ import { MatDialogModule } from '@angular/material';
 import { AssessService } from '../../services/assess.service';
 import { SummaryCalculationService } from './summary-calculation.service';
 
-fdescribe('SummaryComponent', () => {
+describe('SummaryComponent', () => {
   let component: SummaryComponent;
   let fixture: ComponentFixture<SummaryComponent>;
 

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -11,6 +11,7 @@ import { SummaryComponent } from './summary.component';
 import { summaryReducer } from '../store/summary.reducers';
 import { MatDialogModule } from '@angular/material';
 import { AssessService } from '../../services/assess.service';
+import { SummaryCalculationService } from './summary-calculation.service';
 
 describe('SummaryComponent', () => {
   let component: SummaryComponent;
@@ -20,6 +21,8 @@ describe('SummaryComponent', () => {
   let mockReducer: ActionReducerMap<any> = {
     summary: summaryReducer
   };
+
+  const mockService = {};
 
   beforeEach(async(() => {
     const matModules = [
@@ -36,7 +39,11 @@ describe('SummaryComponent', () => {
         ...matModules,
         StoreModule.forRoot(mockReducer),
       ],
-      providers: [GenericApi, AssessService],
+      providers: [GenericApi, AssessService,
+        {
+          provide: SummaryCalculationService,
+          use: mockService
+        }],
     })
       .compileComponents();
   }));

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -40,6 +40,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
   readonly baseAssessUrl = '/assess';
   assessmentName: Observable<string>;
   rollupId: string;
+  assessmentId: string;
   summaries: Assessment[];
   summary: Assessment;
   riskByAttacks: RiskByAttack[];
@@ -79,9 +80,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
    */
   public ngOnInit(): void {
     const idParamSub$ = this.route.params
-      .pluck('rollupId')
-      .subscribe((id: string) => {
-        this.rollupId = id || '';
+      .subscribe((params) => {
+        this.rollupId = params.rollupId || '';
+        this.assessmentId = params.assessmentId || '';
         this.listenForDataChanges();
         const sub$ = this.userStore
           .select('users')
@@ -89,7 +90,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
           .take(1)
           .subscribe((user: UserProfile) => {
             const creatorId = user._id;
-            this.requestData(this.rollupId, creatorId);
+            this.requestData(this.assessmentId, creatorId);
           },
             (err) => console.log(err));
         this.subscriptions.push(sub$);
@@ -360,7 +361,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
       return;
     }
 
-    return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId]);
+    return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId, assessment.id]);
   }
 
   /**

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -60,11 +60,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
     createRoute: this.baseAssessUrl + '/create',
   };
 
-  public assessmentsGroupingTotal: any; // TODO specify
-  public assessmentsGroupingFiltered: any; // TODO specify
-  public selectedRisk: number;
-  public techniqueBreakdown: any; // TODO specify
-
   private readonly subscriptions: Subscription[] = [];
 
   constructor(
@@ -83,7 +78,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
    *  initialize this component, fetching data from backend
    */
   public ngOnInit(): void {
-    this.selectedRisk = 0.5;
     const idParamSub$ = this.route.params
       .pluck('rollupId')
       .subscribe((id: string) => {
@@ -435,91 +429,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
     // }
     // // this.summaryAggregation = allSummaryAggregations; // Maybe??
     // this.summaryCalculationService.setSummaryAggregation(allSummaryAggregations);
-    this.populateAssessmentsGrouping();
-    this.populateTechniqueBreakdown();
-  }
-  /**
-   * @description
-   *  populate kill chain grouping and assessment object tallies for assessment grouping chart
-   * @returns {void}
-   */
-  public populateAssessmentsGrouping(): void {
-    const includedIds = this.filterOnRisk();
-    const killChainTotal = {};
-    const killChainFiltered = {};
-
-    const tally = (tallyObject: object) => {
-      return (assessedObject) => {
-        // flat map kill chain names
-        const killChainNames = assessedObject.attackPatterns
-          .reduce((memo, pattern) => memo.concat(pattern['kill_chain_phases']), []);
-        const names: string[] = killChainNames.map((chain) => chain['phase_name'].toLowerCase() as string);
-        const uniqNames: string[] = Array.from(new Set(names));
-        names.forEach((name) => tallyObject[name] = tallyObject[name] ? tallyObject[name] + 1 : 1);
-        return assessedObject;
-      };
-    };
-
-    // Find assessed-objects to kill chain maps grouping
-    this.summaryAggregation.attackPatternsByAssessedObject
-      // tally totals
-      .map(tally(killChainTotal))
-      .filter((aoToApMap) => includedIds.includes(aoToApMap._id))
-      // tally filtered objects
-      .map(tally(killChainFiltered));
-
-    this.assessmentsGroupingTotal = killChainTotal;
-    this.assessmentsGroupingFiltered = killChainFiltered;
-  }
-
-  /**
- * @description
- *  Find IDs that meet risk threshold
- *  TODO should be <= risk or < risk?
- * @returns {string[]}
- */
-  public filterOnRisk(): string[] {
-    const includedIds: string[] = this.summary.assessment_objects // TODO fix...or active...or this is a roll-up?
-      .filter((ao) => ao.risk <= this.selectedRisk)
-      .map((ao) => ao.stix.id);
-    return includedIds;
-  }
-
-  /**
- * @description
- *  populate grouping and assessment object tallies for technique by skill chart
- * @returns {void}
- */
-  public populateTechniqueBreakdown(): void {
-    // Total assessed objects to calculated risk
-    const assessedRiskMapping = this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel;
-    const includedIds = this.filterOnRisk();
-    const attackPatternSet = new Set();
-    // Find assessed-objects-to-attack-patterns maps that meet those Ids
-    this.summaryAggregation.attackPatternsByAssessedObject
-      .filter((aoToApMap) => includedIds.includes(aoToApMap._id))
-      .forEach((aoToApMap) => {
-        aoToApMap.attackPatterns.forEach((ap) => {
-          attackPatternSet.add(JSON.stringify(ap));
-        });
-      });
-
-    const attackPatternSetMap = {};
-    attackPatternSet.forEach((ap) => {
-      const curAp = JSON.parse(ap);
-      if (attackPatternSetMap[curAp['x_unfetter_sophistication_level']] === undefined) {
-        attackPatternSetMap[curAp['x_unfetter_sophistication_level']] = 0;
-      }
-      ++attackPatternSetMap[curAp['x_unfetter_sophistication_level']];
-    });
-
-    this.techniqueBreakdown = {};
-    for (const prop in Object.keys(assessedRiskMapping)) {
-      if (attackPatternSetMap[prop] === undefined) {
-        this.techniqueBreakdown[prop] = 0;
-      } else {
-        this.techniqueBreakdown[prop] = attackPatternSetMap[prop] / (assessedRiskMapping[prop]);
-      }
-    }
+    this.summaryCalculationService.populateAssessmentsGrouping(this.summary.assessment_objects);
+    this.summaryCalculationService.populateTechniqueBreakdown(this.summary.assessment_objects);
   }
 }

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -8,7 +8,8 @@ import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
 
 import { SummaryState } from '../store/summary.reducers';
-import { LoadAssessmentSummaryData } from '../store/summary.actions';
+import { RiskByAttackPatternState } from '../store/riskbyattackpattern.reducers';
+import { LoadAssessmentSummaryData, LoadSingleAssessmentSummaryData, LoadSingleRiskPerKillChainData } from '../store/summary.actions';
 
 import { AppState } from '../../../root-store/app.reducers';
 import { Assessment } from '../../../models/assess/assessment';
@@ -20,6 +21,12 @@ import { slideInOutAnimation } from '../../../global/animations/animations';
 import { Constance } from '../../../utils/constance';
 import { UserProfile } from '../../../models/user/user-profile';
 import { SummaryDataSource } from './summary.datasource';
+import { SummaryCalculationService } from './summary-calculation.service';
+import { AssessmentObject } from '../../../models/assess/assessment-object';
+import { AssessmentsDashboardService } from '../../../assessments/assessments-dashboard/assessments-dashboard.service';
+import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+import { LoadAssessmentRiskByAttackPatternData, LoadSingleAssessmentRiskByAttackPatternData } from '../store/riskbyattackpattern.actions';
+import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 
 @Component({
   selector: 'summary',
@@ -34,7 +41,13 @@ export class SummaryComponent implements OnInit, OnDestroy {
   rollupId: string;
   summaries: Assessment[];
   summary: Assessment;
+  riskByAttacks: RiskByAttack[];
+  riskByAttack: RiskByAttack;
+  riskByKillChains: RiskByKillChain[];
+  riskByKillChain: RiskByKillChain;
   finishedLoading = false;
+  finishedLoadingRBAP = false;
+  finishedLoadingKCD = false;
   masterListOptions = {
     dataSource: null,
     columns: new MasterListDialogTableHeaders('modified', 'Modified'),
@@ -50,8 +63,10 @@ export class SummaryComponent implements OnInit, OnDestroy {
     private router: Router,
     private dialog: MatDialog,
     private store: Store<SummaryState>,
+    private riskByAttackPatternStore: Store<RiskByAttackPatternState>,
     private userStore: Store<AppState>,
     private assessService: AssessService,
+    private summaryCalculationService: SummaryCalculationService
   ) { }
 
   /**
@@ -104,8 +119,66 @@ export class SummaryComponent implements OnInit, OnDestroy {
       .select('summary')
       .pluck('finishedLoading')
       .distinctUntilChanged()
-      .subscribe((done: boolean) => this.finishedLoading = done,
-        (err) => console.log(err));
+      .subscribe((done: boolean) => {
+        this.finishedLoading = done;
+        if (done) {
+          this.transformSummary()
+        }
+      }, (err) => console.log(err));
+
+    const sub3$ = this.riskByAttackPatternStore
+      .select('riskByAttackPattern')
+      .pluck('riskByAttackPatterns')
+      .distinctUntilChanged()
+      .subscribe((arr: RiskByAttack[]) => {
+        if (!arr || arr.length === 0) {
+          this.riskByAttack = undefined;
+          this.riskByAttacks = [];
+          return;
+        }
+
+        this.riskByAttacks = [...arr];
+        this.riskByAttack = { ...arr[0] };
+      },
+      (err) => console.log(err));
+
+    const sub4$ = this.riskByAttackPatternStore
+      .select('riskByAttackPattern')
+      .pluck('finishedLoading')
+      .distinctUntilChanged()
+      .subscribe((done: boolean) => {
+        this.finishedLoadingRBAP = done;
+        if (done) {
+          this.transformRBAP();
+        }
+      },
+      (err) => console.log(err));
+
+    const sub5$ = this.store
+      .select('summary')
+      .pluck('killChainData')
+      .distinctUntilChanged()
+      .subscribe((arr: RiskByKillChain[]) => {
+        if (!arr || arr.length === 0) {
+          this.riskByKillChain = undefined;
+          this.riskByKillChains = [];
+          return;
+        }
+
+        this.riskByKillChain = { ...arr[0] };
+        this.riskByKillChains = [...arr];
+      })
+
+    const sub6$ = this.store
+      .select('summary')
+      .pluck('finishedLoadingKillChainData')
+      .distinctUntilChanged()
+      .subscribe((done: boolean) => {
+        this.finishedLoadingKCD = done;
+        if (done) {
+          this.transformKCD();
+        }
+      }, (err) => console.log(err));
 
     this.assessmentName = this.store
       .select('summary')
@@ -118,7 +191,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
         return summaries[0].name;
       });
 
-    this.subscriptions.push(sub1$, sub2$);
+    this.subscriptions.push(sub1$, sub2$, sub3$, sub4$, sub5$, sub6$);
   }
 
   /**
@@ -128,8 +201,14 @@ export class SummaryComponent implements OnInit, OnDestroy {
   public requestData(rollupId: string, creatorId?: string): void {
     this.masterListOptions.dataSource = new SummaryDataSource(this.assessService, creatorId);
     this.masterListOptions.columns.id.classes = 'cursor-pointer';
-    this.store.dispatch(new LoadAssessmentSummaryData(rollupId));
+    // TODO fix
+    this.store.dispatch(new LoadSingleAssessmentSummaryData(rollupId));
+    this.riskByAttackPatternStore.dispatch(new LoadSingleAssessmentRiskByAttackPatternData(rollupId));
+    // TODO this.store.dispatch(new LoadAssessmentSummaryData(rollupId));
+    this.store.dispatch(new LoadSingleRiskPerKillChainData(rollupId));
+    // TODO this.store.dispatch(new LoadRiskPerKillChainData(rollupId))
   }
+
 
   /**
    * @description close open subscriptions, clean up resources when we destroy this component
@@ -270,5 +349,32 @@ export class SummaryComponent implements OnInit, OnDestroy {
    */
   public trackByFn(index: number, item: any): number {
     return item.id || index;
+  }
+
+  public transformSummary() {
+    // single
+    this.summaryCalculationService.setAverageRiskPerAssessedObject(this.summary.assessment_objects);
+    // all
+    // let allAssessmentObjects: Array<AssessmentObject> = []; 
+    // for (let assessment of this.summaries) {
+    //   allAssessmentObjects = allAssessmentObjects.concat(assessment.assessment_objects);
+    // }
+    // this.summaryCalculationService.setAverageRiskPerAssessedObject(allAssessmentObjects);
+  }
+
+  public transformRBAP() {
+    // single
+    this.summaryCalculationService.calculateWeakness(this.riskByAttack);
+    // all
+    // let allRiskByAttackObjects: Array<RiskByAttack> = [];
+    // for (let riskByAttack of this.riskByAttacks) {
+    //  allRiskByAttackObjects = allRiskByAttackObjects.concat(riskByAttack);
+    // }
+    // this.summaryCalculationService.calculateWeakness(allRiskByAttackObjects);
+  }
+
+  public transformKCD() {
+    // single
+
   }
 }

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -368,13 +368,18 @@ export class SummaryComponent implements OnInit, OnDestroy {
     // all
     // let allRiskByAttackObjects: Array<RiskByAttack> = [];
     // for (let riskByAttack of this.riskByAttacks) {
-    //  allRiskByAttackObjects = allRiskByAttackObjects.concat(riskByAttack);
+    //   allRiskByAttackObjects = allRiskByAttackObjects.concat(riskByAttack);
     // }
     // this.summaryCalculationService.calculateWeakness(allRiskByAttackObjects);
   }
 
   public transformKCD() {
     // single
-
+    this.summaryCalculationService.calculateTopRisks(this.riskByKillChain);
+    // all
+    // let allRiskByKillChainObjects: Array<RiskByKillChain> = [];
+    // for (let riskByKillChain of this.riskByKillChains) {
+    //   allRiskByKillChainObjects = allRiskByKillChainObjects.concat(riskByKillChain);
+    // }
   }
 }

--- a/src/app/assess/services/assess.service.ts
+++ b/src/app/assess/services/assess.service.ts
@@ -10,6 +10,8 @@ import { AssessmentObject } from '../../models/assess/assessment-object';
 import { JsonApi } from '../../models/json/jsonapi';
 import { RiskByAttack } from '../../models/assess/risk-by-attack';
 import { RiskByKillChain } from '../../models/assess/risk-by-kill-chain';
+import { SummaryAggregation } from '../../models/assess/summary-aggregation';
+import { JsonApiObject } from '../../threat-dashboard/models/adapter/json-api-object';
 
 @Injectable()
 export class AssessService {
@@ -172,11 +174,11 @@ export class AssessService {
         return this.genericApi.getAs<RiskByKillChain>(url);
     }
 
-        /**
-     * @description
-     * @param {string} id
-     * @return {Observable}
-     */
+    /**
+ * @description
+ * @param {string} id
+ * @return {Observable}
+ */
     public getRiskPerKillChainByRollupId(id: string): Observable<any> {
         if (!id) {
             return Observable.empty();
@@ -219,20 +221,40 @@ export class AssessService {
             .getAs<JsonApiData<RiskByAttack>[]>(url)
             .map((data) => data.map((el) => el.attributes));
     }
-    
+
     /**
      * @description
      * @param {string} id
      * @return {Observable}
      */
-    public getSummaryAggregation(id: string): Observable<any> {
+    public getSummaryAggregation(id: string): Observable<SummaryAggregation> {
         if (!id) {
             return Observable.empty();
         }
 
         const url = `${this.assessBaseUrl}/${id}/summary-aggregations`;
-        return this.genericApi.get(url);
+        return this.genericApi.getAs<SummaryAggregation>(url);
     }
+
+    /**
+     * @description
+     * @param {string} id
+     * @return {Observable}
+     */
+    public getSummaryAggregationByRollup(id: string, includeMeta = true): Observable<SummaryAggregation[]> {
+        if (!id) {
+            return Observable.empty();
+        }
+        const filter = {
+            'metaProperties.rollupId': id
+        };
+
+        const url = `${this.assessBaseUrl}/${id}/summary-aggregations?metaproperties=${includeMeta}&filter=${encodeURI(JSON.stringify(filter))}`;
+        return this.genericApi
+            .getAs<JsonApiData<SummaryAggregation>[]>(url)
+            .map((data) => data.map((el) => el.attributes));
+    }
+
 
     /**
      * @description retrieve full assessments for given creator

--- a/src/app/assess/services/assess.service.ts
+++ b/src/app/assess/services/assess.service.ts
@@ -7,6 +7,9 @@ import { GenericApi } from '../../core/services/genericapi.service';
 import { JsonApiData } from '../../models/json/jsonapi-data';
 import { LastModifiedAssessment } from '../models/last-modified-assessment';
 import { AssessmentObject } from '../../models/assess/assessment-object';
+import { JsonApi } from '../../models/json/jsonapi';
+import { RiskByAttack } from '../../models/assess/risk-by-attack';
+import { RiskByKillChain } from '../../models/assess/risk-by-kill-chain';
 
 @Injectable()
 export class AssessService {
@@ -166,28 +169,76 @@ export class AssessService {
         }
 
         const url = `${this.assessBaseUrl}/${id}/risk-per-kill-chain`;
+        return this.genericApi.getAs<RiskByKillChain>(url);
+    }
+
+        /**
+     * @description
+     * @param {string} id
+     * @return {Observable}
+     */
+    public getRiskPerKillChainByRollupId(id: string): Observable<any> {
+        if (!id) {
+            return Observable.empty();
+        }
+
+        const url = `${this.assessBaseUrl}/${id}/risk-per-kill-chain`;
         return this.genericApi.get(url);
     }
 
     /**
      * @description
      * @param {string} id
+     * @return {Observable<RiskByAttack>}
+     */
+    public getRiskPerAttackPattern(id: string, includeMeta = true): Observable<RiskByAttack> {
+        if (!id) {
+            return Observable.empty();
+        }
+        const url = `${this.assessBaseUrl}/${id}/risk-by-attack-pattern?metaproperties=${includeMeta}`;
+        return this.genericApi
+            .getAs<RiskByAttack>(url);
+    }
+
+
+    /**
+     * @description
+     * @param {string} id
      * @return {Observable}
      */
-    public getRiskPerAttackPattern(id: string): Observable<any> {
+    public getRiskPerAttackPatternByRollupId(id: string, includeMeta = true): Observable<RiskByAttack[]> {
+        if (!id) {
+            return Observable.empty();
+        }
+        const filter = {
+            'metaProperties.rollupId': id
+        };
+
+        const url = `${this.assessBaseUrl}/${id}/risk-by-attack-pattern?metaproperties=${includeMeta}&filter=${encodeURI(JSON.stringify(filter))}`;
+        return this.genericApi
+            .getAs<JsonApiData<RiskByAttack>[]>(url)
+            .map((data) => data.map((el) => el.attributes));
+    }
+    
+    /**
+     * @description
+     * @param {string} id
+     * @return {Observable}
+     */
+    public getSummaryAggregation(id: string): Observable<any> {
         if (!id) {
             return Observable.empty();
         }
 
-        const url = `${this.assessBaseUrl}/${id}/risk-by-attack-pattern`;
+        const url = `${this.assessBaseUrl}/${id}/summary-aggregations`;
         return this.genericApi.get(url);
     }
 
     /**
- * @description retrieve full assessments for given creator
- * @param {string} creatorId, creator mongo user id, not stix identity
- * @return {Observable<Assessment[]>}
- */
+     * @description retrieve full assessments for given creator
+     * @param {string} creatorId, creator mongo user id, not stix identity
+     * @return {Observable<Assessment[]>}
+     */
     public getAssessmentsByCreatorId(creatorId: string, includeMeta = true): Observable<Assessment[]> {
         const filter = {
             'creator': creatorId,

--- a/src/app/assess/store/assess.actions.ts
+++ b/src/app/assess/store/assess.actions.ts
@@ -85,7 +85,7 @@ export class FinishedLoading implements Action {
 export class FinishedSaving implements Action {
     public readonly type = FINISHED_SAVING;
 
-    constructor(public payload: { finished: boolean, rollupId: string }) { }
+    constructor(public payload: { finished: boolean, rollupId: string, id: string }) { }
 }
 
 export class AnswerQuestion implements Action {

--- a/src/app/assess/store/assess.effects.ts
+++ b/src/app/assess/store/assess.effects.ts
@@ -136,7 +136,11 @@ export class AssessEffects {
         })
         .flatMap((arr) => arr)
         .map((arr) => {
-            return new assessActions.FinishedSaving({ finished: true, rollupId: arr[0].attributes.metaProperties.rollupId });
+            return new assessActions.FinishedSaving({ 
+                finished: true, 
+                rollupId: arr[0].attributes.metaProperties.rollupId,
+                id: arr[0].attributes.id,
+            });
         })
 
 

--- a/src/app/assess/store/assess.reducers.ts
+++ b/src/app/assess/store/assess.reducers.ts
@@ -16,7 +16,7 @@ export interface AssessState {
     sensors?: JsonApiData<Stix>[];
     mitigations?: JsonApiData<Stix>[];
     finishedLoading: boolean;
-    saved: { saved: boolean, rollupId: string };
+    saved: { finished: boolean, rollupId: string, id: string };
     showSummary: boolean;
     page: number;
 };
@@ -26,7 +26,7 @@ const genAssessState = (state?: Partial<AssessState>) => {
         assessment: new Assessment(),
         backButton: false,
         finishedLoading: false,
-        saved: { saved: false, rollupId: '' },
+        saved: { finished: false, rollupId: '', id: '' },
         showSummary: false,
         page: 1,
     };
@@ -81,8 +81,7 @@ export function assessmentReducer(state = initialState, action: assessmentAction
             return genAssessState({
                 ...state,
                 saved: {
-                    saved: action.payload.finished,
-                    rollupId: action.payload.rollupId,
+                    ...action.payload,
                 }
             });
         case assessmentActions.WIZARD_PAGE:

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -191,16 +191,17 @@ export class WizardComponent extends Measurements implements OnInit, OnDestroy {
         (page: number) => this.page = page,
         (err) => console.log(err));
 
-    interface SavedState { saved: boolean, rollupId: string };
+    interface SavedState { finished: boolean, rollupId: string, id: string };
     const sub6$ = this.store
       .select('assessment')
       .pluck('saved')
       .distinctUntilChanged()
-      .filter((el: SavedState) => el.saved === true)
+      .filter((el: SavedState) => el.finished === true)
       .subscribe(
         (saved: SavedState) => {
           const rollupId = saved.rollupId;
-          this.router.navigate(['assess/result/summary', rollupId]);
+          const id = saved.id;
+          this.router.navigate(['/assess/result/summary', rollupId, id]);
         },
         (err) => console.log(err));
 

--- a/src/app/assessments/assessments-summary/assessments-summary.component.ts
+++ b/src/app/assessments/assessments-summary/assessments-summary.component.ts
@@ -113,7 +113,6 @@ export class AssessmentsSummaryComponent implements OnInit, AfterViewInit {
     public populateTechniqueBreakdown(): void {
         // Total assessed objects to calculated risk
         const assessedRiskMapping = this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel;
-
         const includedIds = this.filterOnRisk();
         const attackPatternSet = new Set();
         // Find assessed-objects-to-attack-patterns maps that meet those Ids

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -30,11 +30,11 @@ export class HeaderNavigationComponent {
       title: 'Analytic Hub',
       icon: Constance.LOGO_IMG_ANALYTIC_HUB
     },
-    {
-      url: 'assessments',
-      title: 'Assessments',
-      icon: Constance.LOGO_IMG_ASSESSMENTS
-    },
+    // {
+    //   url: 'assessments',
+    //   title: 'Assessments',
+    //   icon: Constance.LOGO_IMG_ASSESSMENTS
+    // },
     {
       url: Constance.X_UNFETTER_ASSESSMENT_NAVIGATE_URL,
       title: 'Assessments 2.0',

--- a/src/app/models/assess/assess-attack-pattern-count.ts
+++ b/src/app/models/assess/assess-attack-pattern-count.ts
@@ -1,0 +1,4 @@
+export class AssessAttackPatternCount {
+    public index: number;
+    public count: number;
+}

--- a/src/app/models/assess/assess-attack-pattern-meta.ts
+++ b/src/app/models/assess/assess-attack-pattern-meta.ts
@@ -1,0 +1,5 @@
+
+export class AssessAttackPatternMeta {
+    public attackPatternId: string;
+    public attackPatternName: string;
+}

--- a/src/app/models/assess/assess-attack-pattern.ts
+++ b/src/app/models/assess/assess-attack-pattern.ts
@@ -5,10 +5,12 @@ import { KillChainPhase } from '../kill-chain-phase';
  * @description an assessment of a single type ie, indicator, mitigation, sensor
  */
 export class AssessAttackPattern {
-    public description: string;
-    public external_references = [] as ExternalReference[];
-    public id: string;
+    public description?: string;
+    public external_references? = [] as ExternalReference[];
+    public id?: string;
     public kill_chain_phases = [] as KillChainPhase[];
-    public name: string;
+    public name?: string;
     public x_unfetter_sophistication_level?: number;
+    // summary aggregations only
+    public attackPatternId?: string;
 }

--- a/src/app/models/assess/assess-attack-pattern.ts
+++ b/src/app/models/assess/assess-attack-pattern.ts
@@ -1,0 +1,14 @@
+import { ExternalReference } from '../externalReference';
+import { KillChainPhase } from '../kill-chain-phase';
+
+/**
+ * @description an assessment of a single type ie, indicator, mitigation, sensor
+ */
+export class AssessAttackPattern {
+    public description: string;
+    public external_references = [] as ExternalReference[];
+    public id: string;
+    public kill_chain_phases = [] as KillChainPhase[];
+    public name: string;
+    public x_unfetter_sophistication_level?: number;
+}

--- a/src/app/models/assess/assess-kill-chain-type.ts
+++ b/src/app/models/assess/assess-kill-chain-type.ts
@@ -1,12 +1,11 @@
 import { AssessmentQuestion } from './assessment-question';
-import { Stix } from '../stix/stix';
 
 /**
  * @description
  */
-export class AssessmentObject<T extends Partial<Stix> = Stix> {
+export class AssessKillChainType {
     public risk: number;
     public questions = [] as AssessmentQuestion[];
-    public stix?: T;
-    public assId?: string;
+    public objects = [] as Array<any>;
+    public phaseName: string;
 }

--- a/src/app/models/assess/assessed-by-attack-pattern.ts
+++ b/src/app/models/assess/assessed-by-attack-pattern.ts
@@ -1,0 +1,10 @@
+import { AssessmentObject } from './assessment-object';
+
+/**
+ * @description an assessment of a single type ie, indicator, mitigation, sensor
+ */
+export class AssessedByAttackPattern {
+    public assessedobjects = [] as AssessmentObject[];
+    public risk: number;
+    public _id: string;  
+}

--- a/src/app/models/assess/pattern-by-kill-chain.ts
+++ b/src/app/models/assess/pattern-by-kill-chain.ts
@@ -1,0 +1,9 @@
+import { AssessAttackPattern } from './assess-attack-pattern';
+
+/**
+ * @description an assessment of a single type ie, indicator, mitigation, sensor
+ */
+export class PatternByKillChain {
+    public attackPatterns = [] as AssessAttackPattern[];
+    public _id: string;
+}

--- a/src/app/models/assess/phase.ts
+++ b/src/app/models/assess/phase.ts
@@ -1,0 +1,12 @@
+import { AssessmentObject } from './assessment-object';
+import { AssessAttackPatternMeta } from './assess-attack-pattern-meta';
+
+/**
+ * @description an assessment of a single type ie, indicator, mitigation, sensor
+ */
+export class Phase {
+    public assessedObjects = [] as AssessmentObject[];
+    public attackPatterns = [] as AssessAttackPatternMeta[];
+    public _id: string;
+    public avgRisk?: number;
+}

--- a/src/app/models/assess/risk-by-attack.ts
+++ b/src/app/models/assess/risk-by-attack.ts
@@ -1,0 +1,12 @@
+import { AssessedByAttackPattern } from './assessed-by-attack-pattern';
+import { PatternByKillChain } from './pattern-by-kill-chain';
+import { Phase } from './phase';
+
+/**
+ * @description an assessment of a single type ie, indicator, mitigation, sensor
+ */
+export class RiskByAttack {
+    public assessedByAttackPattern = [] as AssessedByAttackPattern[];
+    public attackPatternsByKillChain = [] as PatternByKillChain[];
+    public phases = [] as Phase[];
+}

--- a/src/app/models/assess/risk-by-kill-chain.ts
+++ b/src/app/models/assess/risk-by-kill-chain.ts
@@ -1,0 +1,10 @@
+import { AssessKillChainType } from './assess-kill-chain-type';
+
+/**
+ * @description kill chain data for risk analysis
+ */
+export class RiskByKillChain {
+    public courseOfActions = [] as AssessKillChainType[];
+    public indicators = [] as AssessKillChainType[];
+    public sensors = [] as AssessKillChainType[];
+}

--- a/src/app/models/assess/summary-aggregation.ts
+++ b/src/app/models/assess/summary-aggregation.ts
@@ -1,0 +1,8 @@
+import { AssessAttackPatternCount } from './assess-attack-pattern-count';
+import { AssessAttackPattern } from './assess-attack-pattern';
+
+export class SummaryAggregation {
+    public assessedAttackPatternCountBySophisicationLevel: AssessAttackPatternCount;
+    public attackPatternsByAssessedObject: [{_id: string, attackPatterns: AssessAttackPattern[]}];
+    public totalAttackPatternCountBySophisicationLevel: AssessAttackPatternCount;
+}


### PR DESCRIPTION
This incorporates all changes to assessments summary except:
-switching assessment types (@mushinlogit will work this)
-ninja slider not operational
-bottom chart not complete
-polish

To test: 
run lint & tests
use *single* assessment id (old style) in the browser like:
https://localhost/#/assess/result/summary/x-unfetter-assessment--dc93f163-4287-49f7-a9d4-8e27126b645b
Investigate summary page.