### PR TITLE
Issue 811/add assessment object

### DIFF
--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -61,7 +61,7 @@
     <mat-sidenav-content>
       <div class="main-panel">
         <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="(assessment|async)?.created"></result-header>
-        <unf-assess-group #assessGroupMain [activePhase]="phase" [rollupId]="rollupId" [assessment]="(assessment|async)" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)"></unf-assess-group>
+        <unf-assess-group #assessGroupMain [assessmentGroup]="assessmentGroup" [activePhase]="phase" [rollupId]="rollupId" [assessment]="(assessment|async)" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)"></unf-assess-group>
       </div>
     </mat-sidenav-content>
   </mat-sidenav-container>

--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="finishedLoading === true; else loadingBlock" class="fadeIn">
-  <mat-sidenav-container *ngIf="assessment !== undefined; else notFound">
+<div *ngIf="(finishedLoading|async) === true; else loadingBlock" class="fadeIn">
+  <mat-sidenav-container *ngIf="(assessment|async) !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
 
@@ -60,8 +60,8 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="assessment?.created"></result-header>
-        <unf-assess-group #assessGroupMain [activePhase]="phase" [rollupId]="rollupId" [assessment]="assessment" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)"></unf-assess-group>
+        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="(assessment|async)?.created"></result-header>
+        <unf-assess-group #assessGroupMain [activePhase]="phase" [rollupId]="rollupId" [assessment]="(assessment|async)" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)"></unf-assess-group>
       </div>
     </mat-sidenav-content>
   </mat-sidenav-container>

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -21,6 +21,7 @@ import { AssessedByAttackPattern } from './group/models/assessed-by-attack-patte
 import { Constance } from '../../../utils/constance';
 import { RiskByAttackPattern } from './group/models/risk-by-attack-pattern';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
+import { FullAssessmentGroup } from './group/models/full-assessment-group';
 
 @Component({
   selector: 'unf-assess-full',
@@ -34,7 +35,7 @@ export class FullComponent implements OnInit, OnDestroy {
   assessmentTypes: Observable<Assessment[]>;
   assessment: Observable<Assessment>;
   assessmentName: Observable<string>;
-  assessmentGroup: Observable<any>;
+  assessmentGroup: Observable<FullAssessmentGroup>;
   rollupId: string;
   assessmentId: string;
   phase: string;
@@ -119,7 +120,7 @@ export class FullComponent implements OnInit, OnDestroy {
 
     this.assessmentGroup = this.store
       .select('fullAssessment')
-      .pluck('group')
+      .pluck<object, FullAssessmentGroup>('group')
       .distinctUntilChanged();
 
     const sub$ = this.store

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -34,6 +34,7 @@ export class FullComponent implements OnInit, OnDestroy {
   assessmentTypes: Observable<Assessment[]>;
   assessment: Observable<Assessment>;
   assessmentName: Observable<string>;
+  assessmentGroup: Observable<any>;
   rollupId: string;
   assessmentId: string;
   phase: string;
@@ -109,11 +110,16 @@ export class FullComponent implements OnInit, OnDestroy {
       .pluck<object, Assessment[]>('assessmentTypes')
       .distinctUntilChanged()
       .filter((arr) => arr && arr.length > 0)
-      .map((arr) => arr[0])
+      .map((arr) => arr[0]);
 
     this.finishedLoading = this.store
       .select('fullAssessment')
       .pluck<Assessment, boolean>('finishedLoading')
+      .distinctUntilChanged();
+
+    this.assessmentGroup = this.store
+      .select('fullAssessment')
+      .pluck('group')
       .distinctUntilChanged();
 
     const sub$ = this.store
@@ -138,12 +144,10 @@ export class FullComponent implements OnInit, OnDestroy {
 
     this.assessmentName = this.store
       .select('fullAssessment')
-      .pluck('assessmentTypes')
+      .pluck<object, Assessment[]>('assessmentTypes')
+      .filter((arr) => arr && arr.length > 0)
       .distinctUntilChanged()
       .map((arr: Assessment[]) => {
-        if (!arr || arr.length === 0) {
-          return '';
-        }
         if (arr[0].assessment_objects && arr[0].assessment_objects.length) {
           let retVal = arr[0].name + ' - ';
           const assessedType = arr[0].assessment_objects[0].stix.type;

--- a/src/app/assess/result/full/group/assessments-group.component.html
+++ b/src/app/assess/result/full/group/assessments-group.component.html
@@ -72,7 +72,7 @@
                 <unf-add-assessed-object #addAssessedObjectComponent *ngIf="assessment" [assessment]="assessment" [addAssessedObject]="addAssessedObject"
                     [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [indicator]="indicator"
                     [courseOfAction]="courseOfAction" [xUnfetterSensor]="xUnfetterSensor" [displayedAssessedObjects]="displayedAssessedObjects"
-                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? requestDataLoad(assessmentId) : 0"></unf-add-assessed-object>
+                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment(assessmentId) : 0"></unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
                     <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'">

--- a/src/app/assess/result/full/group/assessments-group.component.html
+++ b/src/app/assess/result/full/group/assessments-group.component.html
@@ -72,7 +72,7 @@
                 <unf-add-assessed-object #addAssessedObjectComponent *ngIf="assessment" [assessment]="assessment" [addAssessedObject]="addAssessedObject"
                     [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [indicator]="indicator"
                     [courseOfAction]="courseOfAction" [xUnfetterSensor]="xUnfetterSensor" [displayedAssessedObjects]="displayedAssessedObjects"
-                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? initData() : 0"></unf-add-assessed-object>
+                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? requestDataLoad(assessmentId) : 0"></unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
                     <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'">

--- a/src/app/assess/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/result/full/group/assessments-group.component.ts
@@ -16,10 +16,11 @@ import { DisplayedAssessmentObject } from './models/displayed-assessment-object'
 import { FormatHelpers } from '../../../../global/static/format-helpers';
 import { Stix } from '../../../../models/stix/stix';
 import { SortHelper } from '../../../../global/static/sort-helper';
-import { FullAssessmentResultState, FullAssessmentGroupState } from '../../store/full-result.reducers';
+import { FullAssessmentResultState } from '../../store/full-result.reducers';
 import { LoadGroupData, LoadGroupCurrentAttackPattern, PushUrl, LoadGroupAttackPatternRelationships, UpdateAssessmentObject } from '../../store/full-result.actions';
 import { RiskByAttack } from '../../../../models/assess/risk-by-attack';
 import { Relationship } from '../../../../models';
+import { FullAssessmentGroup } from './models/full-assessment-group';
 
 @Component({
   selector: 'unf-assess-group',
@@ -44,7 +45,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public initialAttackPatternId: string;
 
   @Input()
-  public assessmentGroup: Observable<any>;
+  public assessmentGroup: Observable<FullAssessmentGroup>;
 
   @Output('riskByAttackPatternChanged')
   public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
@@ -149,13 +150,13 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public listenForDataChanges(attackPatternIndex: number = 0): void {
     const sub1$ = this.assessmentGroup
       .distinctUntilChanged()
-      .filter((group: any) => {
+      .filter((group: FullAssessmentGroup) => {
         // TODO: stop an infinite loop of network requests
         //  figure out a better way to short circuit
         return group.finishedLoadingGroupData === true
           && this.displayedAssessedObjects === undefined;
       })
-      .subscribe((group: FullAssessmentGroupState) => {
+      .subscribe((group: FullAssessmentGroup) => {
         // initialize the displayed assessed objects, 
         //  used also to stop loop of network calls
         this.displayedAssessedObjects = [];
@@ -172,7 +173,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
         (err) => console.log(err));
 
     const sub3$ = this.assessmentGroup
-      .filter((group: any) => group.finishedLoadingGroupData === true)
+      .filter((group: FullAssessmentGroup) => group.finishedLoadingGroupData === true)
       .pluck('attackPatternRelationships')
       .distinctUntilChanged()
       .subscribe((relationships: Relationship[]) => {

--- a/src/app/assess/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/result/full/group/assessments-group.component.ts
@@ -121,7 +121,15 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     this.assessment = this.assessment || new Assessment();
     this.listenForDataChanges(attackPatternIndex);
     // request for initial data changes
-    this.store.dispatch(new LoadGroupData(this.assessmentId));
+    this.requestDataLoad(this.assessmentId);
+  }
+  
+  /**
+   * @description request data
+   * @returns {void}
+   */
+  public requestDataLoad(assessmentId: string): void {
+    this.store.dispatch(new LoadGroupData(assessmentId));
   }
 
   /**

--- a/src/app/assess/result/full/group/assessments-groups.component.spec.ts
+++ b/src/app/assess/result/full/group/assessments-groups.component.spec.ts
@@ -3,23 +3,26 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { MatDialogModule } from '@angular/material';
 import { StoreModule, ActionReducerMap } from '@ngrx/store';
+
+import { GenericApi } from '../../../../core/services/genericapi.service';
+import { GlobalModule } from '../../../../global/global.module';
+import { FullAssessmentResultState, fullAssessmentResultReducer, genState } from '../../store/full-result.reducers';
 
 import { Assessment } from '../../../../models/assess/assessment';
 import { AssessAttackPatternMeta } from '../../../../models/assess/assess-attack-pattern-meta';
 import { AssessAttackPatternMetaMockFactory } from '../../../../models/assess/assess-attack-pattern-meta.mock';
 import { AssessGroupComponent } from './assessments-group.component';
 import { AssessService } from '../../../services/assess.service';
-
-import { FullAssessmentResultState, fullAssessmentResultReducer, genState } from '../../store/full-result.reducers';
-import { GenericApi } from '../../../../core/services/genericapi.service';
-import { GlobalModule } from '../../../../global/global.module';
+import { AddAssessedObjectComponent } from './add-assessed-object/add-assessed-object.component';
+import { AssessmentObjectMockFactory } from '../../../../models/assess/assessment-object.mock';
 import { Phase } from '../../../../models/assess/phase';
 import { RiskByAttack } from '../../../../models/assess/risk-by-attack';
 import { RiskByAttackPatternMockFactory } from '../../../../models/assess/risk-by-attack-pattern.mock';
 import { SummaryCalculationService } from '../../summary/summary-calculation.service';
-import { AssessmentObjectMockFactory } from '../../../../models/assess/assessment-object.mock';
+import { FullAssessmentGroupMockFactory } from './models/full-assessment-group.mock';
 
 describe('AssessGroupComponent', () => {
   let component: AssessGroupComponent;
@@ -36,8 +39,10 @@ describe('AssessGroupComponent', () => {
 
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
-      declarations: [AssessGroupComponent],
-
+      declarations: [
+        AddAssessedObjectComponent,
+        AssessGroupComponent
+      ],
       imports: [
         RouterTestingModule,
         HttpClientTestingModule,
@@ -59,6 +64,7 @@ describe('AssessGroupComponent', () => {
     fixture = TestBed.createComponent(AssessGroupComponent);
     component = fixture.componentInstance;
     component.assessment = new Assessment();
+    component.assessmentGroup = new BehaviorSubject(FullAssessmentGroupMockFactory.mockOne()).asObservable();
     fixture.detectChanges();
   });
 

--- a/src/app/assess/result/full/group/models/assessed-by-attack-pattern.mock.ts
+++ b/src/app/assess/result/full/group/models/assessed-by-attack-pattern.mock.ts
@@ -1,0 +1,13 @@
+import { AssessedByAttackPattern } from './assessed-by-attack-pattern';
+import { Mock } from '../../../../../models/mock';
+
+export class AssessedByAttackPatternMock extends Mock<AssessedByAttackPattern> {
+    public mockOne(): AssessedByAttackPattern {
+        const tmp = new AssessedByAttackPattern();
+        tmp._id = this.genId();
+        tmp.assessedObjects = [];
+        tmp.risk = Math.random() * 100;
+        return tmp;
+    }
+}
+export const AssessedByAttackPatternMockFactory = new AssessedByAttackPatternMock();

--- a/src/app/assess/result/full/group/models/displayed-assessment-objects.mock.ts
+++ b/src/app/assess/result/full/group/models/displayed-assessment-objects.mock.ts
@@ -1,0 +1,13 @@
+import { AssessmentObjectMockFactory } from '../../../../../models/assess/assessment-object.mock';
+import { DisplayedAssessmentObject } from './displayed-assessment-object';
+import { Mock } from '../../../../../models/mock';
+
+export class DisplayedAssessmentObjectMock extends Mock<DisplayedAssessmentObject> {
+    public mockOne(): DisplayedAssessmentObject {
+        const el = AssessmentObjectMockFactory.mockOne();
+        const tmp = Object.assign(new DisplayedAssessmentObject(), el);
+        tmp.editActive = false;
+        return tmp;
+    }
+}
+export const DisplayedAssessmentObjectMockFactory = new DisplayedAssessmentObjectMock();

--- a/src/app/assess/result/full/group/models/full-assessment-group.mock.ts
+++ b/src/app/assess/result/full/group/models/full-assessment-group.mock.ts
@@ -1,0 +1,25 @@
+import { FullAssessmentGroup } from './full-assessment-group';
+import { StixMockFactory } from '../../../../../models/stix/stix-mock';
+import { RiskByAttackPatternMockFactory } from '../../../../../models/assess/risk-by-attack-pattern.mock';
+import { AssessmentObjectMockFactory } from '../../../../../models/assess/assessment-object.mock';
+import { DisplayedAssessmentObjectMockFactory } from './displayed-assessment-objects.mock';
+import { Mock } from '../../../../../models/mock';
+
+export class FullAssessmentGroupMock extends Mock<FullAssessmentGroup> {
+    public mockOne(): FullAssessmentGroup {
+        const tmp = new FullAssessmentGroup();
+        tmp.finishedLoadingGroupData = false;
+        tmp.currentAttackPattern = StixMockFactory.mockOne();
+        tmp.riskByAttackPattern = RiskByAttackPatternMockFactory.mockOne();
+        tmp.assessedObjects = AssessmentObjectMockFactory.mockMany();
+        tmp.unassessedPhases = [];
+        tmp.displayedAssessedObjects = DisplayedAssessmentObjectMockFactory.mockMany();
+        tmp.unassessedAttackPatterns = [];
+        tmp.attackPatternsByPhase = [];
+        tmp.addAssessedObject = false;
+        tmp.addAssessedType = '';
+        tmp.attackPatternRelationships = [];
+        return tmp;
+    }
+}
+export const FullAssessmentGroupMockFactory = new FullAssessmentGroupMock();

--- a/src/app/assess/result/full/group/models/full-assessment-group.ts
+++ b/src/app/assess/result/full/group/models/full-assessment-group.ts
@@ -1,0 +1,19 @@
+import { AssessmentObject } from '../../../../../models/assess/assessment-object';
+import { DisplayedAssessmentObject } from './displayed-assessment-object';
+import { Relationship } from '../../../../../models/relationship';
+import { RiskByAttack } from '../../../../../models/assess/risk-by-attack';
+import { Stix } from '../../../../../models/stix/stix';
+
+export class FullAssessmentGroup {
+    finishedLoadingGroupData: boolean;
+    currentAttackPattern: Stix;
+    riskByAttackPattern: RiskByAttack;
+    assessedObjects: AssessmentObject[];
+    unassessedPhases: string[];
+    displayedAssessedObjects: DisplayedAssessmentObject[];
+    unassessedAttackPatterns: Stix[];
+    attackPatternsByPhase: any[];
+    addAssessedObject: boolean;
+    addAssessedType: string;
+    attackPatternRelationships: Relationship[];
+}

--- a/src/app/assess/result/store/full-result.reducers.ts
+++ b/src/app/assess/result/store/full-result.reducers.ts
@@ -7,29 +7,16 @@ import { FullAssessmentResultActions, LOAD_ASSESSMENT_RESULT_DATA } from './full
 import { Stix } from '../../../models/stix/stix';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 import { Relationship } from '../../../models';
+import { FullAssessmentGroup } from '../full/group/models/full-assessment-group';
 
 export interface FullAssessmentResultState {
     fullAssessment: Assessment;
     assessmentTypes: Assessment[];
     finishedLoading: boolean;
-    group: FullAssessmentGroupState;
+    group: FullAssessmentGroup;
 };
 
-export interface FullAssessmentGroupState {
-    finishedLoadingGroupData: boolean;
-    currentAttackPattern: Stix;
-    riskByAttackPattern: RiskByAttack;
-    assessedObjects: AssessmentObject[];
-    unassessedPhases: string[];
-    displayedAssessedObjects: DisplayedAssessmentObject[];
-    unassessedAttackPatterns: Stix[];
-    attackPatternsByPhase: any[];
-    addAssessedObject: boolean;
-    addAssessedType: string;
-    attackPatternRelationships: Relationship[];
-}
-
-export const genGroupState = (state?: Partial<FullAssessmentGroupState>) => {
+export const genGroupState = (state?: Partial<FullAssessmentGroup>) => {
     const tmp = {
         finishedLoadingGroupData: false,
         currentAttackPattern: new Stix(),


### PR DESCRIPTION
fixes unfetter-discover/unfetter#823
fixes unfetter-discover/unfetter#811

## To test
* Visit an assessments page
* Click the results tab
* Add an new assessed object on the right
 * Verify it is added on the screen, and all the scores refresh
* Edit an assessed object
 * Verify the scores refresh on across the page
* Be careful of this known issue, when the scores refresh the page, the attack patterns will be reordered and the page will refresh with the previous index but under the new order
* Click around make sure everything updates and works
* Also be sure to try the delete buttons