### PR TITLE
++clear state, --logging

### DIFF
--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -71,7 +71,6 @@ export class FullComponent implements OnInit, OnDestroy {
     const idParamSub$ = this.route.params
       .distinctUntilChanged()
       .subscribe((params) => {
-        console.log('router params changed, updating component id state');
         this.rollupId = params.rollupId || '';
         this.assessmentId = params.assessmentId || '';
         this.phase = params.phase || '';
@@ -88,10 +87,10 @@ export class FullComponent implements OnInit, OnDestroy {
             (err) => console.log(err));
         this.subscriptions.push(sub$);
       },
-        (err) => console.log(err),
-        () => idParamSub$.unsubscribe());
+        (err) => console.log(err));
 
     this.listenForDataChanges();
+    this.subscriptions.push(idParamSub$);
   }
 
   /**
@@ -194,7 +193,6 @@ export class FullComponent implements OnInit, OnDestroy {
   public ngOnDestroy(): void {
     this.subscriptions
       .filter((el) => el !== undefined)
-      .filter((el) => !el.closed)
       .forEach((sub) => sub.unsubscribe());
     this.store.dispatch(new CleanAssessmentResultData());
   }
@@ -213,10 +211,15 @@ export class FullComponent implements OnInit, OnDestroy {
    * @return {Promise<boolean>}
    */
   public onEdit(event?: any): Promise<boolean> {
+    let routePromise: Promise<boolean>;
     if (!event || (event instanceof UIEvent)) {
-      return this.router.navigate([this.masterListOptions.modifyRoute, this.rollupId]);
+      routePromise = this.router.navigate([this.masterListOptions.modifyRoute, this.rollupId]);
+    } else {
+      routePromise = this.router.navigate([this.masterListOptions.modifyRoute, event.rollupId]);
     }
-    return this.router.navigate([this.masterListOptions.modifyRoute, event.rollupId]);
+
+    routePromise.catch((e) => console.log(e));
+    return routePromise;
   }
 
   /**

--- a/src/app/assess/result/full/group/assessments-group.component.scss
+++ b/src/app/assess/result/full/group/assessments-group.component.scss
@@ -24,8 +24,8 @@
     line-height: 1.9em;
     margin-left: -24px;
     margin-right: -24px;
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-left: 16px;
+    padding-right: 16px;
 
     &:hover {
         background-color: $assessments-primary;

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -92,7 +92,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
     const idParamSub$ = this.route.params
       .distinctUntilChanged()
       .subscribe((params) => {
-        console.log('router params changed, updating component id state');
         this.rollupId = params.rollupId || '';
         this.assessmentId = params.assessmentId || '';
         this.summary = undefined;
@@ -114,9 +113,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
             (err) => console.log(err));
         this.subscriptions.push(sub$);
       },
-        (err) => console.log(err),
-        () => idParamSub$.unsubscribe());
+        (err) => console.log(err));
     this.listenForDataChanges();
+    this.subscriptions.push(idParamSub$);
   }
 
   /**
@@ -280,7 +279,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
   public ngOnDestroy(): void {
     this.subscriptions
       .filter((el) => el !== undefined)
-      .filter((el) => !el.closed)
       .forEach((sub) => sub.unsubscribe());
     this.store.dispatch(new CleanAssessmentResultData());
     this.riskByAttackPatternStore.dispatch(new CleanAssessmentRiskByAttackPatternData());
@@ -300,10 +298,15 @@ export class SummaryComponent implements OnInit, OnDestroy {
    * @return {Promise<boolean>}
    */
   public onEdit(event?: any): Promise<boolean> {
+    let routePromise: Promise<boolean>;
     if (!event || (event instanceof UIEvent)) {
-      return this.router.navigate([this.masterListOptions.modifyRoute, this.rollupId]);
+      routePromise = this.router.navigate([this.masterListOptions.modifyRoute, this.rollupId]);
+    } else {
+      routePromise = this.router.navigate([this.masterListOptions.modifyRoute, event.rollupId]);
     }
-    return this.router.navigate([this.masterListOptions.modifyRoute, event.rollupId]);
+
+    routePromise.catch((e) => console.log(e));
+    return routePromise;
   }
 
   /**

--- a/src/app/assess/store/assess.actions.ts
+++ b/src/app/assess/store/assess.actions.ts
@@ -10,6 +10,7 @@ export const START_ASSESSMENT = '[Assess] START_ASSESSMENT';
 export const START_ASSESSMENT_SUCCESS = '[Assess] START_ASSESSMENT_SUCCESS';
 export const SAVE_ASSESSMENT = '[Assess] SAVE_ASSESSMENT';
 export const LOAD_ASSESSMENT_WIZARD_DATA = '[Assess] LOAD_ASSESSMENT_WIZARD_DATA';
+export const CLEAN_ASSESSMENT_WIZARD_DATA = '[Assess] CLEAN_ASSESSMENT_WIZARD_DATA';
 export const FETCH_ASSESSMENT = '[Assess] FETCH_ASSESSMENT';
 
 // For reducers
@@ -98,8 +99,15 @@ export class WizardPage implements Action {
     constructor(public payload: number) { }
 }
 
+export class CleanAssessmentWizardData {
+    public readonly type = CLEAN_ASSESSMENT_WIZARD_DATA;
+
+    constructor() { }
+}
+
 export type AssessmentActions =
     AnswerQuestion |
+    CleanAssessmentWizardData |
     FetchAssessment |
     FinishedLoading |
     FinishedSaving |

--- a/src/app/assess/store/assess.reducers.ts
+++ b/src/app/assess/store/assess.reducers.ts
@@ -39,6 +39,8 @@ const initialState: AssessState = genAssessState();
 
 export function assessmentReducer(state = initialState, action: assessmentActions.AssessmentActions): AssessState {
     switch (action.type) {
+        case assessmentActions.CLEAN_ASSESSMENT_WIZARD_DATA:
+            return genAssessState();
         case assessmentActions.FETCH_ASSESSMENT:
             return genAssessState({
                 ...state,

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -18,7 +18,7 @@ import { Constance } from '../../utils/constance';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { Measurements } from './measurements';
 import { MenuItem } from 'primeng/primeng';
-import { LoadAssessmentWizardData, SaveAssessment, UpdatePageTitle } from '../store/assess.actions';
+import { LoadAssessmentWizardData, SaveAssessment, UpdatePageTitle, CleanAssessmentWizardData } from '../store/assess.actions';
 import { Assessment } from '../../models/assess/assessment';
 import { Stix } from '../../models/stix/stix';
 import { Indicator } from '../../models/stix/indicator';
@@ -140,8 +140,6 @@ export class WizardComponent extends Measurements implements OnInit, OnDestroy {
    *  initializes this component, fetchs data to build page
    */
   public ngOnInit(): void {
-    console.log('in wizard component');
-
     const idParamSub$ = this.route.params
       .subscribe(
         (params) => {
@@ -329,6 +327,7 @@ export class WizardComponent extends Measurements implements OnInit, OnDestroy {
    *  cleans up this component, unsubscribes to data
    */
   public ngOnDestroy(): void {
+    this.wizardStore.dispatch(new CleanAssessmentWizardData());
     this.subscriptions.forEach((sub) => sub.unsubscribe());
   }
 


### PR DESCRIPTION
clearing state in assessments

#To Test
* this is hard to reproduce
* create two assessments, both sensors, the first called 'A', the second called 'B'
* visit the summary page
* click the master list, selected around
* click across the results and summary tabs
* end up on the summary tab
* select edit from the vertical ellipsis on the top right side panel
 * sometimes the wizard might show the wrong assessment?
 * sometimes the edit will not route to the wizard but reroute back to the summary page
 * lots of times it works as expected

I am hoping this improves things.  I suspect there might have been another error that put the app in a bad state. Still this clean up should help