### PR TITLE
Heatmap chart added to analytic exchange page

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.ts
+++ b/src/app/global/components/heatmap/heatmap.component.ts
@@ -291,7 +291,7 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
             batch.width = bounds.cellWidth * batch.columns;
             return [width + batch.width, columns + batch.columns - 1];
         }, [0, 0]);
-        bounds.padding.between = Math.min(availableWidth - usedCellWidth / insideColumns, 1);
+        bounds.padding.between = Math.min(availableWidth - usedCellWidth / Math.max(insideColumns, 1), 1);
 
         const totalUsedWidth = usedCellWidth + minPadding + bounds.padding.between * insideColumns;
         bounds.padding.left += Math.floor((bounds.viewWidth - totalUsedWidth) / 2);

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.ts
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.ts
@@ -105,8 +105,6 @@ export class MasterListDialogComponent implements AfterViewInit, OnDestroy {
      * @return {void}
      */
     public ngAfterViewInit(): void {
-        console.log('afterContentInit');
-
         const sub$ = this.filters.changes.subscribe(
             (comps) => this.initFilter(comps.first),
             (err) => {

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
@@ -1,0 +1,56 @@
+<div id="indicator-analytic-heat-map">
+
+    <div id="indicator-heat-map">
+
+        <unf-heatmap [heatMapData]="heatmap" [options]="heatmapOptions"
+                (onTooltip)="onTooltip($event)" (onClick)="highlightAttackPatternAnalytics($event)"></unf-heatmap>
+
+        <ng-template #tooltipTemplate>
+            <div class="col-md-12 attack-pattern-tooltip">
+                <mat-card>
+                    <mat-card-subtitle>
+                        <div class="flex1"><label>{{attackPattern.name}}</label></div>
+                        <div [hidden]="true">
+                            <button mat-button type="button" class="mat-primary">
+                                <a target="_blank" href="/#/stix/attack-patterns/{{attackPattern.id}}">Details</a>
+                            </button>
+                            <button mat-button type="button" (click)="onTooltip()">Close</button>
+                        </div>
+                    </mat-card-subtitle>
+                    <mat-card-content>
+                        <div class="row" *ngIf="attackPattern.description">
+                            <div class="col-md-3"><label>Description</label></div>
+                            <div class="col-md-8 attack-pattern-desc" [innerHTML]="attackPattern.description"></div>
+                        </div>
+                        <div class="row" *ngIf="attackPattern.sources">
+                            <div class="col-md-3"><label>Data Sources</label></div>
+                            <div class="col-md-9 attack-pattern-sources">{{attackPattern.sources.join(', ')}}</div>
+                        </div>
+                        <div class="row" *ngIf="attackPattern.platforms">
+                            <div class="col-md-3"><label>Platforms</label></div>
+                            <div class="col-md-9 attack-pattern-platforms">{{attackPattern.platforms.join(', ')}}</div>
+                        </div>
+                        <div class="row" *ngIf="attackPattern.phases">
+                            <div class="col-md-3"><label>Phases</label></div>
+                            <div class="col-md-9 attack-pattern-phases">{{attackPattern.phases.join(', ') | capitalize}}</div>
+                        </div>
+                    </mat-card-content>
+                </mat-card>
+            </div>
+        </ng-template>
+
+    </div>
+
+    <div [hidden]="displayIndicators.length === 0" id="indicators" class="col-xs-12">
+        <h4 id="indicators-header">Analytics Using These Patterns</h4>
+        <div #indicatorsGrid id="indicators-grid">
+            <div *ngFor="let indicator of displayIndicators" id="{{indicator.id}}"
+                    class="indicator" [class.selected]="selectedPatterns.length > 0">{{indicator.name}}</div>
+        </div>
+    </div>
+
+    <div [hidden]="displayIndicators.length > 0" id="no-indicators" class="col-xs-12">
+        <h4 id="indicators-header">There are No Analytics Using the Selected Pattern(s)</h4>
+    </div>
+
+</div>

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
@@ -1,0 +1,109 @@
+@import '../../../styles/_variables.scss';
+
+$white: #FFFFFF;
+
+#indicator-analytic-heat-map {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+:host ::ng-deep {
+
+    background-color: $white;
+
+    unf-heatmap {
+        div.heat-map {
+            width: 100%;
+            height: 300px;
+            margin: 0;
+            padding: 0;
+            background: white;
+
+            rect.selected {
+                fill: $analytic-exchange-primary;
+            }
+        }
+    }
+
+}
+
+#indicators, #no-indicators {
+    flex: 1;
+    margin: 10px 0 60px 0;
+    padding: 0px;
+    height: 100%;
+    overflow-y: auto;
+}
+#indicators-header {
+    text-decoration: underline;
+}
+#indicators-grid {
+    display: grid;
+    grid-template-columns: auto auto auto auto;
+}
+.indicator {
+    margin: 4px;
+    padding: 6px;
+    font-size: 14px;
+    background-color: $analytic-exchange-primary-lightest;
+    border: 1px solid $analytic-exchange-primary-lighter;
+    border-radius: 4px;
+}
+.indicator.selected {
+    background-color: $analytic-exchange-primary;
+}
+
+.attack-pattern-tooltip {
+
+    padding: 10px;
+
+    .mat-card {
+        padding: 12px;
+        background-color: #f0f0f0;
+    }
+
+    .mat-card-subtitle {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0;
+
+        label {
+            color: $dark-text-default;
+        }
+    }
+
+    div.row {
+        margin-bottom: 4px;
+    }
+
+    .attack-pattern-desc {
+        max-height: 58px;
+        overflow: hidden;
+    }
+
+    .attack-pattern-desc:after {
+        content: "";
+        text-align: right;
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        top: 40px;
+        width: 70%;
+        height: 20px;
+        background: linear-gradient(to right, rgba(240, 240, 240, 0), rgba(240, 240, 240, 1) 80%);
+    }
+
+    .attack-pattern-sources {
+        max-height: 40px;
+        overflow: hidden;
+    }
+
+    .attack-pattern-platforms {
+        max-height: 20px;
+        overflow: hidden;
+    }
+
+}

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -14,7 +14,7 @@ import { indicatorSharingReducer } from '../store/indicator-sharing.reducers';
 import { CapitalizePipe } from '../../global/pipes/capitalize.pipe';
 import { GenericApi } from '../../core/services/genericapi.service';
 
-fdescribe('IndicatorHeatMapComponent', () => {
+describe('IndicatorHeatMapComponent', () => {
 
     let fixture: ComponentFixture<IndicatorHeatMapComponent>;
     let component: IndicatorHeatMapComponent;

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { IndicatorHeatMapComponent } from './indicator-heat-map.component';
+
+describe('IndicatorHeatMapComponent', () => {
+  // let component: IndicatorHeatMapComponent;
+  // let fixture: ComponentFixture<IndicatorHeatMapComponent>;
+
+  // beforeEach(async(() => {
+  //   TestBed.configureTestingModule({
+  //     declarations: [ IndicatorHeatMapComponent ]
+  //   })
+  //   .compileComponents();
+  // }));
+
+  // beforeEach(() => {
+  //   fixture = TestBed.createComponent(IndicatorHeatMapComponent);
+  //   component = fixture.componentInstance;
+  //   fixture.detectChanges();
+  // });
+
+  // it('should create', () => {
+  //   expect(component).toBeTruthy();
+  // });
+});

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -1,25 +1,116 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { By } from '@angular/platform-browser';
+import { ActionReducerMap, StoreModule } from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+
+import { MatCardModule, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 import { IndicatorHeatMapComponent } from './indicator-heat-map.component';
+import { HeatmapComponent } from '../../global/components/heatmap/heatmap.component';
+import { makeMockIndicatorSharingStore, mockIndicators, mockAttackPatterns } from '../../testing/mock-store';
+import { indicatorSharingReducer } from '../store/indicator-sharing.reducers';
+import { CapitalizePipe } from '../../global/pipes/capitalize.pipe';
+import { GenericApi } from '../../core/services/genericapi.service';
 
 describe('IndicatorHeatMapComponent', () => {
-  // let component: IndicatorHeatMapComponent;
-  // let fixture: ComponentFixture<IndicatorHeatMapComponent>;
 
-  // beforeEach(async(() => {
-  //   TestBed.configureTestingModule({
-  //     declarations: [ IndicatorHeatMapComponent ]
-  //   })
-  //   .compileComponents();
-  // }));
+    let fixture: ComponentFixture<IndicatorHeatMapComponent>;
+    let component: IndicatorHeatMapComponent;
+    let store;
 
-  // beforeEach(() => {
-  //   fixture = TestBed.createComponent(IndicatorHeatMapComponent);
-  //   component = fixture.componentInstance;
-  //   fixture.detectChanges();
-  // });
+    let mockReducer: ActionReducerMap<any> = {
+        indicatorSharing: indicatorSharingReducer
+    };
 
-  // it('should create', () => {
-  //   expect(component).toBeTruthy();
-  // });
+    const mockAttackPatternData = [
+        {
+            type: 'attack-pattern',
+            id: mockAttackPatterns[0].id,
+            attributes: {
+                id: mockAttackPatterns[0].id,
+                name: mockAttackPatterns[0].name,
+                description: 'Attack Pattern #1',
+                kill_chain_phases: [{phase_name: 'Something'}],
+                x_mitre_data_sources: ['The Source'],
+                x_mitre_platforms: ['iOS', 'Android']
+            }
+        },
+        {
+            type: 'attack-pattern',
+            id: mockAttackPatterns[1].id,
+            attributes: {
+                id: mockAttackPatterns[1].id,
+                name: mockAttackPatterns[1].name,
+                description: 'Attack Pattern #2',
+                kill_chain_phases: [{phase_name: 'Something Else'}],
+                x_mitre_data_sources: ['Another Source'],
+                x_mitre_platforms: ['AppleDOS', 'MS-DOS']
+            }
+        },
+    ];
+
+    beforeEach(async(() => {
+        TestBed
+            .configureTestingModule({
+                imports: [
+                    MatCardModule,
+                    OverlayModule,
+                    MatDialogModule,
+                    HttpClientTestingModule,
+                    StoreModule.forRoot(mockReducer),
+                ],
+                declarations: [
+                    IndicatorHeatMapComponent,
+                    HeatmapComponent,
+                    CapitalizePipe,
+                ],
+                providers: [
+                    GenericApi,
+                    {
+                        provide: MAT_DIALOG_DATA,
+                        useValue: {indicators: mockIndicators}
+                    },
+                    {
+                        provide: MatDialogRef,
+                        useValue: {
+                            close: function() {}
+                        }
+                    },
+                ],
+            })
+            .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(IndicatorHeatMapComponent);
+        let heatmap = fixture.debugElement.query(By.css('div#indicator-analytic-heat-map'));
+        heatmap.nativeElement.style.width = '300px';
+        heatmap.nativeElement.style.height = '500px';
+        component = fixture.componentInstance;
+        store = component.store;
+        makeMockIndicatorSharingStore(store);
+        let mockApi = spyOn(component.genericApi, 'get').and.returnValue(Observable.of(mockAttackPatternData));
+        fixture.detectChanges();
+    });
+
+    it('should initialize', async(() => {
+        expect(component).toBeTruthy();
+        expect(component.heatmap.length).toBe(2);
+        expect(component.displayIndicators.length).toBe(3);
+    }));
+
+    it('should filter analytics', async(() => {
+        const first = fixture.nativeElement.querySelector('g.heat-map-cell rect');
+        // TODO i'd rather invoke a mouseclick event on the above rect object, but can't seem to tell angular to do that
+        component.highlightAttackPatternAnalytics({
+            row: component.heatmap[0].columns[0][0],
+            event: {path: [first]}
+        });
+        fixture.detectChanges();
+        expect(component.selectedPatterns.length).toBe(1);
+        expect(component.displayIndicators.length).toBe(2);
+    }));
+
 });

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -1,0 +1,312 @@
+import {
+        Component,
+        OnInit,
+        Inject,
+        Input,
+        ViewChild,
+        ElementRef,
+        TemplateRef,
+        ViewContainerRef,
+        ChangeDetectorRef,
+    } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { Store } from '@ngrx/store';
+
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+
+import { IndicatorSharingFeatureState } from '../store/indicator-sharing.reducers';
+import { GenericApi } from '../../core/services/genericapi.service';
+import { Constance } from '../../utils/constance';
+
+@Component({
+    selector: 'indicator-heat-map',
+    templateUrl: './indicator-heat-map.component.html',
+    styleUrls: ['./indicator-heat-map.component.scss']
+})
+export class IndicatorHeatMapComponent implements OnInit {
+
+    public heatmap: any[] = [];
+    @Input() heatmapOptions = {
+        batchColors: [
+            {header: {bg: 'transparent', fg: '#333'}, body: {bg: 'transparent', fg: 'black'}},
+        ],
+        heatColors: {
+            'true': {bg: '#b2ebf2', fg: 'black'},
+            'false': {bg: '#ccc', fg: 'black'},
+            'selected': {bg: '#33a0b0', fg: 'black'},
+        },
+        showText: false
+    }
+
+    public attackPatterns = {};
+    public attackPattern = null;
+    public selectedPatterns = [];
+
+    /**
+     * @description "indicators" is the old reference to "analytics" used in this page
+     */
+    private indicators: any[];
+    private displayIndicators: any[];
+    private indicatorsToAttackPatternMap: any;
+
+    @ViewChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+    private overlayRef: OverlayRef;
+    private portal: TemplatePortal<any>;
+
+    @ViewChild('indicatorsGrid') indicatorsGrid: ElementRef;
+
+    constructor(
+        public store: Store<IndicatorSharingFeatureState>,
+        public dialogRef: MatDialogRef<IndicatorHeatMapComponent>,
+        @Inject(MAT_DIALOG_DATA) public data: any,
+        public genericApi: GenericApi,
+        private overlay: Overlay,
+        private vcr: ViewContainerRef,
+        private changeDetector: ChangeDetectorRef,
+    ) { }
+
+    ngOnInit() {
+        this.indicators = this.displayIndicators = this.data.indicators || [];
+        this.loadIndicatorMap();
+        this.loadAttackPatterns();
+    }
+
+    /**
+     * @description retrieve the indicators-to-attack-patterns map from the ngrx store
+     */
+    private loadIndicatorMap() {
+        const getIndicatorToAttackPatternMap$ = this.store
+            .select('indicatorSharing')
+            .pluck('indicatorToApMap')
+            .distinctUntilChanged()
+            .finally(() => getIndicatorToAttackPatternMap$.unsubscribe())
+            .subscribe(
+                (indicatorToAttackPatternMap) => this.indicatorsToAttackPatternMap = indicatorToAttackPatternMap,
+                (err) => console.log(err)
+            );
+    }
+
+    /**
+     * @description retrieve the attack patterns and their tactics phases from the backend database
+     */
+    private loadAttackPatterns() {
+        const sort = { 'stix.name': '1' };
+        const project = {
+            'stix.name': 1,
+            'stix.description': 1,
+            'stix.kill_chain_phases': 1,
+            'extendedProperties.x_mitre_data_sources': 1,
+            'extendedProperties.x_mitre_platforms': 1,
+            'stix.id': 1,
+        };
+        const filter = encodeURI(`sort=${JSON.stringify(sort)}&project=${JSON.stringify(project)}`);
+        const initData$ = this.genericApi.get(`${Constance.ATTACK_PATTERN_URL}?${filter}`)
+            .finally(() => initData$.unsubscribe())
+            .subscribe(
+                (results: any[]) => {
+                    const indicators = this.groupIndicatorsByAttackPatterns();
+                    const collects = {attackPatterns: {}, phases: {}};
+                    this.attackPatterns = results.reduce(
+                        (collect, pattern) => this.collectAttackPatterns(collect, pattern), collects).attackPatterns;
+                    this.heatmap = this.groupAttackPatternsByKillchain(collects.phases, indicators);
+                    console.log('resulting heatmap', this.heatmap);
+                },
+                (err) => console.log(err)
+            );
+    }
+
+    /**
+     * @description create a map of attack patterns and their indicators (inverted indicators-to-attack-patterns map)
+     */
+    private groupIndicatorsByAttackPatterns() {
+        const indicatorIds = this.indicators.map(indicator => indicator.id);
+        const patternIndicators = {};
+        Object.entries(this.indicatorsToAttackPatternMap)
+            .filter(indicator => indicatorIds.includes(indicator[0]))
+            .forEach(([indicator, patterns]) => {
+                if (patterns && (patterns as any[]).length) {
+                    (patterns as any[]).forEach((p: any) => {
+                        if (!patternIndicators[p.name]) {
+                            patternIndicators[p.name] = [];
+                        }
+                        patternIndicators[p.name].push(indicator);
+                    });
+                }
+            });
+        return patternIndicators;
+    }
+
+    /**
+     * @description now group up all the phases and the attack patterns they have, for the heatmap display
+     */
+    private collectAttackPatterns(collects, pattern) {
+        const name = pattern.attributes.name;
+        if (name) {
+            collects.attackPatterns[name] = Object.assign({}, {
+                batch: name,
+                name: name,
+                id: pattern.attributes.id,
+                description: pattern.attributes.description,
+                phases: (pattern.attributes.kill_chain_phases || []).map(p => p.phase_name),
+                sources: pattern.attributes.x_mitre_data_sources,
+                platforms: pattern.attributes.x_mitre_platforms,
+                indicators: [],
+                active: false,
+            });
+        }
+
+        (pattern.attributes.kill_chain_phases || [])
+            .forEach(p => {
+                const batch = p.phase_name
+                    .replace(/\-/g, ' ')
+                    .split(/\s+/)
+                    .map(w => w[0].toUpperCase() + w.slice(1))
+                    .join(' ')
+                    .replace(/\sAnd\s/g, ' and ')
+                    ;
+                collects.phases[p.phase_name] = {
+                    batch: batch,
+                    active: null,
+                    columns: [[]],
+                };
+            });
+
+        return collects;
+    }
+
+    private groupAttackPatternsByKillchain(tactics: any, indicators: any): any[] {
+        Object.values(this.attackPatterns).forEach((attackPattern: any) => {
+            const phases = attackPattern.phases;
+            if (phases) {
+                phases.forEach((phase) => {
+                    let group = tactics[phase];
+                    if (group) {
+                        attackPattern.indicators = indicators[attackPattern.name] || [];
+                        attackPattern.active = attackPattern.indicators.length > 0;
+                        group.columns[0].push(attackPattern);
+                    }
+                });
+            }
+        });
+        return Object.values(tactics);
+    }
+
+    /**
+     * @description display a tooltip for the attack pattern the user is hovering over
+     */
+    public onTooltip(selection?: any) {
+        if (!selection || !selection.row || !selection.row.name) {
+            this.hideTooltip();
+        } else {
+            let attackPattern = this.attackPatterns[selection.row.name];
+            if (attackPattern && (!this.attackPattern || (this.attackPattern.name !== attackPattern.name))) {
+                this.attackPattern = attackPattern;
+                this.showTooltip(selection.event);
+            } else {
+                this.hideTooltip();
+            }
+        }
+    }
+
+    private showTooltip(event: UIEvent) {
+        if (!this.overlayRef) {
+            const elem = new ElementRef(event.target);
+
+            const positionStrategy = this.overlay.position()
+              .connectedTo(elem,
+                {originX: 'center', originY: 'bottom'},
+                {overlayX: 'start', overlayY: 'top'})
+              .withFallbackPosition(
+                {originX: 'center', originY: 'top'},
+                {overlayX: 'start', overlayY: 'bottom'})
+              .withFallbackPosition(
+                {originX: 'center', originY: 'bottom'},
+                {overlayX: 'end', overlayY: 'top'})
+              .withFallbackPosition(
+                {originX: 'center', originY: 'bottom'},
+                {overlayX: 'end', overlayY: 'bottom'});
+
+            this.overlayRef = this.overlay.create({
+                minWidth: 300,
+                maxWidth: 500,
+                hasBackdrop: false,
+                positionStrategy,
+                scrollStrategy: this.overlay.scrollStrategies.reposition()
+            });
+
+            const sub$ = this.overlayRef.backdropClick()
+                .finally(() => sub$.unsubscribe())
+                .subscribe(
+                    () => this.hideTooltip(),
+                    (err) => console.log(err));
+
+            this.portal = new TemplatePortal(this.tooltipTemplate, this.vcr);
+        }
+
+        this.overlayRef.attach(this.portal);
+    }
+
+    private hideTooltip() {
+        this.attackPattern = null;
+        if (this.overlayRef) {
+            this.overlayRef.detach();
+            this.overlayRef.dispose();
+            this.overlayRef = null;
+        }
+    }
+
+    /**
+     * @description when clicked, highlight the analytics targeting the attack pattern
+     */
+    public highlightAttackPatternAnalytics(clicked?: any) {
+        console.log('clicked', clicked, this.indicatorsGrid.nativeElement);
+        if (clicked && clicked.row) {
+            const index = this.selectedPatterns.findIndex(pattern => pattern.id === clicked.row.id);
+            console.log('pattern index', index);
+            if (index < 0) {
+                // pattern was not previously selected; select it
+                this.selectedPatterns.push(clicked.row);
+                if (clicked.event && clicked.event.path && clicked.event.path.length) {
+                    console.log('event path', clicked.event.path);
+                    const rect = clicked.event.path.find(node => node && (node.localName === 'rect'));
+                    console.log('event rect', rect);
+                    if (rect && rect.attributes) {
+                        console.log('rect attrs', rect.attributes, rect.attributes.getNamedItem('class'));
+                        const cls = document.createAttribute('class');
+                        cls.value = 'selected';
+                        rect.attributes.setNamedItem(cls);
+                    }
+                }
+            } else {
+                // remove the pattern from our selection list
+                this.selectedPatterns.splice(index, 1);
+                if (event && clicked.event.path && clicked.event.path.length) {
+                    const rect = clicked.event.path.find(node => node && (node.localName === 'rect'));
+                    console.log('event rect', rect);
+                    if (rect && rect.attributes) {
+                        console.log('rect attrs', rect.attributes, rect.attributes.getNamedItem('class'));
+                        rect.attributes.removeNamedItem('class');
+                    }
+                }
+            }
+
+            // update the analytics list
+            console.log('selected patterns', this.selectedPatterns);
+            if (this.selectedPatterns.length === 0) {
+                requestAnimationFrame(() => this.displayIndicators = this.indicators);
+            } else {
+                const selectedIndicators = this.selectedPatterns.reduce(
+                    (indicators, pattern) => {
+                        indicators.push(...pattern.indicators);
+                        return indicators;
+                    }, []);
+                console.log('selected indicators', selectedIndicators);
+                requestAnimationFrame(() => this.displayIndicators =
+                        this.indicators.filter(indicator => selectedIndicators.includes(indicator.id)));
+            }
+        }
+    }
+  
+}

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -286,7 +286,7 @@ export class IndicatorHeatMapComponent implements OnInit {
             } else {
                 // remove the pattern from our selection list
                 this.selectedPatterns.splice(index, 1);
-                if (event && clicked.event.path && clicked.event.path.length) {
+                if (clicked.event && clicked.event.path && clicked.event.path.length) {
                     const rect = clicked.event.path.find(node => node && (node.localName === 'rect'));
                     if (rect) {
                         rect.attributes.removeNamedItem('class');

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -36,6 +36,11 @@
                         <div class="pl-24 pr-24 flex flexItemsCenter">
                             <indicator-sharing-sort></indicator-sharing-sort>
                             <span class="flex1">&nbsp;</span>
+                            <button mat-button id="showAttackPatternHeatMap" (click)="viewHeatMapDialog($event)"
+                                    matTooltip="Display an Attack Pattern Heat Map of all Analytics">
+                                <i class="material-icons mat-24">view_comfy</i>
+                            </button>
+                            <span class="flex1">&nbsp;</span>
                             <label class="mb-0">Results: {{ (store.select('indicatorSharing').pluck('filteredIndicators') | async).length }} / {{ (store.select('indicatorSharing').pluck('indicators')
                                 | async).length }}</label>
                          </div>

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
@@ -29,3 +29,7 @@
   top: 13px;
   left: 7px;
 }
+
+#showAttackPatternHeatMap {
+  color: #9e9e9e;
+}

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -14,6 +14,7 @@ import { IndicatorBase } from '../models/indicator-base-class';
 import { fadeInOut } from '../../global/animations/fade-in-out';
 import { ConfirmationDialogComponent } from '../../components/dialogs/confirmation/confirmation-dialog.component';
 import { initialSearchParameters } from '../store/indicator-sharing.reducers';
+import { IndicatorHeatMapComponent } from '../indicator-heat-map/indicator-heat-map.component';
 
 @Component({
     selector: 'indicator-sharing-list',
@@ -61,7 +62,7 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
                     filteredIndicatorSub$.unsubscribe();
                 }
             );
-        
+
         const displayedIndicatorSub$ = this.store.select('indicatorSharing')
             .pluck('displayedIndicators')
             .distinctUntilChanged()
@@ -110,7 +111,6 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
                     searchParametersSub$.unsubscribe();
                 }
             );
-
 
         const getUser$ = this.store.select('users')
             .take(1)
@@ -205,4 +205,20 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
     public editIndicator(indicatorToEdit: any) {
         this.openDialog(indicatorToEdit);
     }
+
+    /**
+     * @description Displays a popup that shows the user a heat map of all attack patterns used by all the
+     *              currently-filtered analytics.
+     */
+    public viewHeatMapDialog(ev?: UIEvent) {
+        this.dialog.open(IndicatorHeatMapComponent, {
+            width: 'calc(100vw - 150px)',
+            height: 'calc(100vh - 100px)',
+            data: {
+                indicators: this.filteredIndicators,
+                indicatorsToAttackPatternMap: this.indicatorToAttackPatternMap,
+            }
+        });
+    }
+
 }

--- a/src/app/indicator-sharing/indicator-sharing.module.ts
+++ b/src/app/indicator-sharing/indicator-sharing.module.ts
@@ -2,8 +2,24 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatSelectModule, MatChipsModule, MatTooltipModule, MatCardModule,
-    MatTabsModule, MatInputModule, MatIconModule, MatButtonModule, MatDatepickerModule, MatNativeDateModule, MatRadioModule, MatListModule, MatStepperModule, MatDialogModule, MatSidenavModule, MatMenuModule } from '@angular/material';
+import {
+        MatSelectModule,
+        MatChipsModule,
+        MatTooltipModule,
+        MatCardModule,
+        MatTabsModule,
+        MatInputModule,
+        MatIconModule,
+        MatButtonModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
+        MatRadioModule,
+        MatListModule,
+        MatStepperModule,
+        MatDialogModule,
+        MatSidenavModule,
+        MatMenuModule,
+    } from '@angular/material';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { ClipboardModule } from 'ngx-clipboard';
@@ -30,6 +46,7 @@ import { IndicatorSharingSortComponent } from './indicator-sharing-sort/indicato
 import { IndicatorSharingFiltersComponent } from './indicator-sharing-filters/indicator-sharing-filters.component';
 import { GeneratedObservedDataComponent } from './generated-observed-data/generated-observed-data.component';
 import { AddAttackPatternComponent } from './add-attack-pattern/add-attack-pattern.component';
+import { IndicatorHeatMapComponent } from './indicator-heat-map/indicator-heat-map.component';
 
 const matModules = [
     MatButtonModule,
@@ -75,13 +92,15 @@ const matModules = [
         IndicatorSharingSortComponent,
         IndicatorSharingFiltersComponent,
         GeneratedObservedDataComponent,
-        AddAttackPatternComponent
+        AddAttackPatternComponent,
+        IndicatorHeatMapComponent,
     ],
     providers: [
         IndicatorSharingService
     ],
     entryComponents: [
-        AddIndicatorComponent
+        AddIndicatorComponent,
+        IndicatorHeatMapComponent,
     ]
 })
 export class IndicatorSharingModule { }

--- a/src/app/testing/mock-store.ts
+++ b/src/app/testing/mock-store.ts
@@ -107,14 +107,22 @@ export const mockIndicators = [
 ];
 
 export const mockAttackPatterns = [
-    {
-        name: 'fake',
-        id: 'fake123'
-    }
+    { name: 'AP1', id: 'ap1' },
+    { name: 'AP2', id: 'ap2' },
 ];
+
+export const indicatorToApMap = {
+    'fake123': [{id: mockAttackPatterns[0].id, name: mockAttackPatterns[0].name}],
+    'mfake123': [
+        {id: mockAttackPatterns[0].id, name: mockAttackPatterns[0].name},
+        {id: mockAttackPatterns[1].id, name: mockAttackPatterns[1].name},
+    ],
+    'zfake123': [{id: mockAttackPatterns[1].id, name: mockAttackPatterns[1].name}],
+};
 
 export function makeMockIndicatorSharingStore(store: Store<fromIndicatorSharing.IndicatorSharingFeatureState>) {
     store.dispatch(new indicatorSharingActions.SetIndicators(mockIndicators));
     store.dispatch(new indicatorSharingActions.SetAttackPatterns(mockAttackPatterns));
+    store.dispatch(new indicatorSharingActions.SetIndicatorToApMap(indicatorToApMap));
     store.dispatch(new indicatorSharingActions.FilterIndicators());
 }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#801.

Adds a heatmap chart in an overlay on the analytics exchange page.

This is the first form of this component's appearance on the page, and some question of what filter functions it will perform. For now, the overlay displays the currently list of filtered analytics (name only) and a heatmap of the attack patterns they target. Clicking on attack patterns further reduces the displayed analytic list to the ones that target just them.

As always, suggestions for improvement welcome. :)