### PR TITLE
Issue 828

### DIFF
--- a/src/app/assess/wizard/wizard.component.html
+++ b/src/app/assess/wizard/wizard.component.html
@@ -1,5 +1,5 @@
 <div class="sidenav">
-  <div *ngIf="currentAssessmentGroup" class="flex-col mt-18 mb-12">
+  <div *ngIf="currentAssessmentGroup; else noChart" @heightCollapse class="flex-col mt-18 mb-12">
     <div class="center chart-header">
       Phase Rating
     </div>
@@ -8,6 +8,7 @@
         [options]="chartOptions"></canvas>
     </div>
   </div>
+  <ng-template #noChart>&nbsp;</ng-template>
   <mat-accordion displayMode="flat" multi="false">
     <mat-expansion-panel *ngIf="indicators && indicators.length > 0" hideToggle="true" [expanded]="openedSidePanel === 'indicators'"
       (opened)="onOpenSidePanel('indicators', $event)">

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -32,6 +32,7 @@ import { AppState } from '../../root-store/app.reducers';
 import { UserProfile } from '../../models/user/user-profile';
 import { FullAssessmentResultState } from '../result/store/full-result.reducers';
 import { LoadAssessmentResultData } from '../result/store/full-result.actions';
+import { heightCollapse } from '../../global/animations/height-collapse';
 
 type SidePanelName = 'indicators' | 'mitigations' | 'sensors' | 'summary';
 type ButtonLabel = 'SAVE' | 'CONTINUE';
@@ -46,7 +47,8 @@ interface TempModel {
 @Component({
   selector: 'unf-assess-wizard',
   templateUrl: './wizard.component.html',
-  styleUrls: ['./wizard.component.scss']
+  styleUrls: ['./wizard.component.scss'],
+  animations: [heightCollapse],
 })
 export class WizardComponent extends Measurements implements OnInit, OnDestroy {
 
@@ -698,7 +700,7 @@ export class WizardComponent extends Measurements implements OnInit, OnDestroy {
    */
   public showSummarySavePage(): void {
     //  set show summary to show save page
-    this.currentAssessmentGroup = {};
+    this.currentAssessmentGroup = null;
     this.showSummary = true;
     this.buttonLabel = 'SAVE';
   }


### PR DESCRIPTION
To test: 
Edit an assessment and move to the last possible screen before summary.
Click continue and you should see the chart and its title smoothly disappear.
Click somewhere else in the left nav bar and you should see the chart smoothly reappear.
Finally, click the summary heading in the left nav bar and you should see the chart smoothly disappear again.