### PR TITLE
assessments summary now completely working; slider will update chart …

### DIFF
--- a/src/app/assess/models/threshold-option.ts
+++ b/src/app/assess/models/threshold-option.ts
@@ -1,0 +1,4 @@
+export interface ThresholdOption {
+    name: string;
+    risk: number;
+}

--- a/src/app/assess/result/store/summary.actions.ts
+++ b/src/app/assess/result/store/summary.actions.ts
@@ -18,6 +18,7 @@ export const SET_KILL_CHAIN_DATA = '[Assess Summary] SET_KILL_CHAIN_DATA';
 export const FINISHED_LOADING_KILL_CHAIN_DATA = '[Assess Summary] FINISHED_LOADING_KILL_CHAIN_DATA';
 export const SET_SUMMARY_AGGREGATION_DATA = '[Assess Summary] SET_SUMMARY_AGGREGATION_DATA';
 export const FINISHED_LOADING_SUMMARY_AGGREGATION_DATA = '[Assess Summary] FINISHED_LOADING_SUMMARY_AGGREGATION_DATA';
+export const CLEAN_ASSESSMENT_RESULT_DATA = '[Assess Result Group] CLEAN_ASSESSMENT_RESULT_DATA';
 
 
 export class LoadSingleAssessmentSummaryData implements Action {
@@ -98,7 +99,14 @@ export class FinishedLoadingSummaryAggregationData implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class CleanAssessmentResultData {
+    public readonly type = CLEAN_ASSESSMENT_RESULT_DATA;
+
+    constructor() { }
+}
+
 export type SummaryActions =
+    CleanAssessmentResultData |
     SetAssessments |
     LoadAssessmentSummaryData |
     LoadSingleAssessmentSummaryData |

--- a/src/app/assess/result/store/summary.reducers.ts
+++ b/src/app/assess/result/store/summary.reducers.ts
@@ -34,6 +34,8 @@ const initialState: SummaryState = genState();
 
 export function summaryReducer(state = initialState, action: summaryActions.SummaryActions): SummaryState {
     switch (action.type) {
+        case summaryActions.CLEAN_ASSESSMENT_RESULT_DATA:
+            return genState();
         case summaryActions.LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA:
             return genState({
                 ...state,

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -52,6 +52,12 @@ describe('SummaryCalculationService', () => {
     expect(service.weakness).toEqual('');
   }));
 
+  it('should call recalculateDependents when selectedRisk changes', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    spyOn(service, 'recalculateDependents');
+    service.selectedRisk = .75;
+    expect(service.recalculateDependents).toHaveBeenCalled();
+  }));
+
   it('should calculate correct weakness', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
     service.calculateWeakness({ assessedByAttackPattern: null, attackPatternsByKillChain: null, phases: null });
     expect(service.weakness).toEqual('');
@@ -244,11 +250,234 @@ describe('SummaryCalculationService', () => {
   }));
 
   it('should filter assessment objects based on selected risk', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.selectedRisk = 0.5;
     expect(service.filterOnRisk(null)).toEqual([]);
+    expect(service.filterOnRisk([])).toEqual([]);
+    expect(service.filterOnRisk([{ risk: null, questions: null, stix: null }])).toEqual([]);
+    expect(service.filterOnRisk([{
+      risk: .25, questions: null, stix: {
+        id: null, metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }])).toEqual([]);
+    expect(service.filterOnRisk([{
+      risk: .25, questions: null, stix: {
+        id: null, metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }])).toEqual([]);
+    expect(service.filterOnRisk([{
+      risk: .25, questions: null, stix: {
+        id: 'ididid', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }])).toEqual(['ididid']);
+    expect(service.filterOnRisk([
+      {
+        risk: .25, questions: null, stix: {
+          id: 'ididid', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+          granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+        },
+      },
+      {
+        risk: .75, questions: null, stix: {
+          id: 'nope', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+          granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+        }
+      }])).toEqual(['ididid']);
   }));
 
   it('should populate assessments grouping given an array of asssesment objects', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.summaryAggregation = null;
     service.populateAssessmentsGrouping(null);
     expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: null, totalAttackPatternCountBySophisicationLevel: null };
+    service.populateAssessmentsGrouping(null);
+    expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: null, attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateAssessmentsGrouping([]);
+    expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateAssessmentsGrouping([{ risk: null, questions: null }]);
+    expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateAssessmentsGrouping([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [] }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateAssessmentsGrouping([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.assessmentsGroupingTotal).toEqual({});
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: null,
+      attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: null }] }], totalAttackPatternCountBySophisicationLevel: null
+    };
+    service.populateAssessmentsGrouping([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: null, created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.assessmentsGroupingTotal).toEqual({ '': 1 });
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: null,
+      attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
+    };
+    service.populateAssessmentsGrouping([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }], created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.assessmentsGroupingTotal).toEqual({ 'happy camper': 1 });
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: null,
+      attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }, { kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
+    };
+    service.populateAssessmentsGrouping([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }], created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.assessmentsGroupingTotal).toEqual({ 'happy camper': 2 });
   }));
+
+  it('should capitalize all words except for and, or, of, on, and the', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.capitalizeWithExceptions(null, null, null)).toBe(null);
+    expect(service.capitalizeWithExceptions('and', null, null)).toBe('and');
+    expect(service.capitalizeWithExceptions('', null, null)).toBe('');
+    expect(service.capitalizeWithExceptions('apple', null, null)).toBe('apple');
+    expect(service.capitalizeWithExceptions(null, null, 'apple')).toBe(null);
+    expect(service.capitalizeWithExceptions(null, 'a', null)).toBe(null);
+    expect(service.capitalizeWithExceptions('cymbolic', 'a', null)).toBe('A');
+    expect(service.capitalizeWithExceptions('the', 'a', null)).toBe('the');
+    expect(service.capitalizeWithExceptions('chestnut', 'a', 'pple')).toBe('Apple');
+    expect(service.capitalizeWithExceptions('or', 'a', 'pple')).toBe('or');
+    expect(service.capitalizeWithExceptions('apple', 'a', 'pple')).toBe('Apple');
+    expect(service.capitalizeWithExceptions('of', 'o', 'f')).toBe('of');
+    expect(service.capitalizeWithExceptions('on', 'o', 'n')).toBe('on');
+    expect(service.capitalizeWithExceptions('On', 'O', 'n')).toBe('on');
+    expect(service.capitalizeWithExceptions('KAPTAIN', 'K', 'APTAIN')).toBe('Kaptain');
+    expect(service.capitalizeWithExceptions('BUT', 'B', 'BUT')).toBe('but');
+    expect(service.capitalizeWithExceptions('BUT', 'A', 'PPLE')).toBe('but');
+  }));
+
+  it('should capitalize individual single letters in a string', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.capitalizeSingleLetter(null)).toEqual('');
+    expect(service.capitalizeSingleLetter('')).toEqual('');
+    expect(service.capitalizeSingleLetter('1')).toEqual('1');
+    expect(service.capitalizeSingleLetter('a')).toEqual('A');
+    expect(service.capitalizeSingleLetter('a b')).toEqual('a b');
+    expect(service.capitalizeSingleLetter('ab')).toEqual('ab');
+  }));
+
+  it('should convert labels to formatted text for display', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.convertLabels(null)).toEqual([]);
+    expect(service.convertLabels(null)).toEqual([]);
+    expect(service.convertLabels(['apple-jacks'])).toEqual(['Apple Jacks']);
+    expect(service.convertLabels(['apple-jacks', null, ''])).toEqual(['Apple Jacks', '', '']);
+    expect(service.convertLabels(['a-b'])).toEqual(['A B']);
+  }));
+
+  it('should render a legend appropriate for a threshold graph and the current selected threshold', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.thresholdOptions = null;
+    service.selectedRisk = 3;
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [];
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: null, risk: null }];
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: null, risk: 3 }];
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: '', risk: 3 }];
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 3 }];
+    expect(service.renderLegend()).toEqual(`At or Above 'bob'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 1 }];
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 1 }, { name: 'steve', risk: 3 }];
+    expect(service.renderLegend()).toEqual(`At or Above 'steve'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 1 }, { name: 'steve', risk: 3 }];
+    service.selectedRisk = 0;
+    expect(service.renderLegend()).toEqual(`At or Above 'Mitigation Threshold'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 0 }, { name: 'steve', risk: 3 }];
+    service.selectedRisk = 0;
+    expect(service.renderLegend()).toEqual(`At or Above 'bob'`);
+    service.thresholdOptions = [{ name: 'bob', risk: 0 }, { name: 'steve', risk: 0.25 }];
+    service.selectedRisk = .25;
+    expect(service.renderLegend()).toEqual(`At or Above 'steve'`);
+  }));
+
+  it('should convert a single label to formatted text for display', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.convertLabel(null)).toEqual('');
+    expect(service.convertLabel('')).toEqual('');
+    expect(service.convertLabel('a-b')).toEqual('A B');
+  }));
+
+  it('should detect valid summary aggregations', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.summaryAggregation = null;
+    expect(service.isSummaryAggregationValid()).toBe(false);
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, totalAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: null };
+    expect(service.isSummaryAggregationValid()).toBe(false);
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: { index: null, count: null }, totalAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: null };
+    expect(service.isSummaryAggregationValid()).toBe(false);
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: { index: null, count: null },
+      totalAttackPatternCountBySophisicationLevel: { index: null, count: null }, attackPatternsByAssessedObject: null
+    };
+    expect(service.isSummaryAggregationValid()).toBe(true);
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: null,
+      totalAttackPatternCountBySophisicationLevel: { index: null, count: null }, attackPatternsByAssessedObject: null
+    };
+    expect(service.isSummaryAggregationValid()).toBe(false);
+  }));
+
+  it('calculate option names for threshold graphs based on question data', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    const defaultOptions = [
+      { name: 'Mitigation Threshold', risk: 0 },
+      { name: 'Mitigation Threshold', risk: .25 },
+      { name: 'Mitigation Threshold', risk: .5 },
+      { name: 'Mitigation Threshold', risk: .75 },
+      { name: 'Mitigation Threshold', risk: 1 }];
+    service.calculateThresholdOptionNames(null);
+    expect(service.thresholdOptions).toEqual(defaultOptions);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: null, selected_value: null });
+    expect(service.thresholdOptions).toEqual(defaultOptions);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: [], selected_value: null });
+    expect(service.thresholdOptions).toEqual(defaultOptions);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: [{ name: null, risk: 0 }], selected_value: null });
+    expect(service.thresholdOptions).toEqual([{ name: '', risk: 0 }]);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: [{ name: ' ', risk: 0 }], selected_value: null });
+    expect(service.thresholdOptions).toEqual([{ name: ' ', risk: 0 }]);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: [{ name: 'abbas', risk: 0 }], selected_value: null });
+    expect(service.thresholdOptions).toEqual([{ name: 'Abbas', risk: 0 }]);
+    service.calculateThresholdOptionNames({ name: null, risk: null, options: [{ name: 'abbas', risk: 0 }, { name: 'brian', risk: 0 }, { name: 'chris columbus and son', risk: 0 }], selected_value: null });
+    expect(service.thresholdOptions).toEqual([{ name: 'Abbas', risk: 0 }, { name: 'Brian', risk: 0 }, { name: 'Chris Columbus and Son', risk: 0 }]);
+  }));
+
+  it('convert a number to a sophistication value', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.sophisticationValueToWord(null)).toBe('Unknown');
+    expect(service.sophisticationValueToWord(0)).toBe('Novice');
+    expect(service.sophisticationValueToWord(1)).toBe('Practitioner');
+    expect(service.sophisticationValueToWord(2)).toBe('Expert');
+    expect(service.sophisticationValueToWord(3)).toBe('Innovator');
+    expect(service.sophisticationValueToWord(4)).toBe('4');
+  }));
+
+  it('convert a number string to a sophistication value', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    expect(service.sophisticationNumberToWord(null)).toBe('Unknown');
+    expect(service.sophisticationNumberToWord('1')).toBe('Practitioner');
+    expect(service.sophisticationNumberToWord('20')).toBe('20');
+  }));
+
 });

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -10,19 +10,27 @@ import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
 import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
 import { Constance } from '../../../utils/constance';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { ThresholdOption } from '../../models/threshold-option';
+import { AssessmentQuestion } from '../../../models/assess/assessment-question';
 
 @Injectable()
 export class SummaryCalculationService {
   public readonly topNRisks: number;
+  public readonly riskSub: BehaviorSubject<number>;
+  // Combine with riskSub??
+  selectedRiskValue: number;
   numericRiskValue: number;
   weaknessValue: string;
   topRisksValue: AssessKillChainType[];
   summaryAggregationValue: SummaryAggregation;
   barColorsValue: any[];
-  selectedRiskValue: number;
-  assessmentsGroupingTotalValue: any; // TODO specify
-  assessmentsGroupingFilteredValue: any; // TODO specify
-  techniqueBreakdownValue: any; // TODO specify
+
+  assessmentsGroupingTotalValue: any;
+  assessmentsGroupingFilteredValue: any;
+  techniqueBreakdownValue: any;
+  assessmentObjects: AssessmentObject[];
+  thresholdOptionsValue: ThresholdOption[];
 
   constructor() {
     this.numericRisk = 0;
@@ -36,6 +44,7 @@ export class SummaryCalculationService {
         backgroundColor: Constance.MAT_COLORS['lightblue']['100']
       }
     ];
+    this.riskSub = new BehaviorSubject<number>(null);
     this.selectedRisk = 0.5;
   }
 
@@ -61,6 +70,9 @@ export class SummaryCalculationService {
 
   public set selectedRisk(newSelectedRisk: number) {
     this.selectedRiskValue = newSelectedRisk;
+    this.recalculateDependents();
+    // Allow subscribers to use the new data
+    this.riskSub.next(newSelectedRisk);
   }
 
   public set assessmentsGroupingTotal(newAssessmentsGroupingTotal: any) {
@@ -73,6 +85,10 @@ export class SummaryCalculationService {
 
   public set techniqueBreakdown(newTechniqueBreakdown: any) {
     this.techniqueBreakdownValue = newTechniqueBreakdown;
+  }
+
+  public set thresholdOptions(newThresholdOptions: ThresholdOption[]) {
+    this.thresholdOptionsValue = newThresholdOptions;
   }
 
   public get numericRisk(): number {
@@ -94,8 +110,12 @@ export class SummaryCalculationService {
     return this.summaryAggregationValue;
   }
 
-  public get selectedRisk() {
+  public get selectedRisk(): number {
     return this.selectedRiskValue;
+  }
+
+  public getSelectedRiskSub() {
+    return this.riskSub.subscribe((value: number) => this.riskSub.next(this.selectedRisk));
   }
 
   public get assessmentsGroupingTotal(): any {
@@ -108,6 +128,10 @@ export class SummaryCalculationService {
 
   public get techniqueBreakdown(): any {
     return this.techniqueBreakdownValue;
+  }
+
+  public get thresholdOptions(): ThresholdOption[] {
+    return this.thresholdOptionsValue;
   }
 
   public getRiskText(): string {
@@ -193,26 +217,40 @@ export class SummaryCalculationService {
     return risks;
   }
 
+  public recalculateDependents() {
+    this.repopulateAssessmentsGrouping();
+    this.repopulateTechniqueBreakdown();
+  }
+
+  public repopulateAssessmentsGrouping(): void {
+    this.populateAssessmentsGrouping(this.assessmentObjects);
+  }
+
   /**
- * @description
- *  populate kill chain grouping and assessment object tallies for assessment grouping chart
- * @returns {void}
- */
+   * @description
+   *  populate kill chain grouping and assessment object tallies for assessment grouping chart
+   * @returns {void}
+   */
   public populateAssessmentsGrouping(assessmentObjects: AssessmentObject[]): void {
+    this.assessmentObjects = assessmentObjects;
     const includedIds = this.filterOnRisk(assessmentObjects);
     const killChainTotal = {};
     const killChainFiltered = {};
 
-    if (this.summaryAggregation) {
+    if (this.summaryAggregation && this.summaryAggregation.attackPatternsByAssessedObject) {
       const tally = (tallyObject: object) => {
         return (assessedObject) => {
           // flat map kill chain names
-          const killChainNames = assessedObject.attackPatterns
-            .reduce((memo, pattern) => memo.concat(pattern['kill_chain_phases']), []);
-          const names: string[] = killChainNames.map((chain) => chain['phase_name'].toLowerCase() as string);
-          const uniqNames: string[] = Array.from(new Set(names));
-          names.forEach((name) => tallyObject[name] = tallyObject[name] ? tallyObject[name] + 1 : 1);
-          return assessedObject;
+          let result = null;
+          if (assessedObject && assessedObject.attackPatterns) {
+            const killChainNames = assessedObject.attackPatterns
+              .reduce((memo, pattern) => memo.concat(pattern['kill_chain_phases']), []);
+            const names: string[] = killChainNames.map((chain) => chain ? chain['phase_name'].toLowerCase() as string : '');
+            const uniqNames: string[] = Array.from(new Set(names));
+            names.forEach((name) => tallyObject[name] = tallyObject[name] ? tallyObject[name] + 1 : 1);
+            result = assessedObject;
+          }
+          return result;
         };
       };
 
@@ -220,7 +258,7 @@ export class SummaryCalculationService {
       this.summaryAggregation.attackPatternsByAssessedObject
         // tally totals
         .map(tally(killChainTotal))
-        .filter((aoToApMap) => includedIds.includes(aoToApMap._id))
+        .filter((aoToApMap) => (aoToApMap && aoToApMap._id) ? includedIds.includes(aoToApMap._id) : null)
         // tally filtered objects
         .map(tally(killChainFiltered));
     }
@@ -229,40 +267,48 @@ export class SummaryCalculationService {
     this.assessmentsGroupingFiltered = killChainFiltered;
   }
 
+  public repopulateTechniqueBreakdown() {
+    this.populateTechniqueBreakdown(this.assessmentObjects);
+  }
+
   /**
    * @description
    *  populate grouping and assessment object tallies for technique by skill chart
    * @returns {void}
    */
   public populateTechniqueBreakdown(assessmentObjects: AssessmentObject[]): void {
-    // Total assessed objects to calculated risk
-    const assessedRiskMapping = this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel;
-    const includedIds = this.filterOnRisk(assessmentObjects);
-    const attackPatternSet = new Set();
-    // Find assessed-objects-to-attack-patterns maps that meet those Ids
-    this.summaryAggregation.attackPatternsByAssessedObject
-      .filter((aoToApMap) => includedIds.includes(aoToApMap._id))
-      .forEach((aoToApMap) => {
-        aoToApMap.attackPatterns.forEach((ap) => {
-          attackPatternSet.add(JSON.stringify(ap));
+
+    if (assessmentObjects && this.summaryAggregation) {
+      this.assessmentObjects = assessmentObjects;
+      // Total assessed objects to calculated risk
+      const assessedRiskMapping = this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel;
+      const includedIds = this.filterOnRisk(assessmentObjects);
+      const attackPatternSet = new Set();
+      // Find assessed-objects-to-attack-patterns maps that meet those Ids
+      this.summaryAggregation.attackPatternsByAssessedObject
+        .filter((aoToApMap) => includedIds.includes(aoToApMap._id))
+        .forEach((aoToApMap) => {
+          aoToApMap.attackPatterns.forEach((ap) => {
+            attackPatternSet.add(JSON.stringify(ap));
+          });
         });
+
+      const attackPatternSetMap = {};
+      attackPatternSet.forEach((ap) => {
+        const curAp = JSON.parse(ap);
+        if (attackPatternSetMap[curAp['x_unfetter_sophistication_level']] === undefined) {
+          attackPatternSetMap[curAp['x_unfetter_sophistication_level']] = 0;
+        }
+        ++attackPatternSetMap[curAp['x_unfetter_sophistication_level']];
       });
 
-    const attackPatternSetMap = {};
-    attackPatternSet.forEach((ap) => {
-      const curAp = JSON.parse(ap);
-      if (attackPatternSetMap[curAp['x_unfetter_sophistication_level']] === undefined) {
-        attackPatternSetMap[curAp['x_unfetter_sophistication_level']] = 0;
-      }
-      ++attackPatternSetMap[curAp['x_unfetter_sophistication_level']];
-    });
-
-    this.techniqueBreakdown = {};
-    for (const prop in Object.keys(assessedRiskMapping)) {
-      if (attackPatternSetMap[prop] === undefined) {
-        this.techniqueBreakdown[prop] = 0;
-      } else {
-        this.techniqueBreakdown[prop] = attackPatternSetMap[prop] / (assessedRiskMapping[prop]);
+      this.techniqueBreakdown = {};
+      for (const prop in Object.keys(assessedRiskMapping)) {
+        if (attackPatternSetMap[prop] === undefined) {
+          this.techniqueBreakdown[prop] = 0;
+        } else {
+          this.techniqueBreakdown[prop] = attackPatternSetMap[prop] / (assessedRiskMapping[prop]);
+        }
       }
     }
   }
@@ -270,14 +316,13 @@ export class SummaryCalculationService {
   /**
    * @description
    *  Find IDs that meet risk threshold
-   *  TODO should be <= risk or < risk?
    * @returns {string[]}
    */
   public filterOnRisk(assessment_objects: AssessmentObject[]): string[] {
     let filteredIds: string[] = [];
     if (assessment_objects) {
-      const includedIds: string[] = assessment_objects // TODO fix...or active...or this is a roll-up?
-        .filter((ao) => ao.risk <= this.selectedRisk)
+      const includedIds: string[] = assessment_objects
+        .filter((ao) => ((ao.risk || ao.risk === 0) && ao.risk <= this.selectedRisk && (ao.stix && ao.stix.id)))
         .map((ao) => ao.stix.id);
       filteredIds = includedIds;
     }
@@ -290,17 +335,50 @@ export class SummaryCalculationService {
   }
 
   public sophisticationValueToWord(num: number): string {
+    let value = '';
     switch (num) {
       case 0:
-        return 'Novice';
+        value = 'Novice';
+        break;
       case 1:
-        return 'Practitioner';
+        value = 'Practitioner';
+        break;
       case 2:
-        return 'Expert';
+        value = 'Expert';
+        break;
       case 3:
-        return 'Innovator';
+        value = 'Innovator';
+        break;
       default:
-        return num.toString();
+        if (!num) {
+          value = 'Unknown';
+        } else {
+          value = num.toString();
+        }
+    }
+    return value;
+  }
+
+  public calculateThresholdOptionNames(questionData: AssessmentQuestion) {
+    // Default
+    this.thresholdOptions = [
+      { name: 'Mitigation Threshold', risk: 0 },
+      { name: 'Mitigation Threshold', risk: .25 },
+      { name: 'Mitigation Threshold', risk: .5 },
+      { name: 'Mitigation Threshold', risk: .75 },
+      { name: 'Mitigation Threshold', risk: 1 }];
+
+    if (questionData && questionData.options && questionData.options.length > 0) {
+      this.thresholdOptions = questionData.options;
+      this.thresholdOptions = this.thresholdOptions.map((option: ThresholdOption): ThresholdOption => {
+        if (!option.name) {
+          option.name = '';
+        }
+        option.name = option.name.replace(/\b([a-z])(\w+)/g, this.capitalizeWithExceptions);
+        return option;
+      });
+    } else {
+      console.error('Failed to read question data for given assessment question; using default values.');
     }
   }
 
@@ -312,5 +390,76 @@ export class SummaryCalculationService {
       valid = true;
     }
     return valid;
+  }
+
+  public convertLabel(unconvertedLabel: string): string {
+    let convertedLabel: string = '';
+    if (unconvertedLabel) {
+      convertedLabel = this.convertLabels([unconvertedLabel])[0];
+    }
+    return convertedLabel;
+  }
+
+  public convertLabels(unconvertedLabels: string[]): string[] {
+    let convertedLabels: string[] = [];
+    if (unconvertedLabels) {
+      convertedLabels = unconvertedLabels.map((word) => {
+        if (!word) {
+          word = '';
+        }
+        word = word.replace(/-/g, ' ');
+        const tempWord = word;
+        word = word.replace(/\b([a-z])(\w+)/g, this.capitalizeWithExceptions);
+        if (word === tempWord) {
+          word = word.replace(/\b([a-z])/g, this.capitalizeSingleLetter);
+        }
+        return word;
+      });
+    }
+    return convertedLabels;
+  }
+
+  public capitalizeSingleLetter(letter: string): string {
+    let capitalizedValue = '';
+    if (letter) {
+      if (letter.length > 1) { // Not a single letter, return unchanged
+        capitalizedValue = letter;
+      } else {
+        capitalizedValue = letter.toUpperCase();
+      }
+    }
+    return capitalizedValue;
+  }
+
+  public capitalizeWithExceptions(fullString: string, firstLetter: string, restOfString: string): string {
+    let capitalizedValue = fullString;
+    if (fullString) {
+      capitalizedValue = fullString.toLowerCase();
+      if (capitalizedValue !== 'and' && capitalizedValue !== 'or' && capitalizedValue !== 'the'
+        && capitalizedValue !== 'of' && capitalizedValue !== 'on' && capitalizedValue !== 'but' && firstLetter) {
+        capitalizedValue = firstLetter.toUpperCase();
+        if (restOfString) {
+          capitalizedValue += restOfString.toLowerCase();
+        }
+      }
+    }
+    return capitalizedValue;
+  }
+
+  /**
+ * @description
+ *  render legend for top of threshold graphs
+ * @returns {void}
+ */
+  public renderLegend(): string {
+    let label = 'At or Above';
+    let name = 'Mitigation Threshold'
+    if (this.thresholdOptions) {
+      const option = this.thresholdOptions.find((opt) => opt.risk === this.selectedRisk);
+      if (option && option.name) {
+        name = option.name;
+      }
+    }
+    return `${label} '${name}'`;
   }
 }

--- a/src/app/assess/result/summary/summary-report/assessment-chart/assessment-chart.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/assessment-chart/assessment-chart.component.spec.ts
@@ -3,6 +3,7 @@ import { ChartsModule } from 'ng2-charts';
 
 import { AssessmentChartComponent } from './assessment-chart.component';
 import { SummaryCalculationService } from '../../summary-calculation.service';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 describe('AssessmentChartComponent', () => {
   let component: AssessmentChartComponent;
@@ -11,7 +12,10 @@ describe('AssessmentChartComponent', () => {
   let serviceMock;
 
   beforeEach(async(() => {
-    serviceMock = { barColors: ['color'], assessmentsGroupingFiltered: { a: 'be' }, assessmentsGroupingTotal: { a: 'be' } };
+    serviceMock = {
+      barColors: ['color'], assessmentsGroupingFiltered: { a: 'be' }, assessmentsGroupingTotal: { a: 'be' }, riskSub: new BehaviorSubject<number>(null),
+      convertLabels: (unconvertedLabels: string[]) => { return unconvertedLabels; }, renderLegend: () => 'legend here',
+    };
 
     TestBed.configureTestingModule({
 
@@ -69,19 +73,6 @@ describe('AssessmentChartComponent', () => {
     expect(component.getPercentageString({ datasetIndex: 1, index: 1 }, { datasets: [{ data: [1] }, { data: [null, 80] }] })).toBe('80%');
   });
 
-  it('should capitalize all words except for and, or, and the', () => {
-    expect(component.capitalizeWithExceptions(null, null, null)).toBe(null);
-    expect(component.capitalizeWithExceptions('and', null, null)).toBe('and');
-    expect(component.capitalizeWithExceptions('', null, null)).toBe('');
-    expect(component.capitalizeWithExceptions('apple', null, null)).toBe('apple');
-    expect(component.capitalizeWithExceptions(null, null, 'apple')).toBe(null);
-    expect(component.capitalizeWithExceptions(null, 'a', null)).toBe('A');
-    expect(component.capitalizeWithExceptions('the', 'a', null)).toBe('the');
-    expect(component.capitalizeWithExceptions(null, 'a', 'pple')).toBe('Apple');
-    expect(component.capitalizeWithExceptions('or', 'a', 'pple')).toBe('or');
-    expect(component.capitalizeWithExceptions('apple', 'a', 'pple')).toBe('Apple');
-  });
-
   it('should calculate data for the chart', () => {
     expect(component.calculateData(null, null)).toBe(0);
     expect(component.calculateData(null, 1)).toBe(0);
@@ -91,11 +82,8 @@ describe('AssessmentChartComponent', () => {
   });
 
   it('should convert labels to formatted text for display', () => {
-    expect(component.convertLabels(null, null)).toEqual([]);
-    expect(component.convertLabels(null, false)).toEqual([]);
     expect(component.convertLabels(['apple-jacks'], false)).toEqual([]);
-    expect(component.convertLabels(['apple-jacks'], true)).toEqual(['Apple Jacks']);
-    expect(component.convertLabels(['apple-jacks', null, ''], true)).toEqual(['Apple Jacks', '', '']);
+    expect(component.convertLabels(['apple-jacks'], true)).toEqual(['apple-jacks']); // mock value;this is truly tested in the calculate service
   });
 
 });

--- a/src/app/assess/result/summary/summary-report/assessment-chart/assessment-chart.component.ts
+++ b/src/app/assess/result/summary/summary-report/assessment-chart/assessment-chart.component.ts
@@ -79,9 +79,12 @@ export class AssessmentChartComponent implements OnInit {
     this.colors = this.summaryCalculationService.barColors;
     this.showLabels = this.showLabels || this.showLabelsDefault;
     this.showLegend = this.showLegend || this.showLegendDefault;
-    this.riskThreshold = this.summaryCalculationService.selectedRisk || this.riskThresholdDefault;
+    this.riskThreshold = this.riskThresholdDefault
+    this.summaryCalculationService.riskSub.subscribe((value: number) => this.renderChart());
+    this.barChartData[0].label = 'At Or Above Mitigation Threshold';
     this.renderChart();
   }
+
 
   public getPercentageString(tooltipItem, data) {
     let percentage = 0;
@@ -97,17 +100,6 @@ export class AssessmentChartComponent implements OnInit {
     return `${percentage}%`;
   }
 
-  public capitalizeWithExceptions(fullString: string, firstLetter: string, restOfString: string): string {
-    let capitalizedValue = fullString;
-    if (fullString !== 'and' && fullString !== 'or' && fullString !== 'the' && firstLetter) {
-      capitalizedValue = firstLetter.toUpperCase();
-      if (restOfString) {
-        capitalizedValue += restOfString;
-      }
-    }
-    return capitalizedValue;
-  }
-
   public calculateData(assessmentGroupingFilteredCount: number, assessmentsGroupingTotal: number): number {
     let data: number = 0;
     if (assessmentsGroupingTotal) {
@@ -119,68 +111,40 @@ export class AssessmentChartComponent implements OnInit {
   public renderChart(): boolean {
     let successfulRender = false;
 
-    if (!this.summaryCalculationService.assessmentsGroupingFiltered || !this.summaryCalculationService.assessmentsGroupingTotal) {
-      return successfulRender;
+    if (this.summaryCalculationService.assessmentsGroupingFiltered && this.summaryCalculationService.assessmentsGroupingTotal) {
+      // generate uniq grouping
+      const uniqueGroups = Array.from(new Set(
+        Array.from(Object.keys(this.summaryCalculationService.assessmentsGroupingTotal))
+          .map((el) => el.toLowerCase())))
+        .sort(SummarySortHelper.sortDesc());
+
+      // init data array
+      const size = uniqueGroups.length;
+      this.barChartData[0].data = [];
+
+      let index = 0;
+      // assign data array
+      uniqueGroups
+        .forEach((key) => {
+          this.barChartData[0].data[index] = this.calculateData(this.summaryCalculationService.assessmentsGroupingFiltered[key], this.summaryCalculationService.assessmentsGroupingTotal[key]);
+          index = index + 1;
+        });
+
+      // build labels based on root label
+      this.barChartLabels = this.convertLabels(uniqueGroups, this.showLabels);
+
+      this.barChartData[0].label = this.summaryCalculationService.renderLegend();
+
+      successfulRender = true;
     }
-
-    this.renderLegend();
-
-    // generate uniq grouping
-    const uniqueGroups = Array.from(new Set(
-      Array.from(Object.keys(this.summaryCalculationService.assessmentsGroupingTotal))
-        .map((el) => el.toLowerCase())))
-      .sort(SummarySortHelper.sortDesc());
-
-    // init data array
-    const size = uniqueGroups.length;
-    this.barChartData[0].data = [];
-
-    let index = 0;
-    // assign data array
-    uniqueGroups
-      .forEach((key) => {
-        this.barChartData[0].data[index] = this.calculateData(this.summaryCalculationService.assessmentsGroupingFiltered[key], this.summaryCalculationService.assessmentsGroupingTotal[key]);
-        index = index + 1;
-      });
-    const convertedLabels: any = uniqueGroups.map((word) => {
-      word = word.replace(/-/g, ' ');
-      word = word.replace(/\b([a-z])(\w+)/g, this.capitalizeWithExceptions);
-      return word;
-    });
-
-    // build labels based on root label
-    this.barChartLabels = this.convertLabels(uniqueGroups, this.showLabels);
-    successfulRender = true;
     return successfulRender;
   }
 
   public convertLabels(unconvertedLabels: string[], needToConvert: boolean): string[] {
     let convertedLabels: string[] = [];
     if (needToConvert) {
-      convertedLabels = unconvertedLabels.map((word) => {
-        if (!word) {
-          word = '';
-        }
-        word = word.replace(/-/g, ' ');
-        word = word.replace(/\b([a-z])(\w+)/g, this.capitalizeWithExceptions);
-        return word;
-      });
+      convertedLabels = this.summaryCalculationService.convertLabels(unconvertedLabels);
     }
     return convertedLabels;
-  }
-
-  /**
-   * @description
-   *  render legend at top of graph
-   * @returns {void}
-   */
-  public renderLegend(): void {
-    // TODO
-    // if (this.riskLabelOptions) {
-    //     const option = this.riskLabelOptions.find((opt) => opt.risk === this.riskThreshold);
-    //     const name = option.name;
-    //     this.barChartData[0].label = 'At Or Above ' + name;
-    // }
-    this.barChartData[0].label = 'At Or Above Mitigation Threshold';
   }
 }

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
@@ -44,4 +44,23 @@ describe('SophisticationBreakdownComponent', () => {
   it('should create', () => {
     expect(testHostComponent).toBeTruthy();
   });
+
+  it('should generate a relevant tooltip', () => {
+    expect(SophisticationBreakdownComponent.generateTooltipLabel(null, null)).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({}, null)).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({}, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: null}, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: ''}, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: null})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: []})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: [{data: null}]})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: null}]})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: []}]})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [null]}]})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [0]}]})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [1]}]})).toBe(1);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 2, index: 2}, {datasets: [{data: null}, {data: null}, {data: [1, 2, 3]}]})).toBe(3);
+  })
+
 });

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
@@ -33,6 +33,20 @@ export class SophisticationBreakdownComponent implements OnInit {
     this.barChartType = 'bar';
   }
 
+  public static generateTooltipLabel(tooltipItem, data) {
+    let label = 0;
+    if (tooltipItem && data && data.datasets && (tooltipItem.datasetIndex || tooltipItem.datasetIndex === 0)) {
+      const dataset = data.datasets[tooltipItem.datasetIndex];
+      if (dataset && dataset.data && (tooltipItem.index || tooltipItem.index === 0)) {
+        let value = dataset.data[tooltipItem.index];
+        if (value || value === 0) {
+          label = value;
+        }
+      }
+    }
+    return label;
+  }
+
   ngOnInit() {
     this.barChartLabels = [];
     this.barChartOptions = {
@@ -49,10 +63,7 @@ export class SophisticationBreakdownComponent implements OnInit {
       tooltips: {
         mode: 'index',
         callbacks: {
-          label: (tooltipItem, data) => {
-            const dataset = data.datasets[tooltipItem.datasetIndex];
-            return dataset.data[tooltipItem.index] || 0;
-          }
+          label: SophisticationBreakdownComponent.generateTooltipLabel,
         }
       },
       legend: {
@@ -77,5 +88,4 @@ export class SophisticationBreakdownComponent implements OnInit {
       this.barChartData[1].data.push(this.allAttackPatterns[prop]);
     }
   }
-
 }

--- a/src/app/assess/result/summary/summary-report/summary-report.component.html
+++ b/src/app/assess/result/summary/summary-report/summary-report.component.html
@@ -59,7 +59,7 @@
       <div class="flex flexItemsCenter">
         <div class="flex flexItemsCenter" id="sliderContainer">
           <mat-icon color="primary" class="mat-24 icon-people-1" aria-hidden="false" aria-label="Least sophisticated mitigation"></mat-icon>
-          <mat-slider disabled min="0" max="4" step="1" value="2" id="sophisticationSlider" color="primary">
+          <mat-slider min="0" max="1" invert="true" step=".25" tick-interval="1" id="sophisticationSlider" color="primary" [(ngModel)]="summaryCalculationService.selectedRisk">
           </mat-slider>
           <mat-icon color="primary" class="mat-24 icon-people" aria-hidden="false" aria-label="Most sophisticated mitigation"></mat-icon>
         </div>
@@ -83,7 +83,7 @@
           <mat-card-content>
             <div *ngIf="summaryCalculationService.techniqueBreakdown;else noTechniquesData">
               <!-- TODO [riskLabelOptions]="thresholdOptions" -->
-              <techniques-chart #techniquesChart [riskThreshold]="summaryCalculationService.selectedRisk" [techniqueBreakdown]="summaryCalculationService.techniqueBreakdown">
+              <techniques-chart #techniquesChart [riskThreshold]="summaryCalculationService.selectedRisk">
               </techniques-chart>
             </div>
             <ng-template #noTechniquesData>No data to load chart!</ng-template>

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
@@ -3,16 +3,20 @@ import { ChartsModule } from 'ng2-charts';
 
 import { TechniquesChartComponent } from './techniques-chart.component';
 import { SummaryCalculationService } from '../../summary-calculation.service';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 describe('TechniquesChartComponent', () => {
   let component: TechniquesChartComponent;
   let fixture: ComponentFixture<TechniquesChartComponent>;
 
-  const serviceMock = { barColors: ['color'], sophisticationNumberToWord: number => 'word'};
+  const serviceMock = {
+    barColors: ['color'], sophisticationNumberToWord: number => 'word', riskSub: new BehaviorSubject<number>(null), techniqueBreakdown: { a: 'b', c: 'd' },
+    renderLegend: () => 'legend stuff'
+  };
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TechniquesChartComponent ],
-      imports: [ ChartsModule ],
+      declarations: [TechniquesChartComponent],
+      imports: [ChartsModule],
       providers: [
         {
           provide: SummaryCalculationService,
@@ -20,13 +24,12 @@ describe('TechniquesChartComponent', () => {
         }
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TechniquesChartComponent);
     component = fixture.componentInstance;
-    component.techniqueBreakdown = [];
     fixture.detectChanges();
   });
 

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
@@ -9,9 +9,6 @@ import { SummaryCalculationService } from '../../summary-calculation.service';
 })
 export class TechniquesChartComponent implements OnInit {
   @Input()
-  public techniqueBreakdown: number[];
-
-  @Input()
   public showLabels: boolean;
   public readonly showLabelsDefault = true;
 
@@ -76,7 +73,9 @@ export class TechniquesChartComponent implements OnInit {
     this.colors = this.summaryCalculationService.barColors;
     this.showLabels = this.showLabels || this.showLabelsDefault;
     this.showLegend = this.showLegend || this.showLegendDefault;
-    this.riskThreshold = this.riskThreshold || this.riskThresholdDefault;
+    this.riskThreshold = this.riskThresholdDefault
+    this.summaryCalculationService.riskSub.subscribe((value: number) => this.renderChart());
+    this.barChartData[0].label = 'At Or Above Mitigation Threshold';
     this.renderChart();
   }
 
@@ -89,36 +88,21 @@ export class TechniquesChartComponent implements OnInit {
       this.riskThreshold = selectedRisk;
     }
     this.renderLabels();
-    this.renderLegend();
+    this.barChartData[0].label = this.summaryCalculationService.renderLegend();
     this.initDataArray();
 
-    const breakdown = Object.keys(this.techniqueBreakdown);
+    const breakdown = Object.keys(this.summaryCalculationService.techniqueBreakdown);
     let index = 0;
     breakdown.forEach((key) => {
-      const val = this.techniqueBreakdown[key];
+      const val = this.summaryCalculationService.techniqueBreakdown[key];
       this.barChartData[0].data[index] = Math.round(val * 100);
       index = index + 1;
     });
   }
 
   public renderLabels(): void {
-    this.barChartLabels = Object.keys(this.techniqueBreakdown)
+    this.barChartLabels = Object.keys(this.summaryCalculationService.techniqueBreakdown)
       .map((level) => this.summaryCalculationService.sophisticationNumberToWord(level));
-  }
-
-  /**
-   * @description
-   *  render legend at top of graph
-   * @returns {void}
-   */
-  public renderLegend(): void {
-    this.barChartData[0].label = 'At Or Above Mitigation Threshold';
-    // TODO
-    // if (this.riskLabelOptions) {
-    //   const option = this.riskLabelOptions.find((opt) => opt.risk === this.riskThreshold);
-    //   const name = option.name;
-    //   this.barChartData[0].label = 'At Or Above ' + name;
-    // }
   }
 
   protected initDataArray(): void {


### PR DESCRIPTION
…values and labels; many unit tests & much coverage added; summary page will update to another assessment when selected from dialog via sidebar

fixes unfetter-discover/unfetter#731

To test: check multiple assessment categories in the summary page; look for right and bottom charts to update when slider is moved.

I could use a double check on the method I used to subscribe to changes on the slider in the technique and assessment charts.