### PR TITLE
added run mode to api explorer link

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -36,7 +36,7 @@
           </a>
         </span>
         <span class="appLinkWrapper">
-          <a href="{{ swaggerUrl }}?token={{ encodedToken }}" target=_blank class="appLink">
+          <a href="{{ swaggerUrl }}?token={{ encodedToken }}&RUN_MODE={{ runMode }}" target=_blank class="appLink">
             <img src="{{ apiDocsIcon }}" class="appItemImg">
             <div class="appItemText">API Explorer</div>
           </a>


### PR DESCRIPTION
fixes unfetter-discover/unfetter#831

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/111

Requires `issue-831` on `unfetter-ui` and `unfetter-store`

Instructions:

- Stop stack, delete containers, `docker rmi unfetter-api explorer`
- Restart stack
- Confirm API explorer works as intended (assuming UAC mode)
- Stop stack
- (Temporarily) Edit `docker-compose.development.yml` to use `DEMO` mode, including changing `unfetter-ui` entrypoint to `serve:docker:dev:demo`
- Restart stack
- Confirm API explorer works in demo mode

Cleanup:

- Undo `docker-compose.development.yml` changes, restart stack
