### PR TITLE
Fixes long names in master list dialog table

### DIFF
--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
@@ -79,9 +79,12 @@
                 display: flex;
                 flex: 2;
                 align-items: center;
+                overflow: hidden;
 
                 .master-list-item-name {
                     flex: 1;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
                 }
 
                 .master-list-item-arrow {


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#729

Create a really long work product or assessment name, like "supercalifragilisticexpialodocious"...