### PR TITLE
Issue 779/security filter

### DIFF
--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -78,8 +78,9 @@ export class FullComponent implements OnInit, OnDestroy {
           .pluck('userProfile')
           .take(1)
           .subscribe((user: UserProfile) => {
-            const creatorId = user._id;
-            this.requestData(this.rollupId, creatorId);
+            // const creatorId = user._id;
+            const createdById = user.organizations[0].id;
+            this.requestData(this.rollupId, createdById);
           },
             (err) => console.log(err));
         this.subscriptions.push(sub$);

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -67,12 +67,11 @@ export class FullComponent implements OnInit, OnDestroy {
     const idParamSub$ = this.route.params
       .distinctUntilChanged()
       .subscribe((params) => {
+        console.log('router params changed, updating component id state');
         this.rollupId = params.rollupId || '';
         this.assessmentId = params.assessmentId || '';
         this.phase = params.phase || '';
         this.attackPatternId = params.attackPatternId || '';
-
-        this.listenForDataChanges();
         const sub$ = this.userStore
           .select('users')
           .pluck('userProfile')
@@ -87,6 +86,8 @@ export class FullComponent implements OnInit, OnDestroy {
       },
         (err) => console.log(err),
         () => idParamSub$.unsubscribe());
+
+    this.listenForDataChanges();
   }
 
   /**
@@ -106,7 +107,10 @@ export class FullComponent implements OnInit, OnDestroy {
         }
 
         this.assessmentTypes = [...arr];
-        this.assessment = { ...arr[0] };
+        this.assessment = this.assessmentTypes
+          .filter((el) => el !== undefined && el.id)
+          .filter((el) => el.id === this.assessmentId)
+          .pop();
       },
         (err) => console.log(err));
 

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -100,7 +100,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
           .pluck('userProfile')
           .take(1)
           .subscribe((user: UserProfile) => {
-            // const creatorId = user._id;
+            const creatorId = user._id;
             const createdById = user.organizations[0].id;
             this.requestData(this.assessmentId, createdById);
           },

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -100,8 +100,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
           .pluck('userProfile')
           .take(1)
           .subscribe((user: UserProfile) => {
-            const creatorId = user._id;
-            this.requestData(this.assessmentId, creatorId);
+            // const creatorId = user._id;
+            const createdById = user.organizations[0].id;
+            this.requestData(this.assessmentId, createdById);
           },
             (err) => console.log(err));
         this.subscriptions.push(sub$);

--- a/src/app/assess/result/summary/summary.datasource.ts
+++ b/src/app/assess/result/summary/summary.datasource.ts
@@ -14,7 +14,7 @@ import { LastModifiedAssessment } from '../../models/last-modified-assessment';
  * @description handles filter events from the UI sent to the datasource, in this case a service call
  */
 export class SummaryDataSource extends DataSource<Partial<LastModifiedAssessment>> {
-    
+
     public readonly demoMode: boolean = (environment.runMode === 'DEMO');
     protected filterChange = new BehaviorSubject('');
     protected dataChange = new BehaviorSubject(undefined);
@@ -98,13 +98,21 @@ export class SummaryDataSource extends DataSource<Partial<LastModifiedAssessment
     }
 
     /**
-     * @description route to a create page or the last modified summary for this user
+     * @description
+     *  route user to their own assessments, then fallback and show a group assessment if needed
      * @param {string} creatorId
      * @return {Observable<Partial<LastModifiedAssessment>[]>}
      */
     public fetchWithCreatorId(creatorId: string): Observable<Partial<LastModifiedAssessment>[]> {
         return this.assessService
-            .getLatestAssessmentsByCreatorId(creatorId);
+            .getLatestAssessmentsByCreatorId(creatorId)
+            .switchMap((data: any[]) => {
+                if (!data || data.length < 1) {
+                    return this.fetchWithNoCreatorId();
+                } else {
+                    return Observable.of(data);
+                }
+            });
     }
 
     /**

--- a/src/app/models/assess/assessment.ts
+++ b/src/app/models/assess/assessment.ts
@@ -12,7 +12,6 @@ export class Assessment extends Stix {
     public assessmentMeta = new AssessmentMeta();
     public assessment_objects = [] as AssessmentObject[];
     public created = new Date().toISOString();
-    public create_by_ref?: string;
     public description: string;
     public id?: string;
     public modified: string;


### PR DESCRIPTION
supports unfetter-discover/unfetter#779

Pull unfetter-discover/unfetter-store#105

This PR supports reads and creation only (update, delete wip) 
## To Test
* Pull both projects for this PR
* `npm run test`

### Test Assessment creation
* visit the assessment creation page
* create an assessment
* open a mongo shell
* execute `db.getCollection('stix').find({'stix.type': 'x-unfetter-assessment'})`
* open the newly created assessments, and notice a stix.created_by_ref with an identity value of one of the orgs your user belongs

### Test read and route, single user
* visit the home page
* select the assessment 2.0 app link
* you should be routed to your assessment (use the full results tab, there may be a know issue w/ the summary tab Fix in another PR)
* navigate in the master list, the data on the page should change

### Test read and route, multi user
* log into the app as a different github user, make it the same group as your initial user
* route to the assessment page, you should see the other users assessment
* create an new assessment, subsequent routes should show the user their created assessment before the groups

### Test restricted read, multi user
* open a mongo shell
* run `db.getCollection('stix').find({'stix.type': 'identity'})`
* view the users, change user2 to have different groups than user1 (the assessment creator)
* visit the API swagger endpoints (https://localhost/explorer)
* as user2 post a good assessment id in the `/x-unfetter-assessments/{id}` endpoint
* notice the id is not found
* add user2 to the same group as the assessment (and user1). repost and you should see data

### Test demo mode
* clear the docker images, run in demo mode things should still work

