### PR TITLE
fix assessment edit, expression changed dev mode warning

### DIFF
--- a/src/app/assess/layout/assess-layout.component.html
+++ b/src/app/assess/layout/assess-layout.component.html
@@ -1,10 +1,14 @@
 <div class="layout">
   <div class="titleWrapper">
     <span class="title mat-title">
-      <button *ngIf="showBackButton|async" mat-icon-button class="mat-24" (click)="onBack($event)">
-        <mat-icon>keyboard_backspace</mat-icon>
-      </button>
-      {{(title | async) || 'Untitled Assessment'}}
+      <span *ngIf="showBackButton|async">
+        <button mat-icon-button class="mat-24" (click)="onBack($event)">
+          <mat-icon>keyboard_backspace</mat-icon>
+        </button>
+      </span>
+      <span>
+        {{(title | async)}}
+      </span>
     </span>
   </div>
   <div class="fadeIn flex contentWrapper">

--- a/src/app/assess/layout/assess-layout.component.ts
+++ b/src/app/assess/layout/assess-layout.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, ViewEncapsulation, AfterViewInit } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, AfterViewInit, ChangeDetectorRef } from '@angular/core';
 import { Location } from '@angular/common';
 
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
 
@@ -14,30 +15,46 @@ import { AssessStateService } from '../services/assess-state.service';
   templateUrl: './assess-layout.component.html',
   styleUrls: ['./assess-layout.component.scss'],
 })
-export class AssessLayoutComponent implements OnInit {
-  public title: Observable<string>;
-  public showBackButton: Observable<boolean>;
+export class AssessLayoutComponent implements OnInit, AfterViewInit {
+
+  public title = new BehaviorSubject('').asObservable();
+  public showBackButton = new BehaviorSubject(false).asObservable();
 
   public constructor(
     private store: Store<assessReducers.AssessState>,
     private location: Location,
+    private changeDetectorRef: ChangeDetectorRef,
   ) { }
 
   /**
    * @description
+   * @returns {void}
    */
-  public ngOnInit(): void {
+  public ngOnInit(): void { }
+
+  /**
+   * @description wait for childern to populate the store, then render
+   * @returns {void}
+   */
+  public ngAfterViewInit(): void {
     this.title = this.store
       .select('assessment')
       .filter((el) => el !== undefined)
+      .distinctUntilChanged()
       .pluck('assessment')
       .pluck('assessmentMeta')
       .pluck('title');
 
     this.showBackButton = this.store
       .select('assessment')
-      .filter((el) => el !== undefined)
-      .pluck('backButton');
+      .pluck<object, boolean>('backButton')
+      .filter((el) => (el && typeof el === 'boolean'))
+      .distinctUntilChanged()
+      .map((el) => {
+        this.changeDetectorRef.detectChanges();
+        return el;
+      });
+    this.changeDetectorRef.detectChanges();
   }
 
   /**

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -129,7 +129,6 @@ export class FullComponent implements OnInit, OnDestroy {
       .filter((group: any) => group.finishedLoadingGroupData === true)
       .subscribe(
         (group: any) => {
-          console.log('refreshing group information at full component top level');
           const riskByAttackPattern = group.riskByAttackPattern || {};
           // active phase is either the current active phase, 
           let activePhase = this.activePhase;

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -244,7 +244,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
    */
   public ngAfterViewInit(): void {
     this.questions.changes.subscribe((questionElements: QueryList<MatSelect>) => {
-      console.log('questions changed, focus on first', questionElements);
       const firstQuestion = questionElements.first;
       if (firstQuestion) {
         firstQuestion.focus();

--- a/src/environments/environment.uac.ts
+++ b/src/environments/environment.uac.ts
@@ -3,5 +3,5 @@ export const environment = {
     showBanner: false,
     bannerText: '',
     runMode: 'UAC',
-    hmr: false
+    hmr: true
 };


### PR DESCRIPTION
turn on hot module reloading for local ng serve
fix expression changed message on assessment edit
fixes unfetter-discover/unfetter#843

## To test
* pull this feature branch
* visit the assessments page
* open the dev tools in your browser
* create a assessment
* navigate away
* come back to edit the assessment
* notice the edit page no longer shows a "Expression has changed" message
