### PR TITLE
Issue 766/newlines

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.2-alpine
+FROM node:9.5-alpine
 
 LABEL MAINTAINER="UNFETTER"
 LABEL Description="UNFETTER user interface, Angular app"


### PR DESCRIPTION
git config for windows users
also, ++ node version

supports unfetter-discover/unfetter#766
supports unfetter-discover/unfetter#765

coupled these together because you have to clean the docker images to test them both

See PRs
https://github.com/unfetter-discover/unfetter/pull/769
https://github.com/unfetter-discover/unfetter-store/pull/95

## To Test
* Pull the PR for all three repos _in a clean directory_ to test the newline git config
* `docker-clean` i use, `alias docker-clean='docker stop $(docker ps -qa) && docker rm -f $(docker ps -qa); docker rmi -f $(docker images -q)'`
* `cd unfetter && docker-compose -f docker-compose.development.yml up`
* verify the app works
* Note we really need a windows users to test this