### PR TITLE
security tests for header-navigation bar

### DIFF
--- a/src/app/admin/admin.service.spec.ts
+++ b/src/app/admin/admin.service.spec.ts
@@ -1,0 +1,255 @@
+import { TestBed, inject, fakeAsync } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+
+import { AdminService } from './admin.service';
+import { GenericApi } from '../core/services/genericapi.service';
+import { UserProfile } from '../models/user/user-profile';
+
+describe('Admin Service', () => {
+
+    let subscriptions: Subscription[];
+    beforeEach(() => {
+        subscriptions = [];
+
+        TestBed.configureTestingModule({
+            imports: [
+                HttpClientModule,
+                HttpClientTestingModule
+            ],
+            providers: [AdminService, GenericApi]
+        });
+    });
+
+    afterEach(() => {
+        if (subscriptions) {
+            subscriptions
+                .filter((sub) => sub !== undefined)
+                .filter((sub) => !sub.closed)
+                .forEach((sub) => sub.unsubscribe());
+        }
+    });
+
+    it('should be created', inject([AdminService], (service) => {
+        expect(service).toBeTruthy();
+    }));
+
+    it('should get users pending approval',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        expect(api).toBeDefined();
+        const userProfile = {
+            userName: 'tester',
+            firstName: 'Teresa',
+            lastName: 'Stern',
+        } as UserProfile;
+        const spy = spyOn(api, 'getAs').and.returnValue(Observable.of([{attributes: userProfile}]));
+        let getUsers$ = service.getUsersPendingApproval()
+            .subscribe(
+                (users) => {
+                    expect(users).toBeDefined();
+                    expect(users.length).toEqual(1);
+                    expect(users[0].userName).toEqual(userProfile.userName);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getUsers$);
+    })));
+
+    it('should get current users',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const userProfile = {
+            userName: 'tester',
+            firstName: 'Teresa',
+            lastName: 'Stern',
+        } as UserProfile;
+        const spy = spyOn(api, 'getAs').and.returnValue(Observable.of([{attributes: userProfile}]));
+        let getUsers$ = service.getCurrentUsers()
+            .subscribe(
+                (users) => {
+                    expect(users).toBeDefined();
+                    expect(users.length).toEqual(1);
+                    expect(users[0].userName).toEqual(userProfile.userName);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getUsers$);
+    })));
+
+    it('should get org leader applicants',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const userProfile = {
+            userName: 'tester',
+            firstName: 'Teresa',
+            lastName: 'Stern',
+        } as UserProfile;
+        const spy = spyOn(api, 'get').and.returnValue(Observable.of([userProfile]));
+        let getUsers$ = service.getOrgLeaderApplicants()
+            .subscribe(
+                (users) => {
+                    expect(users).toBeDefined();
+                    expect(users.length).toEqual(1);
+                    expect(users[0].userName).toEqual(userProfile.userName);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getUsers$);
+    })));
+
+    it('should get website visits',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const spy = spyOn(api, 'get').and.returnValue(Observable.of([3]));
+        let getVisits$ = service.getWebsiteVisits()
+            .subscribe(
+                (visit) => {
+                    expect(visit).toBeDefined();
+                    expect(visit.length).toEqual(1);
+                    expect(visit[0]).toEqual(3);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getVisits$);
+    })));
+
+    it('should get a website visit graph',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const visits = [{day: '1', visits: 6}, {day: '2', visits: 11}, {day: '3', visits: 8}];
+        const spies = spyOn(api, 'get').and.returnValue(Observable.of(visits));
+        let getGraph$ = service.getWebsiteVisitsGraph(3)
+            .subscribe(
+                (graph) => {
+                    expect(graph).toBeDefined();
+                    expect(graph.length).toEqual(3);
+                    expect(graph[1].visits).toEqual(11);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getGraph$);
+    })));
+
+    it('should change user status',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const spies = spyOn(api, 'post').and.returnValue(Observable.of(true));
+        let editUser$ = service.changeUserStatus({})
+            .subscribe(
+                (result) => expect(result).toBeTruthy(),
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(editUser$);
+    })));
+
+    it('should get configuration',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const configs = {
+            server: 'server.xyz.com',
+            items: 3,
+            updated: true,
+        };
+
+        let response: Observable<any> = Observable.of(configs);
+        const spy = spyOn(api, 'get').and.returnValue(response);
+
+        let getConfigs$ = service.getConfig()
+            .subscribe(
+                (result) => {
+                    expect(result).toBeDefined();
+                    expect(result.updated).toEqual(configs.updated);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getConfigs$);
+
+        response = Observable.of(configs.server);
+        spy.and.returnValue(response);
+        let getConfig$ = service.getSingleConfig('server')
+            .subscribe(
+                (result) => {
+                    expect(result).toEqual(configs.server);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getConfig$);
+
+        const newProperty = { date: Date.now() };
+        response = Observable.of(Object.assign({}, configs, newProperty));
+        spyOn(api, 'post').and.returnValue(response);
+        let addConfig$ = service.addConfig(newProperty)
+            .subscribe(
+                (result) => {
+                    expect(result).toBeDefined();
+                    expect(result.date).toEqual(newProperty.date);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getConfig$);
+
+        delete configs.items;
+        response = Observable.of(configs);
+        spyOn(api, 'delete').and.returnValue(response);
+        let deleteConfig$ = service.deleteSingleConfig('items')
+            .subscribe(
+                (result) => {
+                    expect(result).toBeDefined();
+                    expect(result.items).toBeUndefined();
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(deleteConfig$);
+    })));
+
+    it('should process changed data',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const spies = spyOn(api, 'patch').and.returnValue(Observable.of(true));
+        let processChange$ = service.processChangedData({}, '')
+            .subscribe(
+                (result) => expect(result).toBeTruthy(),
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(processChange$);
+    })));
+
+    it('should get organizations',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const orgs = [{name: 'org1'}, {name: 'org2'}, {name: 'org3'}];
+        const spies = spyOn(api, 'get').and.returnValue(Observable.of(orgs));
+        let getOrgs$ = service.getOrganizations()
+            .subscribe(
+                (result) => {
+                    expect(result).toBeDefined();
+                    expect(result.length).toBe(3);
+                },
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(getOrgs$);
+    })));
+
+    it('should process org applicants',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const userProfile = {
+            userName: 'tester',
+            firstName: 'Teresa',
+            lastName: 'Stern',
+        } as UserProfile;
+        const spies = spyOn(api, 'post').and.returnValue(Observable.of(true));
+        let processChange$ = service.processOrgApplicant(userProfile, 'theOrg')
+            .subscribe(
+                (result) => expect(result).toBeTruthy(),
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(processChange$);
+    })));
+
+    it('should get heartbeat',
+            fakeAsync(inject([AdminService, GenericApi], (service: AdminService, api: GenericApi) => {
+        const spies = spyOn(api, 'get').and.returnValue(Observable.of(true));
+        let processChange$ = service.getHeartbeat()
+            .subscribe(
+                (result) => expect(result).toBeTruthy(),
+                (err) => console.log(`error`, err),
+                () => {});
+        subscriptions.push(processChange$);
+    })));
+
+});

--- a/src/app/admin/heartbeat/heartbeat.component.spec.ts
+++ b/src/app/admin/heartbeat/heartbeat.component.spec.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs/Observable';
 import { HeartbeatStatus } from '../../global/models/heartbeat';
 import { CapitalizePipe } from '../../global/pipes/capitalize.pipe';
 import { LoadingSpinnerComponent } from '../../global/components/loading-spinner/loading-spinner.component';
+import { Constance } from '../../utils/constance';
 
 describe('HeartbeatComponent', () => {
     let component: HeartbeatComponent;
@@ -58,4 +59,21 @@ describe('HeartbeatComponent', () => {
         const services = component.heartbeats;
         expect(services.length > 0).toBeTruthy();
     });
+
+    it(`should handle all heartbeat status values`, () => {
+        const statuses = [{
+            value: HeartbeatStatus.DOWN,
+            color: Constance.COLORS.red
+        }, {
+            value: HeartbeatStatus.RUNNING,
+            color: Constance.COLORS.green
+        }, {
+            value: HeartbeatStatus.UNKNOWN,
+            color: Constance.COLORS.yellow
+        }];
+        statuses.forEach(status => {
+            expect(component.getStatusColor(status.value)).toBe(status.color);
+        });
+    });
+
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,57 +1,162 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { inject, async, TestBed,  ComponentFixture } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { Router, NavigationEnd, Routes } from '@angular/router';
+import { inject, async, TestBed, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Observable } from 'rxjs/Observable';
+import { StoreModule } from '@ngrx/store';
 
 // Load the implementations that should be tested
-import { AppComponent } from './app.component';
+import { AppModule } from './app.module';
 import { AppState } from './app.service';
+import { AppComponent } from './app.component';
 import { AuthService } from './core/services/auth.service';
 import { ConfigService } from './core/services/config.service';
 import { GenericApi } from './core/services/genericapi.service';
 import { WebAnalyticsService } from './core/services/web-analytics.service';
-import { AppModule } from './app.module';
-import { StoreModule } from '@ngrx/store';
+import { environment } from '../environments/environment';
 import { reducers } from './root-store/app.reducers';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Themes } from './global/enums/themes.enum';
 
 describe(`App`, () => {
-  let comp: AppComponent;
-  let fixture: ComponentFixture<AppComponent>;
 
-  // async beforeEach
-  beforeEach(async(() => {
-    const services = [
-      AppState, 
-      AuthService, 
-      GenericApi,
-      ConfigService,
-      WebAnalyticsService,
+    let comp: AppComponent;
+    let fixture: ComponentFixture<AppComponent>;
+    let location: Location;
+    let router: Router;
+
+    let loggedIn: boolean;
+    const mockAuthService = {
+        loggedIn() {
+            return loggedIn;
+        },
+        getUser() {
+            return {
+                _id: '1234',
+                userName: 'Demo-User',
+                firstName: 'Demo',
+                lastName: 'User',
+                organizations : [{
+                    'id': 'identity--e240b257-5c42-402e-a0e8-7b81ecc1c09a',
+                    'approved': true,
+                    'role': 'STANDARD_USER'
+                }],
+            };
+        },
+        getToken() {
+            return 'token';
+        }
+    };
+
+    const routes: Routes = [
+        { path: '', component: AppComponent },
+        { path: 'home', component: AppComponent },
+        { path: 'partners', component: AppComponent },
+        { path: 'intrusion-set-dashboard', component: AppComponent },
+        { path: 'assessments', component: AppComponent },
+        { path: 'assess', component: AppComponent },
+        { path: 'threat-dashboard', component: AppComponent },
+        { path: 'users', component: AppComponent },
+        { path: 'indicator-sharing', component: AppComponent },
+        { path: 'organizations', component: AppComponent },
+        { path: 'admin', component: AppComponent },
+        { path: '**', component: AppComponent },
     ];
 
-    TestBed.configureTestingModule({
-      imports: [
-        RouterTestingModule, 
-        HttpClientTestingModule,
-        StoreModule.forRoot(reducers)
-      ],
-      declarations: [AppComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [...services]
-    })
-    .compileComponents(); // compile template and css
-  }));
+    // async beforeEach
+    beforeEach(async(() => {
+        const services = [
+            AppState,
+            { provide: AuthService, useValue: mockAuthService },
+            GenericApi,
+            ConfigService,
+            WebAnalyticsService,
+        ];
 
-  // synchronous beforeEach
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AppComponent);
-    comp    = fixture.componentInstance;
+        TestBed.configureTestingModule({
+            imports: [
+                RouterTestingModule.withRoutes(routes),
+                HttpClientTestingModule,
+                StoreModule.forRoot(reducers)
+            ],
+            declarations: [AppComponent],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [...services]
+        })
+        .compileComponents(); // compile template and css
 
-    fixture.detectChanges(); // trigger initial data binding
-  });
+        router = TestBed.get(Router);
+        location = TestBed.get(Location);
+    }));
 
-  it(`should be readly initialized`, () => {
-    expect(fixture).toBeDefined();
-    expect(comp).toBeDefined();
-  });
+    it(`should be readly initialized`, () => {
+        loggedIn = true;
+        fixture = TestBed.createComponent(AppComponent);
+        comp = fixture.componentInstance;
+        fixture.detectChanges();
+        expect(fixture).toBeDefined();
+        expect(comp).toBeDefined();
+    });
+
+    it(`should handle initialization with different logged-in states and run modes`, () => {
+        const logins = [true, false];
+        const runmodes = ['DEMO', 'UAC', undefined];
+        logins.forEach(login => {
+            loggedIn = login;
+            runmodes.forEach(runmode => {
+                environment.runMode = runmode;
+                fixture = TestBed.createComponent(AppComponent);
+                comp = fixture.componentInstance;
+                fixture.detectChanges();
+                expect(fixture).toBeDefined();
+                expect(comp).toBeDefined();
+                expect(comp.authService.loggedIn()).toEqual(login,
+                        `user should ${login ? '' : 'not '}have been logged in`);
+                expect(comp.runMode).toBe(runmode, `run mode was supposed to be ${runmode}`);
+            });
+        });
+    });
+
+    it(`should handle various router outlets`, fakeAsync(() => {
+        const routeChecks = [
+            { path: '', title: undefined, theme: Themes.DEFAULT },
+            { path: 'home', title: 'home', theme: Themes.DEFAULT },
+            { path: 'partners', title: 'partners', theme: Themes.DEFAULT },
+            { path: 'intrusion-set-dashboard', title: 'intrusion-set-dashboard', theme: Themes.DEFAULT },
+            { path: 'assessments', title: 'assessments', theme: Themes.ASSESSMENTS },
+            { path: 'assess', title: 'assessments', theme: Themes.ASSESSMENTS },
+            { path: 'threat-dashboard', title: 'threat-dashboard', theme: Themes.THREAT_DASHBOARD },
+            { path: 'users', title: 'users', theme: Themes.DEFAULT },
+            { path: 'indicator-sharing', title: 'Analytic Hub', theme: Themes.ANALYTIC_HUB },
+            { path: 'organizations', title: 'organizations', theme: Themes.DEFAULT },
+            { path: 'admin', title: 'admin', theme: Themes.DEFAULT },
+            { path: 'non-existent-page', title: 'non-existent-page', theme: Themes.DEFAULT },
+        ];
+
+        loggedIn = true;
+        fixture = TestBed.createComponent(AppComponent);
+        comp = fixture.componentInstance;
+        router.initialNavigation();
+
+        routeChecks.forEach((check, index, checks) => {
+            router.navigate([check.path]).then(
+                () => {
+                    comp.ngOnInit();
+                    expect(comp.theme).toBe(check.theme);
+                    expect(comp.title).toBe(check.title);
+                }
+            );
+            tick();
+        });
+    }));
+
+    it(`stub AppState class`, () => {
+        let appState = fixture.debugElement.injector.get(AppState);
+        appState.set('user', 'pat');
+        expect(appState.get('user')).toEqual('pat');
+        expect(appState.get()).toEqual({'user': 'pat'});
+        expect(function() {appState.state = {'user': 'chris'}}).toThrowError();
+    });
 
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -128,7 +128,7 @@ describe(`App`, () => {
             { path: 'assess', title: 'assessments 2.0 (beta)', theme: Themes.ASSESSMENTS },
             { path: 'threat-dashboard', title: 'threat-dashboard', theme: Themes.THREAT_DASHBOARD },
             { path: 'users', title: 'users', theme: Themes.DEFAULT },
-            { path: 'indicator-sharing', title: 'Analytic Hub', theme: Themes.ANALYTIC_HUB },
+            { path: 'indicator-sharing', title: 'Analytic Exchange', theme: Themes.ANALYTIC_HUB },
             { path: 'organizations', title: 'organizations', theme: Themes.DEFAULT },
             { path: 'admin', title: 'admin', theme: Themes.DEFAULT },
             { path: 'non-existent-page', title: 'non-existent-page', theme: Themes.DEFAULT },

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -125,7 +125,7 @@ describe(`App`, () => {
             { path: 'partners', title: 'partners', theme: Themes.DEFAULT },
             { path: 'intrusion-set-dashboard', title: 'intrusion-set-dashboard', theme: Themes.DEFAULT },
             { path: 'assessments', title: 'assessments', theme: Themes.ASSESSMENTS },
-            { path: 'assess', title: 'assessments', theme: Themes.ASSESSMENTS },
+            { path: 'assess', title: 'assessments 2.0 (beta)', theme: Themes.ASSESSMENTS },
             { path: 'threat-dashboard', title: 'threat-dashboard', theme: Themes.THREAT_DASHBOARD },
             { path: 'users', title: 'users', theme: Themes.DEFAULT },
             { path: 'indicator-sharing', title: 'Analytic Hub', theme: Themes.ANALYTIC_HUB },

--- a/src/app/global/components/header-navigation/header-navigation.component.spec.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.spec.ts
@@ -1,55 +1,266 @@
-// import { NO_ERRORS_SCHEMA } from '@angular/core';
-// import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-// import { RouterTestingModule } from '@angular/router/testing';
-// import { MatIconModule, MatButtonModule, MatToolbarModule } from '@angular/material';
-// import { StoreModule } from '@ngrx/store';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StoreModule, Store } from '@ngrx/store';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { Observable } from 'rxjs/Observable';
 
-// import { HeaderNavigationComponent } from './header-navigation.component';
-// import * as fromRoot from '../../../root-store/app.reducers';
-// import { AuthService } from '../../../core/services/auth.service';
-// import { CapitalizePipe } from '../../pipes/capitalize.pipe';
-// import { mockAuthService } from '../../../testing/mock-auth-service';
-// import { TimeAgoPipe } from '../../pipes/time-ago.pipe';
-// import { NotificationWindowComponent } from '../notification-window/notification-window.component';
-// import { HttpClientTestingModule } from '@angular/common/http/testing';
-// import { FieldSortPipe } from '../../pipes/field-sort.pipe';
+import { HeaderNavigationComponent } from './header-navigation.component';
+import { NotificationWindowComponent } from '../notification-window/notification-window.component';
+import { ConfigService } from '../../../core/services/config.service';
+import { AuthService } from '../../../core/services/auth.service';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import * as fromApp from '../../../root-store/app.reducers';
+import * as userActions from '../../../root-store/users/user.actions';
+import { environment } from '../../../../environments/environment';
+import { CapitalizePipe } from '../../pipes/capitalize.pipe';
+import { FieldSortPipe } from '../../pipes/field-sort.pipe';
+import { TimeAgoPipe } from '../../pipes/time-ago.pipe';
 
-// describe('HeaderNavigationComponent', () => {
-//     let component: HeaderNavigationComponent;
-//     let fixture: ComponentFixture<HeaderNavigationComponent>;
+describe('HeaderNavigationComponent', () => {
 
-//     beforeEach(async(() => {
-//         TestBed.configureTestingModule({
-//             declarations: [
-//                 HeaderNavigationComponent,
-//                 CapitalizePipe,
-//                 TimeAgoPipe,
-//                 FieldSortPipe,
-//                 NotificationWindowComponent
-//             ],
-//             imports: [
-//                 MatIconModule,
-//                 MatButtonModule,
-//                 MatToolbarModule,
-//                 RouterTestingModule,
-//                 HttpClientTestingModule,
-//                 StoreModule.forRoot(fromRoot.reducers),
-//             ],
-//             providers: [
-//                 { provide: AuthService, userValue: mockAuthService }
-//             ],
-//             schemas: [ NO_ERRORS_SCHEMA ]
-//         })
-//         .compileComponents();
-//     }));
+    let component: HeaderNavigationComponent;
+    let fixture: ComponentFixture<HeaderNavigationComponent>;
 
-//     beforeEach(() => {
-//         fixture = TestBed.createComponent(HeaderNavigationComponent);
-//         component = fixture.componentInstance;
-//         fixture.detectChanges();
-//     });
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+                declarations: [
+                    HeaderNavigationComponent,
+                    NotificationWindowComponent,
+                    CapitalizePipe,
+                    TimeAgoPipe,
+                    FieldSortPipe,
+                ],
+                imports: [
+                    RouterTestingModule,
+                    HttpClientTestingModule,
+                    BrowserAnimationsModule,
+                    StoreModule.forRoot(fromApp.reducers),
+                ],
+                providers: [
+                    // { provide: AuthService, useValue: MockAuthService },
+                    AuthService,
+                    GenericApi,
+                    ConfigService,
+                ],
+                schemas: [ NO_ERRORS_SCHEMA ]
+            })
+            .compileComponents();
+    }));
 
-//     it('should create', () => {
-//         expect(component).toBeTruthy();
-//     });
-// });
+    beforeEach(() => {
+        environment.runMode = 'UAC';
+        fixture = TestBed.createComponent(HeaderNavigationComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('mat-toolbar')).nativeElement.className).not.toContain('demoMode');
+    });
+
+    it('displays the proper logo and title', () => {
+        const logoEl = 'img.logo';
+        const titleEl = 'span#titleWrapper span#titleText';
+        const tests = [
+            {title: '', logo: /.*logo\-default\.svg/, text: undefined},
+            {title: 'assessments', logo: /.*logo\-assessments\.svg/, text: /assessments/i},
+            {title: 'assessments 2.0 (beta)', logo: /.*logo\-assessments\.svg/, text: /assessments 2\.0 \(beta\)/i},
+            {title: 'threat-dashboard', logo: /.*logo\-threat\-dashboard\.svg/, text: /threat dashboard/i},
+            {title: 'Analytic Exchange', logo: /.*logo\-indicator\-sharing\.svg/, text: /analytic exchange/i},
+        ];
+        tests.forEach(test => {
+            const titledFixture = TestBed.createComponent(HeaderNavigationComponent);
+            const titledComponent = titledFixture.componentInstance;
+            titledComponent.title = test.title;
+            titledFixture.detectChanges();
+            expect(titledFixture.debugElement.query(By.css(logoEl)).nativeElement.src).toMatch(test.logo);
+            if (test.title) {
+                expect(titledFixture.debugElement.query(By.css(titleEl)).nativeElement.textContent).toMatch(test.text);
+            } else {
+                expect(titledFixture.debugElement.query(By.css(titleEl))).toBeNull();
+            }
+        });
+
+        {
+            expect(component.topPx).toEqual('0px');
+
+            environment.showBanner = true;
+            const titledFixture = TestBed.createComponent(HeaderNavigationComponent);
+            const titledComponent = titledFixture.componentInstance;
+            titledFixture.detectChanges();
+            expect(titledComponent.topPx).toEqual('17px');
+        }
+    });
+
+    it('can run in demo mode', () => {
+        environment.runMode = 'DEMO';
+        const demoFixture = TestBed.createComponent(HeaderNavigationComponent);
+        const demoComponent = demoFixture.componentInstance;
+        demoFixture.detectChanges();
+        expect(demoComponent).toBeTruthy();
+        expect(demoFixture.debugElement.query(By.css('mat-toolbar')).nativeElement.className).toContain('demoMode');
+        expect(demoFixture.debugElement.query(By.css('a[href*="api/auth"][href*="-login"]'))).toBeNull();
+        expect(demoFixture.debugElement.query(By.css('notification-window'))).toBeNull();
+        expect(demoFixture.debugElement.query(By.css('#appMenuWrapper .navButton'))).toBeNull();
+        expect(demoFixture.debugElement.query(By.css('#accountWrapper'))).toBeNull();
+    });
+
+    it('displays the sign in button, when not logged in', () => {
+        const authService = fixture.debugElement.injector.get(AuthService);
+        spyOn(authService, 'loggedIn').and.returnValue(false);
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('a[href*="api/auth"][href*="-login"]')).nativeElement).toBeDefined();
+        expect(fixture.debugElement.query(By.css('notification-window'))).toBeNull();
+        expect(fixture.debugElement.query(By.css('#accountWrapper'))).toBeNull();
+    });
+
+    describe('with a logged in user', () => {
+
+        let store: Store<fromApp.AppState>;
+        let authService: AuthService;
+
+        const demoUser = {
+            _id: '123',
+            userName: 'Demo-User',
+            firstName: 'Demo',
+            lastName: 'User',
+            role: 'STANDARD_USER',
+            github: {id: 1, userName: 'demo', avatar_url: 'assets/icon/stix-icons/svg/identity-b.svg'},
+            approved: true
+        };
+        const adminUser = {
+            _id: '456',
+            userName: 'Admin-User',
+            firstName: 'Admin',
+            lastName: 'User',
+            role: 'ADMIN',
+            github: {id: 2, userName: 'admin', avatar_url: 'assets/icon/stix-icons/svg/identity-b.svg'},
+            approved: true
+        };
+        const orgUser = {
+            _id: '789',
+            userName: 'Org-Leader',
+            firstName: 'Org',
+            lastName: 'Chief',
+            organizations : [{ 'approved': true, 'role': 'STANDARD_USER' }],
+            role: 'ORG_LEADER',
+            github: {id: 3, userName: 'chief', avatar_url: 'assets/icon/stix-icons/svg/identity-b.svg'},
+            approved: true
+        };
+    
+        beforeEach(() => {
+            store = fixture.debugElement.injector.get(Store) as Store<fromApp.AppState>;
+            store.dispatch({type: userActions.LOGIN_USER, payload: { token: 'Bearer 123', userData: demoUser }});
+
+            authService = fixture.debugElement.injector.get(AuthService);
+            spyOn(authService, 'loggedIn').and.returnValue(true);
+
+            fixture.detectChanges();
+        });
+
+        it('does not display the sign in button', async(() => {
+            spyOn(authService, 'getUser').and.returnValue(demoUser);
+            expect(store).toBeDefined();
+            expect(fixture.debugElement.query(By.css('a[href*="api/auth"][href*="-login"]'))).toBeNull();
+            expect(fixture.debugElement.query(By.css('notification-window')).nativeElement).toBeDefined();
+        }));
+
+        it('displays the account dropdown when clicked', () => {
+            spyOn(authService, 'getUser').and.returnValue(demoUser);
+            expect(component.showAccountMenu).toBeFalsy();
+            expect(fixture.debugElement.query(By.css('#accountWrapper')).nativeElement).toBeDefined();
+            expect(fixture.debugElement.query(By.css('#accountWrapper img#avatar')).nativeElement.src)
+                .toMatch(new RegExp(`${demoUser.github.avatar_url}$`));
+            expect(fixture.debugElement.query(By.css('#accountMenuWindow'))).toBeNull();
+            fixture.debugElement.query(By.css('#accountWrapper div.cursor-pointer'))
+                .triggerEventHandler('click', null);
+            fixture.detectChanges();
+            expect(component.showAccountMenu).toBeTruthy();
+            expect(fixture.debugElement.query(By.css('#accountMenuWindow div strong')).nativeElement.textContent)
+                .toContain(demoUser.userName);
+
+            // let's also prove clicking outside the dropdown closes it
+            component.clickedOutside(new MouseEvent('click', {
+                relatedTarget: fixture.debugElement.query(By.css('.flex1')).nativeElement
+            }));
+            fixture.detectChanges();
+            expect(component.showAccountMenu).toBeFalsy();
+
+            // test the logout button
+            fixture.debugElement.query(By.css('#accountWrapper div.cursor-pointer'))
+                .triggerEventHandler('click', null);
+            fixture.detectChanges();
+            const spy = spyOn(store, 'dispatch').and.returnValue(false);
+            fixture.debugElement.query(By.css('#accountWrapper .accountMenuLine:last-child a'))
+                .triggerEventHandler('click', null);
+            fixture.detectChanges();
+            expect(store.dispatch).toHaveBeenCalledWith(new userActions.LogoutUser());
+        });
+
+        it('as regular user, the app menu displays the correct icons', () => {
+            spyOn(authService, 'getUser').and.returnValue(demoUser);
+            expect(component.showAppMenu).toBeFalsy();
+            expect(fixture.debugElement.query(By.css('#appMenuWindow'))).toBeNull();
+            fixture.debugElement.query(By.css('#appMenuWrapper .navButton')).triggerEventHandler('click', null);
+            fixture.detectChanges();
+            expect(component.showAppMenu).toBeTruthy();
+            expect(fixture.debugElement.query(By.css('#appMenuWindow')).nativeElement).toBeDefined();
+            const links = fixture.debugElement.queryAllNodes(By.css('.appLinkWrapper a .appItemText'))
+                .map(node => node.nativeNode.innerText);
+            expect(links).not.toContain('Organizations');
+            expect(links).not.toContain('Admin');
+
+            // let's also prove clicking outside the dropdown closes it
+            component.clickedOutside(new MouseEvent('click', {
+                relatedTarget: fixture.debugElement.query(By.css('.flex1')).nativeElement
+            }));
+            fixture.detectChanges();
+            expect(component.showAppMenu).toBeFalsy();
+        });
+
+        it('as Org Leader, the app menu still displays the correct icons', () => {
+            spyOn(authService, 'getUser').and.returnValue(orgUser);
+            store.dispatch({type: userActions.LOGIN_USER, payload: { token: 'Bearer 456', userData: orgUser }});
+            fixture.detectChanges();
+            expect(component.showAppMenu).toBeFalsy();
+            fixture.debugElement.query(By.css('#appMenuWrapper .navButton')).triggerEventHandler('click', null);
+            fixture.detectChanges();
+            const links = fixture.debugElement.queryAllNodes(By.css('.appLinkWrapper a .appItemText'))
+                .map(node => node.nativeNode.innerText);
+            expect(links).toContain('Organizations');
+            expect(links).not.toContain('Admin');
+
+            // let's also prove clicking outside the dropdown closes it
+            component.clickedOutside(new MouseEvent('click', {
+                relatedTarget: fixture.debugElement.query(By.css('.flex1')).nativeElement
+            }));
+            fixture.detectChanges();
+            expect(component.showAppMenu).toBeFalsy();
+        });
+
+        it('as Admin, the app menu STILL displays the correct icons', () => {
+            spyOn(authService, 'getUser').and.returnValue(adminUser);
+            store.dispatch({type: userActions.LOGIN_USER, payload: { token: 'Bearer 789', userData: adminUser }});
+            fixture.detectChanges();
+            fixture.debugElement.query(By.css('#appMenuWrapper .navButton')).triggerEventHandler('click', null);
+            fixture.detectChanges();
+            const links = fixture.debugElement.queryAllNodes(By.css('.appLinkWrapper a .appItemText'))
+                .map(node => node.nativeNode.innerText);
+            expect(links).toContain('Organizations');
+            expect(links).toContain('Admin');
+
+            // let's also prove clicking outside the dropdown closes it
+            component.clickedOutside(new MouseEvent('click', {
+                relatedTarget: fixture.debugElement.query(By.css('.flex1')).nativeElement
+            }));
+            fixture.detectChanges();
+            expect(component.showAppMenu).toBeFalsy();
+        });
+
+    });
+
+});


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#626
(Adds unit tests for admin and organization management dashboard links)

Supports unfetter-discover/unfetter#728
(Some code coverage tests added for app, AdminService, and Heartbeat component)
