### PR TITLE
fixed issue where token wasnt being set properly on app refresh, fixe…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -45,6 +45,7 @@ export class AppComponent implements OnInit {
     if (this.authService.loggedIn()) {
       if (!this.demoMode) {
         const token = this.authService.getToken();
+        this.store.dispatch(new userActions.SetToken(token));
         this.store.dispatch(new userActions.FetchUser(token));
       } else {
         this.store.dispatch(new userActions.LoginUser({

--- a/src/app/root-store/users/user.effects.ts
+++ b/src/app/root-store/users/user.effects.ts
@@ -19,6 +19,8 @@ export class UserEffects {
     private refreshTokenDelayMS: number = 10000;
     // The buffer between a token expiring and refresh attempts being made
     private refreshBufferPercent: number = 0.3;
+    private tokenInitialized: boolean = false;
+    private doRefreshToken: boolean = false;
     
     @Effect()
     public fetchUser = this.actions$
@@ -46,6 +48,7 @@ export class UserEffects {
                     userData,
                     token
                 }),
+                new userActions.SetToken(token),
                 new configActions.FetchConfig(),
                 new notificationActions.FetchNotificationStore(),
                 new notificationActions.StartNotificationStream(),
@@ -67,36 +70,54 @@ export class UserEffects {
                 this.refreshTokenDelayMS = this.refreshTokenDelayMS - (this.refreshTokenDelayMS * this.refreshBufferPercent);
                 this.refreshTokenDelayMS = Math.floor(this.refreshTokenDelayMS);
             }
-            return Observable.of([token, store])
+            this.doRefreshToken = store.users.authenticated || !this.tokenInitialized;
+            if (!this.tokenInitialized) {
+                this.tokenInitialized = true;
+            }
+            return Observable.of(null)
                 .delay(this.refreshTokenDelayMS);
         })
-        .map(([token, store]: [string, AppState]) => new userActions.RefreshToken());
+        .map((_) => new userActions.RefreshToken());
 
     @Effect()
     public refreshToken = this.actions$
         .ofType(userActions.REFRESH_TOKEN)
-        .switchMap((_) => {
-            return this.usersService.refreshToken()
-                .map((token: string) => {
-                    return {
-                        success: true,
-                        token
-                    };
-                })
-                .catch((err, caught) => {
-                    return Observable.of({
-                        success: false,
-                        token: null
-                    });
-                })
+        .withLatestFrom(this.store)
+        .switchMap(([_, store]: [any, AppState]) => {
+            this.doRefreshToken = store.users.authenticated || !this.tokenInitialized;
+            if (this.doRefreshToken) {
+                return this.usersService.refreshToken()
+                    .map((token: string) => {
+                        return {
+                            success: true,
+                            token
+                        };
+                    })
+                    .catch((err, caught) => {
+                        return Observable.of({
+                            success: false,
+                            token: null
+                        });
+                    })
+            } else {
+                return Observable.of({
+                    success: false,
+                    token: null
+                });
+            }
         })
         .map(({success, token}: { success: boolean, token: string }) => {
-            if (success) {
-                console.log('Token successfully refreshed');
-                return new userActions.SetToken(token);
+            if (!this.doRefreshToken) {
+                console.log('User logged out, stopping refresh cycle');
+                return new utilityActions.NullAction();
             } else {
-                console.log('Failed to refesh token');
-                return new userActions.LogoutUser();
+                if (success) {
+                    console.log('Token successfully refreshed');
+                    return new userActions.SetToken(token);
+                } else {
+                    console.log('Failed to refesh token');
+                    return new userActions.LogoutUser();
+                }
             }
         });
 

--- a/src/app/root-store/utility/utility.actions.ts
+++ b/src/app/root-store/utility/utility.actions.ts
@@ -6,6 +6,7 @@ export const UPDATE_LOCAL_STORAGE = '[Utility] Update Local Storage Item';
 export const DELETE_LOCAL_STORAGE_ITEM = '[Utility] Delete Local Storage Item';
 export const NAVIGATE = '[Utility] Navigate';
 export const RECORD_VISIT = '[Utility] Record Visit';
+export const NULL_ACTION = '[Utility] Null Action';
 
 export class ClearAllLocalStorage implements Action {
     public readonly type = CLEAR_ALL_LOCAL_STORAGE;
@@ -37,10 +38,15 @@ export class RecordVisit implements Action {
     public readonly type = RECORD_VISIT;
 }
 
+export class NullAction implements Action {
+    public readonly type = NULL_ACTION;
+}
+
 export type UtilityActions =
     ClearAllLocalStorage |
     AddLocalStorage |
     UpdateLocalStorage |
     DeleteLocalStorageItem |
     Navigate |
-    RecordVisit;
+    RecordVisit |
+    NullAction;

--- a/src/app/root-store/utility/utility.effects.ts
+++ b/src/app/root-store/utility/utility.effects.ts
@@ -51,9 +51,7 @@ export class UtilityEffects {
     @Effect({ dispatch: false })
     public recordVisit = this.actions$
         .ofType(utilityActions.RECORD_VISIT)
-            .do((_) => console.log('VISIT ENTER'))
-            .switchMap((_) => this.genericApi.get(`${this.webAnalyticsUrl}/visit`))
-            .do((_) => console.log('VISIT RECORDED'));
+        .switchMap((_) => this.genericApi.get(`${this.webAnalyticsUrl}/visit`));
 
     constructor(
         private actions$: Actions,


### PR DESCRIPTION
…d an unrelated issue where token would have a failed refresh attempt after logout

To speed up testing, you can do the following:

In `unfetter-ui/src/app/root-store/users/user.effects.ts`, edit lines 18 and 20 to:

```    // Initial token refresh delay until configuration is loaded
    private refreshTokenDelayMS: number = 0;
    // The buffer between a token expiring and refresh attempts being made
    private refreshBufferPercent: number = 0.995;
```

This will significantly speed up the token refresh cycle

Instructions
- Sign in using the sign in button, ensures token refreshes
- Reload the application with an active token where you'd be automatically signed in, and be sure it refreshes
- Sign out shortly after a refresh, and ensure the cycle ends itself safely via the following console.log: `User logged out, stopping refresh cycle`

fixes unfetter-discover/unfetter#854