### PR TITLE
fixes unfetter-discover#760

### DIFF
--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { ChartsModule } from 'ng2-charts';
 
 import { SophisticationBreakdownComponent } from './sophistication-breakdown.component';
@@ -7,23 +8,21 @@ import { SummaryCalculationService } from '../../summary-calculation.service';
 
 @Component({
   template: '<sophistication-breakdown [assessedAttackPatterns]="assessedAttackPatternCountBySophisticationLevel"' +
-            '[allAttackPatterns]="totalAttackPatternCountBySophisticationLevel"></sophistication-breakdown>'
+    '[allAttackPatterns]="totalAttackPatternCountBySophisticationLevel"></sophistication-breakdown>'
 })
 class TestHostComponent {
-  assessedAttackPatternCountBySophisticationLevel = {0: 16, 1: 13, 2: 16, 3: 2};
-  totalAttackPatternCountBySophisticationLevel = {0: 29, 1: 30, 2: 34, 3: 4};
+  assessedAttackPatternCountBySophisticationLevel = { 0: 16, 1: 13, 2: 16, 3: 2 };
+  totalAttackPatternCountBySophisticationLevel = { 0: 29, 1: 30, 2: 34, 3: 4 };
 }
 
 describe('SophisticationBreakdownComponent', () => {
-  let component: SophisticationBreakdownComponent;
-  let fixture: ComponentFixture<SophisticationBreakdownComponent>;
   let hostFixture: ComponentFixture<TestHostComponent>;
   let testHostComponent: TestHostComponent;
 
-  const serviceMock = { barColors: ['color'], sophisticationNumberToWord: number => 'word'};
+  const serviceMock = { barColors: ['color'], sophisticationNumberToWord: number => 'word' };
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SophisticationBreakdownComponent, TestHostComponent ],
+      declarations: [SophisticationBreakdownComponent, TestHostComponent],
       imports: [ChartsModule],
       providers: [
         {
@@ -32,7 +31,7 @@ describe('SophisticationBreakdownComponent', () => {
         }
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -45,22 +44,42 @@ describe('SophisticationBreakdownComponent', () => {
     expect(testHostComponent).toBeTruthy();
   });
 
+  it('should generate appropriate values', () => {
+    let component = hostFixture.debugElement.query(By.directive(SophisticationBreakdownComponent)).componentInstance;
+    // how many assessed phases for first sophistication level
+    expect(component.barChartData[0].data[0]).toBe(16);
+
+    // how many unassessed phases for first sophistication level (total - assessed)
+    expect(component.barChartData[1].data[0]).toBe(29 - 16);
+
+    component.assessedAttackPatterns = { 0: 1, 3: 2 };
+    component.allAttackPatterns = { 0: 3, 1: 3, 2: 5, 3: 6 }
+    component.calculateData();
+    expect(component.barChartData[1].data[1]).toBe(3 - 0);
+
+    component.assessedAttackPatterns = { 1: 2 };
+    component.allAttackPatterns = { 0: 29, 1: 30, 2: 34, 3: 4 }
+    component.calculateData();
+    expect(component.barChartData[1].data[1]).toBe(30 - 2);
+
+  });
+
   it('should generate a relevant tooltip', () => {
     expect(SophisticationBreakdownComponent.generateTooltipLabel(null, null)).toBe(0);
     expect(SophisticationBreakdownComponent.generateTooltipLabel({}, null)).toBe(0);
     expect(SophisticationBreakdownComponent.generateTooltipLabel({}, {})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: null}, {})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: ''}, {})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: null})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: []})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0}, {datasets: [{data: null}]})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: null}]})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: []}]})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [null]}]})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [0]}]})).toBe(0);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 0, index: 0}, {datasets: [{data: [1]}]})).toBe(1);
-    expect(SophisticationBreakdownComponent.generateTooltipLabel({datasetIndex: 2, index: 2}, {datasets: [{data: null}, {data: null}, {data: [1, 2, 3]}]})).toBe(3);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: null }, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: '' }, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0 }, {})).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0 }, { datasets: null })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0 }, { datasets: [] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0 }, { datasets: [{ data: null }] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0, index: 0 }, { datasets: [{ data: null }] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0, index: 0 }, { datasets: [{ data: [] }] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0, index: 0 }, { datasets: [{ data: [null] }] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0, index: 0 }, { datasets: [{ data: [0] }] })).toBe(0);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 0, index: 0 }, { datasets: [{ data: [1] }] })).toBe(1);
+    expect(SophisticationBreakdownComponent.generateTooltipLabel({ datasetIndex: 2, index: 2 }, { datasets: [{ data: null }, { data: null }, { data: [1, 2, 3] }] })).toBe(3);
   })
 
 });

--- a/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
+++ b/src/app/assess/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
@@ -79,13 +79,22 @@ export class SophisticationBreakdownComponent implements OnInit {
     this.colors = this.summaryCalculationService.barColors;
     this.barChartLabels = Object.keys(this.allAttackPatterns)
       .map((level) => this.summaryCalculationService.sophisticationNumberToWord(level));
+    this.calculateData();
+  }
 
-    for (const prop in Object.keys(this.assessedAttackPatterns)) {
-      this.barChartData[0].data.push(this.assessedAttackPatterns[prop]);
-    }
+  public calculateData() {
+    let assessedAttackPatternKeys = Object.keys(this.assessedAttackPatterns);
+    let allAttackPatternKeys = Object.keys(this.allAttackPatterns);
 
-    for (const prop in Object.keys(this.allAttackPatterns)) {
-      this.barChartData[1].data.push(this.allAttackPatterns[prop]);
+    this.barChartData[0].data = [];
+    this.barChartData[1].data = [];
+    for (let index = 0; index < allAttackPatternKeys.length; index++) {
+      let assessed = 0;
+      if (assessedAttackPatternKeys.includes(index.toString())) {
+        assessed = this.assessedAttackPatterns[index];
+      }
+      this.barChartData[0].data.push(assessed);
+      this.barChartData[1].data.push(this.allAttackPatterns[index] - assessed);
     }
   }
 }

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.spec.ts
@@ -10,7 +10,7 @@ describe('TechniquesChartComponent', () => {
   let fixture: ComponentFixture<TechniquesChartComponent>;
 
   const serviceMock = {
-    barColors: ['color'], sophisticationNumberToWord: number => 'word', riskSub: new BehaviorSubject<number>(null), techniqueBreakdown: { a: 'b', c: 'd' },
+    barColors: ['color'], sophisticationNumberToWord: number => 'word', riskSub: new BehaviorSubject<number>(null), techniqueBreakdown: { a: '1', c: '.33' },
     renderLegend: () => 'legend stuff'
   };
   beforeEach(async(() => {
@@ -36,4 +36,9 @@ describe('TechniquesChartComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should generate appropriate values', () => {
+    expect(component.barChartData[0].data[0]).toBe(100);
+    expect(component.barChartData[0].data[1]).toBe(33);
+  })
 });

--- a/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
+++ b/src/app/assess/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
@@ -90,11 +90,10 @@ export class TechniquesChartComponent implements OnInit {
     this.renderLabels();
     this.barChartData[0].label = this.summaryCalculationService.renderLegend();
     this.initDataArray();
-
     const breakdown = Object.keys(this.summaryCalculationService.techniqueBreakdown);
     let index = 0;
     breakdown.forEach((key) => {
-      const val = this.summaryCalculationService.techniqueBreakdown[key];
+      const val: number = this.summaryCalculationService.techniqueBreakdown[key];
       this.barChartData[0].data[index] = Math.round(val * 100);
       index = index + 1;
     });

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -183,8 +183,8 @@ describe('SummaryComponent', () => {
 
     component.summary = {
       assessmentMeta: null, created: null, description: null, modified: null, name: null, type: null, version: null, external_references: null,
-      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null, 
-      assessment_objects: [{risk: null, questions: null}]
+      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null,
+      assessment_objects: [{ risk: null, questions: null }]
     }
     component.transformSummary();
     expect(service.setAverageRiskPerAssessedObject).toHaveBeenCalled();
@@ -192,8 +192,8 @@ describe('SummaryComponent', () => {
 
     component.summary = {
       assessmentMeta: null, created: null, description: null, modified: null, name: null, type: null, version: null, external_references: null,
-      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null, 
-      assessment_objects: [{risk: null, questions: []}]
+      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null,
+      assessment_objects: [{ risk: null, questions: [] }]
     }
     component.transformSummary();
     expect(service.setAverageRiskPerAssessedObject).toHaveBeenCalled();
@@ -201,8 +201,8 @@ describe('SummaryComponent', () => {
 
     component.summary = {
       assessmentMeta: null, created: null, description: null, modified: null, name: null, type: null, version: null, external_references: null,
-      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null, 
-      assessment_objects: [{risk: null, questions: [{name: null, risk: null, options: null, selected_value: null}]}]
+      granular_markings: null, pattern: null, kill_chain_phases: null, created_by_ref: null, valid_from: null, labels: null, metaProperties: null,
+      assessment_objects: [{ risk: null, questions: [{ name: null, risk: null, options: null, selected_value: null }] }]
     }
     component.transformSummary();
     expect(service.setAverageRiskPerAssessedObject).toHaveBeenCalled();
@@ -230,8 +230,13 @@ describe('SummaryComponent', () => {
       attackPatternsByAssessedObject: null,
       totalAttackPatternCountBySophisicationLevel: null
     });
-    expect(service.populateAssessmentsGrouping).toHaveBeenCalled();
-    expect(service.populateTechniqueBreakdown).toHaveBeenCalled();
+    expect(service.populateAssessmentsGrouping).toHaveBeenCalledTimes(1);
+    expect(service.populateTechniqueBreakdown).toHaveBeenCalledTimes(1);
+
+    component.summary = null;
+    component.transformSAD();
+    expect(service.populateAssessmentsGrouping).toHaveBeenCalledTimes(1);
+    expect(service.populateTechniqueBreakdown).toHaveBeenCalledTimes(1);
   });
 
   it('should transform Kill Chain Data (KCD)', () => {
@@ -250,12 +255,12 @@ describe('SummaryComponent', () => {
 
   it('should be able to track by an id or an index', () => {
     expect(component.trackByFn(null, null)).toBe(null);
-    expect(component.trackByFn(null, {id: null})).toBe(null);
-    expect(component.trackByFn(null, {id: 3})).toBe(3);
+    expect(component.trackByFn(null, { id: null })).toBe(null);
+    expect(component.trackByFn(null, { id: 3 })).toBe(3);
     // This seems off...
-    expect(component.trackByFn(null, {id: 0})).toBe(null);
+    expect(component.trackByFn(null, { id: 0 })).toBe(null);
     // This seems off...
-    expect(component.trackByFn(3, {id: 0})).toBe(3);
+    expect(component.trackByFn(3, { id: 0 })).toBe(3);
 
   });
 

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -415,7 +415,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
 
   public transformSAD() {
     this.summaryCalculationService.summaryAggregation = this.summaryAggregation;
-    this.summaryCalculationService.populateAssessmentsGrouping(this.summary.assessment_objects);
-    this.summaryCalculationService.populateTechniqueBreakdown(this.summary.assessment_objects);
+    if (this.summary) {
+      this.summaryCalculationService.populateAssessmentsGrouping(this.summary.assessment_objects);
+      this.summaryCalculationService.populateTechniqueBreakdown(this.summary.assessment_objects);
+    }
   }
 }


### PR DESCRIPTION
also adds unit test that highlights the issue and fixes another small problem

Self merging, but to test: view different assessments and see that the unassessed value in the sophistication breakdown graph are the total minus the assessed value. This is on the new assessment summary page (2.0 beta).