### PR TITLE
Assessment result: better data refresh on routing and edit

### DIFF
--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -272,7 +272,7 @@ export class FullComponent implements OnInit, OnDestroy {
     // this.assessment = undefined;
     // this.assessmentTypes = undefined;
     // this.attackPatternId = undefined;
-    // this.store.dispatch(new CleanAssessmentResultData());
+    this.store.dispatch(new CleanAssessmentResultData());
     return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId, assessment.id]);
   }
 

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -12,7 +12,7 @@ import { Assessment } from '../../../models/assess/assessment';
 import { AssessService } from '../../services/assess.service';
 import { ConfirmationDialogComponent } from '../../../components/dialogs/confirmation/confirmation-dialog.component';
 import { LastModifiedAssessment } from '../../models/last-modified-assessment';
-import { LoadAssessmentResultData } from '../store/full-result.actions';
+import { LoadAssessmentResultData, CleanAssessmentResultData } from '../store/full-result.actions';
 import { MasterListDialogTableHeaders } from '../../../global/components/master-list-dialog/master-list-dialog.component';
 import { SummaryDataSource } from '../summary/summary.datasource';
 import { UserProfile } from '../../../models/user/user-profile';
@@ -65,6 +65,7 @@ export class FullComponent implements OnInit, OnDestroy {
    */
   public ngOnInit(): void {
     const idParamSub$ = this.route.params
+      .distinctUntilChanged()
       .subscribe((params) => {
         this.rollupId = params.rollupId || '';
         this.assessmentId = params.assessmentId || '';
@@ -166,6 +167,7 @@ export class FullComponent implements OnInit, OnDestroy {
       .filter((el) => el !== undefined)
       .filter((el) => !el.closed)
       .forEach((sub) => sub.unsubscribe());
+    this.store.dispatch(new CleanAssessmentResultData());
   }
 
   /**
@@ -265,12 +267,12 @@ export class FullComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.activePhase = undefined;
-    this.rollupId = undefined;
-    this.assessment = undefined;
-    this.assessmentTypes = undefined;
-    this.attackPatternId = undefined;
-    // TODO: clear the ngrx store
+    // this.activePhase = undefined;
+    // this.rollupId = undefined;
+    // this.assessment = undefined;
+    // this.assessmentTypes = undefined;
+    // this.attackPatternId = undefined;
+    // this.store.dispatch(new CleanAssessmentResultData());
     return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId, assessment.id]);
   }
 

--- a/src/app/assess/result/full/group/assessments-group.component.html
+++ b/src/app/assess/result/full/group/assessments-group.component.html
@@ -80,8 +80,6 @@
                             <mat-card-title>
                                 <img src="{{ getStixIcon(assessedObj.stix.type) }}" alt=""> {{ assessedObj.stix.name }}</mat-card-title>
                             <mat-card-content>
-                                <!--<span class="text-muted">Risk Accepted &bull;</span>&nbsp;{{ getRisk(assessedObj.stix.id)
-                                | percent:'2.1-1'}}-->
                                 <span class="text-muted">Risk Accepted &bull;</span>&nbsp;{{ assessedObj.risk | percent:'2.1-1'}}
                             </mat-card-content>
                             <mat-card-content>

--- a/src/app/assess/result/store/full-result.actions.ts
+++ b/src/app/assess/result/store/full-result.actions.ts
@@ -4,10 +4,13 @@ import { Assessment } from '../../../models/assess/assessment';
 import { AssessmentObject } from '../../../models/assess/assessment-object';
 import { Stix } from '../../../models/stix/stix';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+import { Relationship } from '../../../models';
 
 // For effects
 export const LOAD_ASSESSMENT_RESULT_DATA = '[Assess Result] LOAD_ASSESSMENT_RESULT_DATA';
 export const LOAD_GROUP_DATA = '[Assess Result Group] LOAD_GROUP_DATA';
+export const LOAD_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] LOAD_GROUP_CURRENT_ATTACK_PATTERN';
+export const LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] LOAD_ATTACK_PATTERN_RELATIONSHIPS';
 
 // For reducers
 export const SET_ASSESSMENTS = '[Assess Result] SET_ASSESSMENTS';
@@ -15,9 +18,10 @@ export const SET_GROUP_DATA = '[Assess Result Group] SET_GROUP_DATA';
 export const SET_GROUP_ASSESSMENT_OBJECTS = '[Assess Result Group] SET_GROUP_ASSESSMENT_OBJECTS_DATA';
 export const SET_GROUP_RISK_BY_ATTACK_PATTERN = '[Assess Result Group] SET_RISK_BY_ATTACK_PATTERN';
 export const SET_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] SET_GROUP_CURRENT_ATTACK_PATTERN';
-export const LOAD_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] LOAD_GROUP_CURRENT_ATTACK_PATTERN';
+export const SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS';
 export const PUSH_URL = '[Assess Result] PUSH_URL';
-
+export const DONE_PUSH_URL = '[Assess Result] DONE_PUSH_URL';
+export const CLEAN_ASSESSMENT_RESULT_DATA = '[Assess Result Group] CLEAN_ASSESSMENT_RESULT_DATA';
 export const FINISHED_LOADING = '[Assess Result] FINISHED_LOADING';
 
 export class SetAssessments implements Action {
@@ -58,8 +62,20 @@ export class SetGroupRiskByAttackPattern implements Action {
     constructor(public payload: RiskByAttack) { }
 }
 
+export class SetGroupAttackPatternRelationships implements Action {
+    public readonly type = SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS;
+
+    constructor(public payload: Relationship[]) { }
+}
+
 export class LoadGroupCurrentAttackPattern implements Action {
     public readonly type = LOAD_GROUP_CURRENT_ATTACK_PATTERN;
+    constructor(public payload: string) { }
+}
+
+export class LoadGroupAttackPatternRelationships implements Action {
+    public readonly type = LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS;
+
     constructor(public payload: string) { }
 }
 
@@ -80,19 +96,30 @@ export class PushUrl implements Action {
 }
 
 export class DonePushUrl implements Action {
-    public readonly type = PUSH_URL;
+    public readonly type = DONE_PUSH_URL;
+
+    constructor() { }
+}
+
+export class CleanAssessmentResultData {
+    public readonly type = CLEAN_ASSESSMENT_RESULT_DATA;
 
     constructor() { }
 }
 
 export type FullAssessmentResultActions =
+    CleanAssessmentResultData |
+    DonePushUrl |
+    FinishedLoading |
+    LoadAssessmentResultData |
+    LoadGroupData |
+    LoadGroupCurrentAttackPattern |
+    LoadGroupAttackPatternRelationships |
+    PushUrl |
     SetAssessments |
     SetGroupData |
     SetGroupAssessedObjects |
+    SetGroupAttackPatternRelationships |
     SetGroupRiskByAttackPattern |
-    SetGroupCurrentAttackPattern |
-    LoadAssessmentResultData |
-    LoadGroupData |
-    PushUrl |
-    FinishedLoading;
+    SetGroupCurrentAttackPattern;
 

--- a/src/app/assess/result/store/full-result.effects.ts
+++ b/src/app/assess/result/store/full-result.effects.ts
@@ -7,12 +7,17 @@ import { Observable } from 'rxjs/Observable';
 
 import { Assessment } from '../../../models/assess/assessment';
 import { AssessService } from '../../services/assess.service';
-import { LOAD_ASSESSMENT_RESULT_DATA, SetAssessments, FinishedLoading, SetGroupAssessedObjects, SetGroupRiskByAttackPattern, SetGroupData, LOAD_GROUP_DATA, LOAD_GROUP_CURRENT_ATTACK_PATTERN, SetGroupCurrentAttackPattern, PUSH_URL, DonePushUrl } from './full-result.actions';
+import {
+    LOAD_ASSESSMENT_RESULT_DATA, SetAssessments,
+    FinishedLoading, SetGroupAssessedObjects, SetGroupRiskByAttackPattern,
+    SetGroupData, LOAD_GROUP_DATA, LOAD_GROUP_CURRENT_ATTACK_PATTERN, SetGroupCurrentAttackPattern,
+    PUSH_URL, DonePushUrl, LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS, SetGroupAttackPatternRelationships
+} from './full-result.actions';
 import { fullAssessmentResultReducer } from './full-result.reducers';
 import { Constance } from '../../../utils/constance';
 import { Stix } from '../../../models/stix/stix';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
-// import { RiskByAttackPattern } from '../full/group/models/risk-by-attack-pattern';
+import { Relationship } from '../../../models';
 
 
 @Injectable()
@@ -55,6 +60,20 @@ export class FullResultEffects {
         })
         .map((data: Stix) => {
             return new SetGroupCurrentAttackPattern({ currentAttackPattern: data });
+        });
+
+    @Effect()
+    public loadGroupAttackPatternRelationships = this.actions$
+        .ofType(LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS)
+        .pluck('payload')
+        .switchMap((attackPatternId: string) => {
+            return this.assessService.getAttackPatternRelationships(attackPatternId);
+        })
+        .mergeMap((relationships: Relationship[]) => {
+            return [
+                new SetGroupAttackPatternRelationships(relationships),
+                new FinishedLoading(true),
+            ];
         });
 
     @Effect()

--- a/src/app/assess/result/store/full-result.reducers.ts
+++ b/src/app/assess/result/store/full-result.reducers.ts
@@ -6,6 +6,7 @@ import { DisplayedAssessmentObject } from '../full/group/models/displayed-assess
 import { FullAssessmentResultActions, LOAD_ASSESSMENT_RESULT_DATA } from './full-result.actions';
 import { Stix } from '../../../models/stix/stix';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+import { Relationship } from '../../../models';
 
 export interface FullAssessmentResultState {
     fullAssessment: Assessment;
@@ -25,6 +26,7 @@ export interface FullAssessmentGroupState {
     attackPatternsByPhase: any[];
     addAssessedObject: boolean;
     addAssessedType: string;
+    attackPatternRelationships: Relationship[];
 }
 
 const genGroupState = (state?: Partial<FullAssessmentGroupState>) => {
@@ -43,6 +45,7 @@ const genGroupState = (state?: Partial<FullAssessmentGroupState>) => {
         attackPatternsByPhase: [],
         addAssessedObject: false,
         addAssessedType: '',
+        attackPatternRelationships: [],
     };
 
     if (state) {
@@ -68,30 +71,51 @@ const initialState: FullAssessmentResultState = genState();
 
 export function fullAssessmentResultReducer(state = initialState, action: FullAssessmentResultActions): FullAssessmentResultState {
     switch (action.type) {
+        case fullAssessmentResultActions.CLEAN_ASSESSMENT_RESULT_DATA:
+            return genState();
         case LOAD_ASSESSMENT_RESULT_DATA:
-            return genState({
+            return {
                 ...state,
-            });
+            };
         case fullAssessmentResultActions.SET_ASSESSMENTS:
-            return genState({
+            return {
                 ...state,
                 assessmentTypes: [...action.payload],
-            });
+            };
         case fullAssessmentResultActions.FINISHED_LOADING:
-            return genState({
+            return {
                 ...state,
                 finishedLoading: action.payload
-            });
+            };
         case fullAssessmentResultActions.SET_GROUP_DATA:
-            return genState({
+            return {
                 ...state,
-                group: genGroupState({ ...action.payload, finishedLoadingGroupData: true })
-            });
+                group: {
+                    ...state.group,
+                    ...action.payload,
+                    finishedLoadingGroupData: true,
+                },
+            };
         case fullAssessmentResultActions.SET_GROUP_CURRENT_ATTACK_PATTERN:
-            return genState({
+            return {
                 ...state,
-                group: genGroupState({ ...action.payload })
-            });
+                group: {
+                    ...state.group,
+                    ...action.payload,
+                }
+            };
+        case fullAssessmentResultActions.SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS:
+            return {
+                ...state,
+                group: {
+                    ...state.group,
+                    attackPatternRelationships: [...action.payload],
+                }
+            };
+        case fullAssessmentResultActions.DONE_PUSH_URL:
+            return {
+                ...state,
+            }
         default:
             return state;
     }

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -28,6 +28,7 @@ import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 import { LoadAssessmentRiskByAttackPatternData, LoadSingleAssessmentRiskByAttackPatternData } from '../store/riskbyattackpattern.actions';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
+import { CleanAssessmentResultData } from '../store/full-result.actions';
 
 @Component({
   selector: 'summary',
@@ -259,6 +260,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
       .filter((el) => el !== undefined)
       .filter((el) => !el.closed)
       .forEach((sub) => sub.unsubscribe());
+    this.store.dispatch(new CleanAssessmentResultData());
   }
 
   /**
@@ -322,16 +324,16 @@ export class SummaryComponent implements OnInit, OnDestroy {
 
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, { data: { attributes: assessment } });
     const dialogSub$ = dialogRef.afterClosed()
-    .subscribe(
-      (result) => {
-        const isBool = typeof result === 'boolean';
-        const isString = typeof result === 'string';
-        if (!result ||
-          (isBool && result !== true) ||
-          (isString && result !== 'true')) {
+      .subscribe(
+        (result) => {
+          const isBool = typeof result === 'boolean';
+          const isString = typeof result === 'string';
+          if (!result ||
+            (isBool && result !== true) ||
+            (isString && result !== 'true')) {
             return;
           }
-          
+
           const isCurrentlyViewed = assessment.rollupId === this.rollupId ? true : false;
           const sub$ = this.assessService
             .deleteByRollupId(assessment.rollupId)
@@ -342,7 +344,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
                 if (sub$) {
                   sub$.unsubscribe();
                 }
-                
+
                 // we deleted the current assessment
                 if (isCurrentlyViewed) {
                   return this.router.navigate([Constance.X_UNFETTER_ASSESSMENT_NAVIGATE_URL]);
@@ -363,6 +365,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.store.dispatch(new CleanAssessmentResultData());
     return this.router.navigate([this.masterListOptions.displayRoute, assessment.rollupId, assessment.id]);
   }
 

--- a/src/app/assess/result/summary/summary.datasource.ts
+++ b/src/app/assess/result/summary/summary.datasource.ts
@@ -33,7 +33,7 @@ export class SummaryDataSource extends DataSource<Partial<LastModifiedAssessment
             .switchMap(() => {
                 const val = this.filterChange.getValue();
                 const filterVal = val.trim().toLowerCase() || '';
-                const products$ = this.fetchAssessments().let(this.dedupByRollupId);
+                const products$ = this.fetchAssessments(); // .let(this.dedupByRollupId);
                 if (!filterVal || filterVal.length === 0) {
                     return products$;
                 }


### PR DESCRIPTION
supports 
unfetter-discover/unfetter#751 
unfetter-discover/unfetter#733 
unfetter-discover/unfetter#734

#To Test
* route to assessments 2.0
* create 2 or more assessments
* visit an assessment, results page (summary might still be broken)
  * verify route and data refresh across assessments by clicking an item in the master list
  * verify risk update by click the pencil in a indicator card (lower left), change the value, see the data update in the card (need to propogate across the page still)
* `npm run test`