### PR TITLE
added temporary fix for assessments naming

### DIFF
--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -147,7 +147,26 @@ export class FullComponent implements OnInit, OnDestroy {
         if (!arr || arr.length === 0) {
           return '';
         }
-        return arr[0].name;
+        if (arr[0].assessment_objects && arr[0].assessment_objects.length) {
+          let retVal = arr[0].name + ' - ';
+          const assessedType = arr[0].assessment_objects[0].stix.type;
+          // NOTE this is a temporary fix for naming in rollupId
+          // TODO remove this when a better fix is in place
+          switch (assessedType) {
+            case 'course-of-action':
+              retVal += 'Mitigations';
+              break;
+            case 'indicator':
+              retVal += 'Indicators';
+              break;
+            case 'x-unfetter-sensor':
+              retVal += 'Sensors';
+              break;
+          }
+          return retVal;
+        } else {
+          return arr[0].name;
+        }
       });
 
     this.subscriptions.push(sub1$, sub2$, sub3$);

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -235,7 +235,27 @@ export class SummaryComponent implements OnInit, OnDestroy {
         if (!summaries || summaries.length === 0) {
           return '';
         }
-        return summaries[0].name;
+        console.log(summaries);
+        if (summaries[0].assessment_objects && summaries[0].assessment_objects.length) {
+          let retVal = summaries[0].name + ' - ';
+          const assessedType = summaries[0].assessment_objects[0].stix.type;
+          // NOTE this is a temporary fix for naming in rollupId
+          // TODO remove this when a better fix is in place
+          switch (assessedType) {
+            case 'course-of-action':
+              retVal += 'Mitigations';
+              break;
+            case 'indicator':
+              retVal += 'Indicators';
+              break;
+            case 'x-unfetter-sensor':
+              retVal += 'Sensors';
+              break;
+          }
+          return retVal;
+        } else {
+          return summaries[0].name;
+        }
       });
 
     this.subscriptions.push(sub1$, sub2$, sub3$, sub4$, sub5$, sub6$, sub7$, sub8$);

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -235,7 +235,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
         if (!summaries || summaries.length === 0) {
           return '';
         }
-        console.log(summaries);
         if (summaries[0].assessment_objects && summaries[0].assessment_objects.length) {
           let retVal = summaries[0].name + ' - ';
           const assessedType = summaries[0].assessment_objects[0].stix.type;


### PR DESCRIPTION
Requirements:

`assessmentsLatestNameFix` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/109

Instructions: Load assessments master list, each assessment should have its type identified in the title.

Additionally, the summary page should show the assessment type in title as well.