### PR TITLE
chrome headless script for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ addons:
 #  - "sleep 3"
 before_install:
   - npm install
-  - npm run checkup &
+  - npm run checkup

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ addons:
 #  - "sleep 3"
 before_install:
   - npm install
-  - npm run test:headless
-  # - google-chrome-stable --headless --disable-gpu http://localhost &
+  - npm run checkup &

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ addons:
 #  - "sh -e /etc/init.d/xvfb start"
 #  - "sleep 3"
 before_install:
-  - google-chrome-stable --headless --disable-gpu http://localhost &
+  - npm run test:headless
+  # - google-chrome-stable --headless --disable-gpu http://localhost &

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ addons:
 #  - "sh -e /etc/init.d/xvfb start"
 #  - "sleep 3"
 before_install:
+  - npm install
   - npm run test:headless
   # - google-chrome-stable --headless --disable-gpu http://localhost &

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "build:dev": "ng version && ng build",
     "watch:test": "ng test --watch --source=false",
     "test": "ng test --single-run --source=false",
-    "test:headless": "ng test --browsers ChromeHeadless",
+    "headless:test": "ng test --single-run --browsers ChromeHeadless",
     "coverage": "ng test --code-coverage --single-run",
+    "headless:coverage": "ng test --code-coverage --single-run --browsers ChromeHeadless",
     "lint": "ng lint",
     "doc": "typedoc --out tsdocs --ignoreCompilerErrors src/",
-    "checkup": "npm run lint && npm run doc && npm run test && npm run coverage && npm run build:prod",
+    "checkup": "npm run lint && npm run doc && npm run headless:test && npm run headless:coverage && npm run build:prod",
     "e2e": "ng e2e"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build:dev": "ng version && ng build",
     "watch:test": "ng test --watch --source=false",
     "test": "ng test --single-run --source=false",
+    "test:headless": "ng test --browsers ChromeHeadless",
     "coverage": "ng test --code-coverage --single-run",
     "lint": "ng lint",
     "doc": "typedoc --out tsdocs --ignoreCompilerErrors src/",


### PR DESCRIPTION
* `npm run test:headless`

requires Chrome 59+