### PR TITLE
added current users admin dashboard

### DIFF
--- a/src/app/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/admin/admin-layout/admin-layout.component.ts
@@ -11,6 +11,7 @@ export class AdminLayoutComponent {
         { url: 'site-usage', label: 'Site Usage Data' },
         { url: 'organization-leader-approval', label: 'Organization Leader Approval' },
         { url: 'config-edit', label: 'Edit Configurations' },
-        { url: 'heartbeat', label: 'Server Status' }
+        { url: 'heartbeat', label: 'Server Status' },
+        { url: 'current-users', label: 'Current Users' },
     ];
 }

--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -7,6 +7,7 @@ import { SiteUsageComponent } from './site-usage/site-usage.component';
 import { OrgLeaderApprovalComponent } from './org-leader-approval/org-leader-approval.component';
 import { ConfigEditComponent } from './config-edit/config-edit.component';
 import { HeartbeatComponent } from './heartbeat/heartbeat.component';
+import { CurrentUsersComponent } from './current-users/current-users.component';
 
 const routes = [
     {
@@ -37,6 +38,10 @@ const routes = [
             {
                 path: 'heartbeat',
                 component: HeartbeatComponent
+            },
+            {
+                path: 'current-users',
+                component: CurrentUsersComponent
             },
         ]
     }

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -12,6 +12,7 @@ import { ConfigEditComponent } from './config-edit/config-edit.component';
 import { OrgLeaderApprovalComponent } from './org-leader-approval/org-leader-approval.component';
 import { ChartsModule } from 'ng2-charts';
 import { HeartbeatComponent } from './heartbeat/heartbeat.component';
+import { CurrentUsersComponent } from './current-users/current-users.component';
 
 @NgModule({
     imports: [
@@ -29,7 +30,8 @@ import { HeartbeatComponent } from './heartbeat/heartbeat.component';
         SiteUsageComponent,
         OrgLeaderApprovalComponent,
         ConfigEditComponent,
-        HeartbeatComponent
+        HeartbeatComponent,
+        CurrentUsersComponent
     ],
     providers: [
         AdminService

--- a/src/app/admin/admin.service.ts
+++ b/src/app/admin/admin.service.ts
@@ -4,6 +4,8 @@ import { Observable } from 'rxjs/Observable';
 
 import { GenericApi } from '../core/services/genericapi.service';
 import { Constance } from '../utils/constance';
+import { JsonApiData } from '../models/json/jsonapi-data';
+import { UserProfile } from '../models/user/user-profile';
 
 @Injectable()
 export class AdminService {
@@ -18,6 +20,14 @@ export class AdminService {
         return this.genericApi.get(`${this.adminUrl}/users-pending-approval`);
     }
 
+    public getCurrentUsers(): Observable<UserProfile[]> {
+        return this.genericApi
+            .getAs<JsonApiData<UserProfile>[]>(`${this.adminUrl}/current-users`)
+            .map((usersData: JsonApiData<UserProfile>[]) => {
+                return usersData.map((userData: JsonApiData<UserProfile>) => userData.attributes);
+            });
+    }
+
     public getOrgLeaderApplicants(): Observable<any> {
         return this.genericApi.get(`${this.adminUrl}/organization-leader-applicants`);
     }
@@ -30,8 +40,8 @@ export class AdminService {
         return this.genericApi.get(`${this.adminUrl}/site-visits-graph/${numDays}`);
     }
 
-    public processUserApproval(user): Observable<any> {
-        return this.genericApi.post(`${this.adminUrl}/process-user-approval`, user);
+    public changeUserStatus(user): Observable<any> {
+        return this.genericApi.post(`${this.adminUrl}/change-user-status`, user);
     }
 
     public getConfig(): Observable<any> {

--- a/src/app/admin/approve-users/approve-users.component.ts
+++ b/src/app/admin/approve-users/approve-users.component.ts
@@ -31,7 +31,7 @@ export class ApproveUsersComponent implements OnInit {
                 return;
         }
         let processUserApproval$ = this.adminService
-            .processUserApproval({ data: { attributes: tempUser } })
+            .changeUserStatus({ data: { attributes: tempUser } })
             .subscribe(
             (res) => {
                 this.fetchUsers();

--- a/src/app/admin/current-users/current-users.component.html
+++ b/src/app/admin/current-users/current-users.component.html
@@ -1,0 +1,42 @@
+<div id="currentUsersComponent" class="row">
+  <div class="col-xs-12">
+
+    <div class="uf-well" *ngIf="message">{{message}}</div>
+
+    <div *ngIf="users && users.length">
+      <h5>Current Users</h5>
+      <table class="table table-striped">
+        <thead>
+          <th>User Name</th>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Organizations</th>
+          <th class="text-right">Make Admin</th>
+          <th class="text-right">Lock Account</th>
+        </thead>
+        <tbody>
+          <tr *ngFor="let user of users">
+            <td>{{ user.userName }}</td>
+            <td>{{ user.lastName }}, {{ user.firstName }}</td>
+            <td>{{ user.email }}</td>
+            <td>{{ user.role }}</td>
+            <td>{{ formatOrganizations(user.organizations) }}</td>
+            <td class="text-right">
+              <div *ngIf="user.role !== adminRole">
+                <button mat-button class="mat-24" (click)="userAction(user, 'PROMOTE_TO_ADMIN')">
+                  <i class="material-icons">arrow_upward</i>
+                </button>
+              </div>              
+            </td>
+            <td class="text-right">
+              <button mat-button class="mat-24" (click)="userAction(user, 'LOCK_USER')">
+                <i class="material-icons">lock</i>
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/src/app/admin/current-users/current-users.component.spec.ts
+++ b/src/app/admin/current-users/current-users.component.spec.ts
@@ -1,0 +1,25 @@
+// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+// import { CurrentUsersComponent } from './current-users.component';
+
+// describe('CurrentUsersComponent', () => {
+//   let component: CurrentUsersComponent;
+//   let fixture: ComponentFixture<CurrentUsersComponent>;
+
+//   beforeEach(async(() => {
+//     TestBed.configureTestingModule({
+//       declarations: [ CurrentUsersComponent ]
+//     })
+//     .compileComponents();
+//   }));
+
+//   beforeEach(() => {
+//     fixture = TestBed.createComponent(CurrentUsersComponent);
+//     component = fixture.componentInstance;
+//     fixture.detectChanges();
+//   });
+
+//   it('should create', () => {
+//     expect(component).toBeTruthy();
+//   });
+// });

--- a/src/app/admin/current-users/current-users.component.ts
+++ b/src/app/admin/current-users/current-users.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit } from '@angular/core';
+
+import { AdminService } from '../admin.service';
+import { UserProfile } from '../../models/user/user-profile';
+import { OrganizationIdentity } from '../../models/user/organization-identity';
+import { RxjsHelpers } from '../../global/static/rxjs-helpers';
+import { UserRole } from '../../models/user/user-role.enum';
+import { Constance } from '../../utils/constance';
+
+@Component({
+  selector: 'current-users',
+  templateUrl: './current-users.component.html',
+  styleUrls: ['./current-users.component.scss']
+})
+export class CurrentUsersComponent implements OnInit {
+
+  public users: UserProfile[] = [];
+  public message: string;
+  public adminRole = UserRole.ADMIN;
+
+  private readonly unfetterOpenId: string = Constance.UNFETTER_OPEN_ID;
+  private organizations: any[];
+
+  constructor(private adminService: AdminService) { }
+
+  ngOnInit() {
+    this.fetchUsers();
+    const getOrganizaitons$ = this.adminService.getOrganizations()
+      .map(RxjsHelpers.mapArrayAttributes)
+      .subscribe(
+        (organizations: any[]) => {
+          this.organizations = organizations;
+          console.log(this.organizations);
+        },
+        (err) => {
+          console.log(err);
+        },
+        () => {
+          getOrganizaitons$.unsubscribe();
+        }
+      );
+  }
+
+  public userAction(user, action: string) {
+    let tempUser;
+    switch (action) {
+      case 'PROMOTE_TO_ADMIN':
+        tempUser = { ...user, role: UserRole.ADMIN };
+        break;
+      case 'LOCK_USER':
+        tempUser = { ...user, approved: false, locked: true };
+        break;
+      default:
+        this.message = 'Error processing user action.';
+        return;
+    }
+    let processUserApproval$ = this.adminService
+      .changeUserStatus({ data: { attributes: tempUser } })
+      .subscribe(
+        (res) => {
+          this.fetchUsers();
+          this.message = `${tempUser.userName} (${tempUser.lastName}, ${tempUser.firstName}) has been ${tempUser.approved ? 'promoted to admin' : 'locked'}.`;
+        },
+        (err) => {
+          console.log(err);
+        },
+        () => {
+          processUserApproval$.unsubscribe();
+        }
+      );
+  }
+
+  public formatOrganizations(organizations: OrganizationIdentity[]): string {
+    return this.organizations && this.organizations.length ? organizations
+      .filter((organization: OrganizationIdentity) => organization.id !== this.unfetterOpenId)
+      .map((organization: OrganizationIdentity) => organization.id)
+      .map((orgId: string) => {
+        const matchingOrg = this.organizations.find((org) => org.id === orgId);
+        return matchingOrg ? matchingOrg.name : 'Unknown'; 
+      })
+      .join(', ') : '';
+  }
+
+  private fetchUsers(): void {
+    const getUsers$ = this.adminService.getCurrentUsers()
+      .subscribe(
+        (users: UserProfile[]) => {
+          this.users = users;
+        },
+        (err) => {
+          console.log(err);
+        },
+        () => {
+          getUsers$.unsubscribe();
+        }
+      );
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { WSMessageTypes } from './global/enums/ws-message-types.enum';
 import { environment } from '../environments/environment';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { Themes } from './global/enums/themes.enum';
+import { Constance } from './utils/constance';
 
 @Component({
   selector: 'unf-app',
@@ -62,7 +63,7 @@ export class AppComponent implements OnInit {
             lastName: 'User',
             organizations: [
               {
-                'id': 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                'id': Constance.UNFETTER_OPEN_ID,
                 'approved': true,
                 'role': 'STANDARD_USER'
               }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -5,6 +5,7 @@ import { tokenNotExpired } from 'angular2-jwt';
 import { GenericApi } from './genericapi.service';
 import { ConfigService } from './config.service';
 import { environment } from '../../../environments/environment';
+import { Constance } from '../../utils/constance';
 
 @Injectable()
 export class AuthService {
@@ -46,7 +47,7 @@ export class AuthService {
                 lastName: 'User',
                 organizations : [
                     {
-                        'id': 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                        'id': Constance.UNFETTER_OPEN_ID,
                         'approved': true,
                         'role': 'STANDARD_USER'
                     }
@@ -85,8 +86,12 @@ export class AuthService {
         return this.loggedIn() && (this.getUser().role === 'ADMIN' || this.getUser().role === 'ORG_LEADER');
     }
 
-    public pendingApproval() {
-        return tokenNotExpired('unfetterUiToken') && this.getUser() !== null && this.getUser().approved === false;
+    public pendingApproval(): boolean {
+        return tokenNotExpired('unfetterUiToken') && this.getUser() !== null && this.getUser().approved === false && this.getUser().locked === false;
+    }
+
+    public userLocked(): boolean {
+        return tokenNotExpired('unfetterUiToken') && this.getUser() !== null && this.getUser().locked === true;
     }
 
     public logOut() {

--- a/src/app/global/components/landing-page/landing-page.component.html
+++ b/src/app/global/components/landing-page/landing-page.component.html
@@ -7,6 +7,14 @@
       </div>
     </div>
   </div>
+  <div class="row mt-20" *ngIf="authService.userLocked()">
+    <div class="col-xs-6 col-xs-offset-3">
+      <div class="uf-well-warn">
+        <a (click)="authService.logOut()" class="close" data-dismiss="alert">&times;</a>
+        Your access to Unfetter has been revoked.
+      </div>
+    </div>
+  </div>
   <div class="row">
     <div id="logoWrapper" class="text-center col-xs-12">
       <img src="assets/icon/unfetter_black_lg.png" alt="Unfetter Logo" id="logoImg">

--- a/src/app/models/user/user-role.enum.ts
+++ b/src/app/models/user/user-role.enum.ts
@@ -4,5 +4,5 @@
  */
 export enum UserRole {
     STANDARD_USER = 'STANDARD_USER',
-    ADMIN = 'ADMIM'
+    ADMIN = 'ADMIN'
 }

--- a/src/app/users/settings/settings.component.ts
+++ b/src/app/users/settings/settings.component.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { UsersService } from '../../core/services/users.service';
 import { AuthService } from '../../core/services/auth.service';
+import { Constance } from '../../utils/constance';
 
 @Component({
     selector: 'settings',
@@ -16,7 +17,7 @@ export class SettingsComponent implements OnInit {
     public approvedOrganizations: any[];
     public unaffiliatedOrganizations: any[];
     public userId: string;
-    public unfetterOpenId: string = 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a';
+    public unfetterOpenId: string = Constance.UNFETTER_OPEN_ID;
 
     constructor(
         private usersService: UsersService,

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -490,5 +490,6 @@ export const Constance = {
     }
   },
   DIALOG_WIDTH_MEDIUM: '800px',
-  DIALOG_HEIGHT_TALL: 'calc(100vh - 50px)'
+  DIALOG_HEIGHT_TALL: 'calc(100vh - 50px)',
+  UNFETTER_OPEN_ID: 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a'
 };


### PR DESCRIPTION
fixes unfetter-discover/unfetter#741

Requirements:

- issue-741 on `unfetter-ui` and `unfetter-store`
- Two github accounts
- Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/91

Instructions:

- (user1) Go to admin > current users, promote user 2 to admin
- (user2) confirm admin works
- (user1) lock user2
- (user2) attempt to login and confirm you're locked

FYI, there is no unlock for user2, you should delete or unlock the user in mongo.

