### PR TITLE
Issue 779/api security 2

### DIFF
--- a/src/app/assess/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -92,10 +92,11 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
         // Uploaded indicator, COA, or sensor
         const sub = this.assessService
             .genericPost(`api/${convertedObj.type}s`, convertedObj)
+            .map((assessments) => assessments.map((el) => el.attributes))
             .subscribe(
             (assessedRes) => {
-                const newId = assessedRes[0].attributes.id;
-                const createdObj = assessedRes[0].attributes;
+                const newId = assessedRes[0].id;
+                const createdObj = assessedRes[0];
 
                 // create relationship
                 const relationshipObj: any = { type: 'relationship' };
@@ -137,10 +138,10 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
                         .map((question) => question.risk)
                         .reduce((prev, cur) => (prev += cur), 0) / questions.length;
 
-                this.assessment.attributes.assessment_objects.push(
+                this.assessment.assessment_objects.push(
                     tempAssessmentObject
                 );
-                const assessmentToUpload: any = this.assessment.attributes;
+                const assessmentToUpload: any = this.assessment;
                 assessmentToUpload.modified = new Date().toISOString();
                 const sub2 = this.assessService
                     .genericPatch(`${Constance.X_UNFETTER_ASSESSMENT_URL}/${this.assessment.id}`, assessmentToUpload)

--- a/src/app/assess/result/store/riskbyattackpattern.actions.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.actions.ts
@@ -10,6 +10,7 @@ export const LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA = '[Assess Risk 
 // For reducers
 export const SET_RISK_BY_ATTACK_PATTERNS = '[Assess Risk By Attack Pattern] SET_RISK_BY_ATTACK_PATTERN_DATA';
 export const FINISHED_LOADING = '[Assess Risk By Attack Pattern] FINISHED_LOADING';
+export const CLEAN_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA = '[Assess Risk By Attack Pattern] CLEAN_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA';
 
 export class LoadSingleAssessmentRiskByAttackPatternData implements Action {
     public readonly type = LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA;
@@ -37,7 +38,13 @@ export class FinishedLoading implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class CleanAssessmentRiskByAttackPatternData implements Action {
+    // CLEAN_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA
+    public readonly type = CLEAN_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA;
+}
+
 export type RiskByAttackPatternActions =
+    CleanAssessmentRiskByAttackPatternData |
     SetRiskByAttackPattern |
     LoadAssessmentRiskByAttackPatternData |
     LoadSingleAssessmentRiskByAttackPatternData |

--- a/src/app/assess/result/store/riskbyattackpattern.reducers.ts
+++ b/src/app/assess/result/store/riskbyattackpattern.reducers.ts
@@ -23,6 +23,8 @@ const initialState: RiskByAttackPatternState = genState();
 
 export function riskByAttackPatternReducer(state = initialState, action: riskByAttackPatternActions.RiskByAttackPatternActions): RiskByAttackPatternState {
     switch (action.type) {
+        case riskByAttackPatternActions.CLEAN_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA:
+            return genState();
         case riskByAttackPatternActions.LOAD_SINGLE_ASSESSMENT_RISK_BY_ATTACK_PATTERN_DATA:
             return genState({
                 ...state,

--- a/src/app/assess/result/store/summary.effects.ts
+++ b/src/app/assess/result/store/summary.effects.ts
@@ -33,8 +33,19 @@ export class SummaryEffects {
     public fetchSingleAssessmentSummaryData = this.actions$
         .ofType(LOAD_SINGLE_ASSESSMENT_SUMMARY_DATA)
         .pluck('payload')
-        .switchMap((assessmentId: string) => this.assessService.getById(assessmentId))
-        .mergeMap((data: Assessment) => [new SetAssessments([data]), new FinishedLoading(true)])
+        .switchMap((assessmentId: string) => {
+            return this.assessService
+                .getById(assessmentId)
+                .catch((ex) => Observable.of({}));
+        })
+        .mergeMap((data: Assessment) => {
+            console.log(data);
+            const actions = [new FinishedLoading(true)];
+            if (!data || !data.id) {
+                return actions
+            }
+            return [new SetAssessments([data]), ...actions];
+        });
 
     @Effect()
     public fetchAssessmentSummaryData = this.actions$

--- a/src/app/assess/result/store/summary.effects.ts
+++ b/src/app/assess/result/store/summary.effects.ts
@@ -39,7 +39,6 @@ export class SummaryEffects {
                 .catch((ex) => Observable.of({}));
         })
         .mergeMap((data: Assessment) => {
-            console.log(data);
             const actions = [new FinishedLoading(true)];
             if (!data || !data.id) {
                 return actions

--- a/src/app/assess/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.spec.ts
@@ -351,6 +351,54 @@ describe('SummaryCalculationService', () => {
     expect(service.assessmentsGroupingTotal).toEqual({ 'happy camper': 2 });
   }));
 
+  it('should populate technique breakdown groupings given an array of asssesment objects', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    service.summaryAggregation = null;
+    service.populateTechniqueBreakdown(null);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.populateTechniqueBreakdown([]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.populateTechniqueBreakdown([{ risk: null, questions: null }]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: null, totalAttackPatternCountBySophisicationLevel: null };
+    service.populateTechniqueBreakdown([]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.populateTechniqueBreakdown([{ risk: null, questions: null }]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: null, attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateTechniqueBreakdown([]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.populateTechniqueBreakdown([{ risk: null, questions: null }]);
+    expect(service.techniqueBreakdown).toEqual({});
+    service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: { index: null, count: null }, attackPatternsByAssessedObject: [{ _id: null, attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
+    service.populateTechniqueBreakdown([]);
+    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    service.populateTechniqueBreakdown([{ risk: null, questions: null }]);
+    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: { index: null, count: null },
+      attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
+    };
+    service.populateTechniqueBreakdown([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }], created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    service.summaryAggregation = {
+      assessedAttackPatternCountBySophisicationLevel: { index: 0, count: 3 },
+      attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
+    };
+    service.populateTechniqueBreakdown([{
+      risk: .25, questions: null, stix: {
+        id: 'an id', metaProperties: null, created: null, modified: null, version: null, external_references: null,
+        granular_markings: null, name: null, description: null, pattern: null, kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }], created_by_ref: null, type: null, valid_from: null, labels: null
+      }
+    }]);
+    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+
+  }));
+
   it('should capitalize all words except for and, or, of, on, and the', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
     expect(service.capitalizeWithExceptions(null, null, null)).toBe(null);
     expect(service.capitalizeWithExceptions('and', null, null)).toBe('and');

--- a/src/app/assess/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/result/summary/summary-calculation.service.ts
@@ -278,7 +278,8 @@ export class SummaryCalculationService {
    */
   public populateTechniqueBreakdown(assessmentObjects: AssessmentObject[]): void {
 
-    if (assessmentObjects && this.summaryAggregation) {
+    this.techniqueBreakdown = {};
+    if (assessmentObjects && this.summaryAggregation && this.summaryAggregation.attackPatternsByAssessedObject && this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel) {
       this.assessmentObjects = assessmentObjects;
       // Total assessed objects to calculated risk
       const assessedRiskMapping = this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel;
@@ -302,7 +303,6 @@ export class SummaryCalculationService {
         ++attackPatternSetMap[curAp['x_unfetter_sophistication_level']];
       });
 
-      this.techniqueBreakdown = {};
       for (const prop in Object.keys(assessedRiskMapping)) {
         if (attackPatternSetMap[prop] === undefined) {
           this.techniqueBreakdown[prop] = 0;

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -1,4 +1,4 @@
-<div id="newAssessmentsSummary" *ngIf="finishedLoading && finishedLoadingRBAP && finishedLoadingKCD && finishedLoadingSAD === true; else loadingBlock" class="fadeIn">
+<div id="newAssessmentsSummary" *ngIf="finishedLoading === true; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="summary !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">

--- a/src/app/assess/result/summary/summary.component.spec.ts
+++ b/src/app/assess/result/summary/summary.component.spec.ts
@@ -261,7 +261,14 @@ describe('SummaryComponent', () => {
     expect(component.trackByFn(null, { id: 0 })).toBe(null);
     // This seems off...
     expect(component.trackByFn(3, { id: 0 })).toBe(3);
+  });
 
+  it('should set all loading flags to done', () => {
+    component.setLoadingToDone();
+    expect(component.finishedLoading).toBe(true);
+    expect(component.finishedLoadingKCD).toBe(true);
+    expect(component.finishedLoadingRBAP).toBe(true);
+    expect(component.finishedLoadingSAD).toBe(true);
   });
 
 });

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -416,9 +416,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
    * @returns {void}
    */
   public transformSAD(): void {
-    if (!this.summary) {
-      return;
-    }
     this.summaryCalculationService.summaryAggregation = this.summaryAggregation;
     if (this.summary) {
       this.summaryCalculationService.populateAssessmentsGrouping(this.summary.assessment_objects);
@@ -427,7 +424,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description set all the flags to finsihd loadin
+   * @description set all the flags to finished loading
    * @returns {void}
    */
   public setLoadingToDone(): void {


### PR DESCRIPTION
supports unfetter-discover/unfetter#779
fixes unfetter-discover/unfetter#814
supports unfetter-discover/unfetter#811

This PR also includes a partial fix for add new assessment object from results page.

## To Test
* Pull this feature branch
* visit an assessment summary page
* in the url, change the id, hit enter
* verify you see a not found page
* change your orgs for the current user in by editing mongo
* refresh the page w/ a known good id, verify a not found page since the data is now protected
* verify the same is true for the assessments results page