### PR TITLE
Adds features to heatmap, modifies kill chain table to adjust

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.scss
+++ b/src/app/global/components/heatmap/heatmap.component.scss
@@ -7,3 +7,12 @@ div.heat-map {
     padding: 0;
     background: $app-background-color;
 }
+
+:host ::ng-deep {
+    .heat-map-canvas {
+        cursor: move; /* fallback: no `url()` support or images disabled */
+        cursor: -webkit-grab; /* Chrome 1-21, Safari 4+ */
+        cursor:    -moz-grab; /* Firefox 1.5-26 */
+        cursor:         grab; /* W3C standards syntax, should come least */
+    }
+}

--- a/src/app/global/components/heatmap/heatmap.component.spec.ts
+++ b/src/app/global/components/heatmap/heatmap.component.spec.ts
@@ -77,16 +77,17 @@ describe('HeatmapComponent', () => {
         component.ngOnInit();
         fixture.detectChanges();
 
-        let cells: NodeList = fixture.nativeElement.querySelectorAll('.heat-map svg g.cell');
-        console.log(cells);
+        let cells: NodeList = fixture.nativeElement.querySelectorAll('.heat-map svg g.heat-map-cell');
+        console.log('cells', cells);
         expect(cells).toBeTruthy();
         expect(cells.length).toEqual(21);
         expect(Array.from(cells).every(cell => cell.childNodes.length === 1)).toBeTruthy();
 
-        let rects: NodeList = fixture.nativeElement.querySelectorAll('.heat-map svg g.cell rect');
-        console.log(rects);
+        let rects: NodeList = fixture.nativeElement.querySelectorAll('.heat-map svg g.heat-map-cell rect');
+        console.log('rects', rects);
         expect(Array.from(rects)
-            .filter(rect => rect.attributes['fill'].nodeValue === component.heatColors['true'].bg).length).toEqual(9);
+            .filter(rect => rect.attributes['fill'].nodeValue ===
+                    component.options.heatColors['true'].bg).length).toEqual(9);
     });
 
 });

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
@@ -42,12 +42,14 @@
 
     <div [hidden]="!showTreeMap">
         <h3 class="mat-title tree-map-header">Attack Patterns Used (Tree Map View)</h3>
-        <unf-treemap [treeMapData]="googleTreeMapData" (onTooltip)="showTreeMapTooltip($event)"></unf-treemap>
+        <unf-treemap [treeMapData]="treeMapData" (onTooltip)="showTreeMapTooltip($event)"></unf-treemap>
     </div>
 
     <div [hidden]="!showHeatMap">
         <h3 class="mat-title heat-map-header">Attack Patterns Used (HeatMap Chart View)</h3>
-        <unf-heatmap [heatMapData]="d3HeatMapData" [showText]="true" (onTooltip)="showHeatMapTooltip($event)"></unf-heatmap>
+        <unf-heatmap [heatMapData]="heatMapData" [options]="heatMapOptions"
+                (onTooltip)="showHeatMapTooltip($event, true)"
+                (onClick)="showHeatMapTooltip($event, false)"></unf-heatmap>
     </div>
 
     <div #toolbox class="toolbox mat-elevation-z5" [style.display]="showToolbox === true ? 'flex': 'none'" [@topRightSlide]>

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.html
@@ -99,7 +99,7 @@
                 </div>
                 <div class="row" *ngIf="attackPhases">
                     <div class="col-md-3"><label>Phases</label></div>
-                    <div class="col-md-9 attack-pattern-phases">{{attackPhases.join(', ')}}</div>
+                    <div class="col-md-9 attack-pattern-phases">{{attackPhases.join(', ') | capitalize}}</div>
                 </div>
             </mat-card-content>
         </mat-card>

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
@@ -116,36 +116,31 @@ $white: #FFFFFF;
             margin: auto auto;
         }
     }
-}
 
-h3.tree-map-header {
-    height: 64px;
-    margin: 0;
-    padding: 16px 16px 0 16px;
-    color: #ffffffde;
-    background: linear-gradient(60deg, #1e88e5, #2196f3) !important;
-}
-div.tree-map {
-    width: 100%;
-    height: 500px;
-    margin: 0;
-    padding: 0;
-    background: white;
-}
+    h3.tree-map-header {
+        height: 64px;
+        margin: 0;
+        padding: 16px 16px 0 16px;
+        color: #ffffffde;
+        background: linear-gradient(60deg, #1e88e5, #2196f3) !important;
+    }
+    unf-treemap div.tree-map {
+        height: 500px;
+        background: $white;
+    }
+    
+    h3.heat-map-header {
+        height: 64px;
+        margin: 0;
+        padding: 16px 16px 0 16px;
+        color: #ffffffde;
+        background: linear-gradient(60deg, #1e88e5, #2196f3) !important;
+    }
+    unf-heatmap div.heat-map {
+        height: 400px;
+        background: $white;
+    }
 
-h3.heat-map-header {
-    height: 64px;
-    margin: 0;
-    padding: 16px 16px 0 16px;
-    color: #ffffffde;
-    background: linear-gradient(60deg, #1e88e5, #2196f3) !important;
-}
-div.heat-map {
-    width: 100%;
-    height: 500px;
-    margin: 0;
-    padding: 0;
-    background: white;
 }
 
 .attack-pattern-clicker:hover {


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#825.

Few sample on threat dashboard.

- Adds event emitter for clicking on a cell.

- Adds a highlight color when hovering over a cell to help illustrate which cell you are seeing a tooltip for, or are about to click.

- Adds a delay for displaying a tooltip. Panning or zooming the mouse swiftly over the canvas area should not flash dozens of tooltips.

- Threat dashboard heatmap should no longer display the names of the attack patterns in the cells (we may want to add an option to write them in later; otherwise zooming in is kind of boring.

- The tooltips for the threat dashboard view should now display the phase names. Clicking, instead of just hovering, over a cell should now display the tooltip as an overlay, with the ability to click a Details button.

- The cursor should be a hand symbol, and should remain that way over the heatmap, instead of bouncing between an arrow and a text cursor.