### PR TITLE
Issue 849

### DIFF
--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -2,6 +2,7 @@
     <button mat-fab color="primary" class="bottomRightFab" (click)="openDialog()">
         <i class="material-icons mat-24">add</i>
     </button>
+    <indicator-sharing-summary-statistics></indicator-sharing-summary-statistics>
 
     <mat-sidenav-container>
         <mat-sidenav #filterContainer id="filterContainer" opened="false" mode="side" class="mat-elevation-z8" (openedStart)="openedStart()" (closedStart)="closedStart()">

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -1,8 +1,7 @@
 <div id="indicatorSharingList" class="fadeIn" *ngIf="SERVER_CALL_COMPLETE; else loadingBlock">
     <button mat-fab color="primary" class="bottomRightFab" (click)="openDialog()">
         <i class="material-icons mat-24">add</i>
-    </button>
-    <indicator-sharing-summary-statistics></indicator-sharing-summary-statistics>
+    </button>   
 
     <mat-sidenav-container>
         <mat-sidenav #filterContainer id="filterContainer" opened="false" mode="side" class="mat-elevation-z8" (openedStart)="openedStart()" (closedStart)="closedStart()">
@@ -31,20 +30,30 @@
             </div>
             
             <div class="container-fluid">
-            
-                <div class="row">
+
+                <div class="row" id="listControls">
                     <div class="col-lg-8 col-lg-offset-2 col-md-12">
                         <div class="pl-24 pr-24 flex flexItemsCenter">
                             <indicator-sharing-sort></indicator-sharing-sort>
-                            <span class="flex1">&nbsp;</span>
-                            <button mat-button id="showAttackPatternHeatMap" (click)="viewHeatMapDialog($event)"
-                                    matTooltip="Display an Attack Pattern Heat Map of all Analytics">
-                                <i class="material-icons mat-24">view_comfy</i>
-                            </button>
-                            <span class="flex1">&nbsp;</span>
+                            <label class="spacer" id="spacer1">&nbsp;|&nbsp;</label>
                             <label class="mb-0">Results: {{ (store.select('indicatorSharing').pluck('filteredIndicators') | async).length }} / {{ (store.select('indicatorSharing').pluck('indicators')
                                 | async).length }}</label>
+                            <label class="spacer" id="spacer2">&nbsp;|&nbsp;</label>
+                            <button mat-icon-button id="showAttackPatternHeatMap" (click)="viewHeatMapDialog($event)" matTooltip="Show Heat Map">
+                                <i class="material-icons mat-24 labelColor" >view_comfy</i>
+                            </button>
+                            <button mat-icon-button matTooltip="{{ showSummaryStats ? 'Hide' : 'Show' }} Statistics" (click)="showSummaryStats = !showSummaryStats">
+                                <i class="material-icons mat-24" [ngClass]="{'labelColor': !showSummaryStats}">equalizer</i>
+                            </button>
                          </div>
+                    </div>
+                </div>
+
+                <div class="row" id="summaryStatsWrapper" @heightCollapse *ngIf="showSummaryStats">
+                    <div class="col-lg-8 col-lg-offset-2 col-md-12">
+                        <div class="pl-24 pr-24">
+                            <indicator-sharing-summary-statistics></indicator-sharing-summary-statistics>
+                        </div>
                     </div>
                 </div>
             

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
@@ -30,6 +30,21 @@
   left: 7px;
 }
 
-#showAttackPatternHeatMap {
-  color: #9e9e9e;
+#listControls {
+  label {
+    margin-bottom: 0;
+  }
+}
+
+#indicatorSharingList {
+  .spacer {
+    font-size: 28px;
+  }
+  #spacer1 {
+    margin-right: 13px;
+  }
+  #spacer2 {
+    margin-left: 14px;
+    margin-right: 6px;
+  }
 }

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -15,12 +15,13 @@ import { fadeInOut } from '../../global/animations/fade-in-out';
 import { ConfirmationDialogComponent } from '../../components/dialogs/confirmation/confirmation-dialog.component';
 import { initialSearchParameters } from '../store/indicator-sharing.reducers';
 import { IndicatorHeatMapComponent } from '../indicator-heat-map/indicator-heat-map.component';
+import { heightCollapse } from '../../global/animations/height-collapse';
 
 @Component({
     selector: 'indicator-sharing-list',
     templateUrl: 'indicator-sharing-list.component.html',
     styleUrls: ['indicator-sharing-list.component.scss'],
-    animations: [fadeInOut],
+    animations: [ fadeInOut, heightCollapse ],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 
@@ -32,6 +33,7 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
     public searchParameters;
     public filterOpen: boolean = false;
     public filterOpened: boolean = false;
+    public showSummaryStats: boolean = false;
 
     @ViewChild('filterContainer') public filterContainer: MatSidenav;
 

--- a/src/app/indicator-sharing/indicator-sharing.module.ts
+++ b/src/app/indicator-sharing/indicator-sharing.module.ts
@@ -47,6 +47,7 @@ import { IndicatorSharingFiltersComponent } from './indicator-sharing-filters/in
 import { GeneratedObservedDataComponent } from './generated-observed-data/generated-observed-data.component';
 import { AddAttackPatternComponent } from './add-attack-pattern/add-attack-pattern.component';
 import { IndicatorHeatMapComponent } from './indicator-heat-map/indicator-heat-map.component';
+import { SummaryStatisticsComponent } from './summary-statistics/summary-statistics.component';
 
 const matModules = [
     MatButtonModule,
@@ -94,6 +95,7 @@ const matModules = [
         GeneratedObservedDataComponent,
         AddAttackPatternComponent,
         IndicatorHeatMapComponent,
+        SummaryStatisticsComponent,
     ],
     providers: [
         IndicatorSharingService

--- a/src/app/indicator-sharing/indicator-sharing.service.ts
+++ b/src/app/indicator-sharing/indicator-sharing.service.ts
@@ -6,6 +6,7 @@ import { Constance } from '../utils/constance';
 import { AuthService } from '../core/services/auth.service';
 import { environment } from '../../environments/environment';
 import { RxjsHelpers } from '../global/static/rxjs-helpers';
+import { IndicatorSharingSummaryStatistics } from './models/summary-statistics';
 
 @Injectable()
 export class IndicatorSharingService {
@@ -166,5 +167,9 @@ export class IndicatorSharingService {
                 this.genericApi.get(`${this.sensorsUrl}?filter=${encodeURI(JSON.stringify(sensorFilter))}`).map(RxjsHelpers.mapArrayAttributes)
             )
             .map((results: [any[], any[], any[]]): any[] => results.reduce((prev, cur) => prev.concat(cur), []));
+    }
+
+    public getSummaryStatistics(): Observable<IndicatorSharingSummaryStatistics[]> {
+        return this.genericApi.get(`${this.baseUrl}/summary-statistics`).pluck('attributes');
     }
 }

--- a/src/app/indicator-sharing/models/summary-statistics.ts
+++ b/src/app/indicator-sharing/models/summary-statistics.ts
@@ -1,0 +1,7 @@
+export interface IndicatorSharingSummaryStatistics {
+    _id: string;
+    count: number;
+    likes: number;
+    views: number;
+    comments: number;
+}

--- a/src/app/indicator-sharing/summary-statistics/summary-statistics.component.html
+++ b/src/app/indicator-sharing/summary-statistics/summary-statistics.component.html
@@ -1,4 +1,5 @@
-<div id="summaryStatisticsComponent" *ngIf="serverCallComplete">
+<div id="summaryStatisticsComponent" *ngIf="serverCallComplete" class="uf-well">
+  <h3 class="lightH3">Summary Statistics</h3>
 
   <label>Most Contributions</label>
   <p>{{ mostIndicators.org }}: {{ mostIndicators.number }}</p>

--- a/src/app/indicator-sharing/summary-statistics/summary-statistics.component.html
+++ b/src/app/indicator-sharing/summary-statistics/summary-statistics.component.html
@@ -1,0 +1,14 @@
+<div id="summaryStatisticsComponent" *ngIf="serverCallComplete">
+
+  <label>Most Contributions</label>
+  <p>{{ mostIndicators.org }}: {{ mostIndicators.number }}</p>
+
+  <label>Most Views</label>
+  <p>{{ mostViewed.org }}: {{ mostViewed.number }}</p>
+
+  <label>Most Likes Recieved</label>
+  <p>{{ mostLiked.org }}: {{ mostLiked.number }}</p>
+
+  <label>Most Comments Recieved</label>
+  <p>{{ mostComments.org }}: {{ mostComments.number }}</p>
+</div>

--- a/src/app/indicator-sharing/summary-statistics/summary-statistics.component.spec.ts
+++ b/src/app/indicator-sharing/summary-statistics/summary-statistics.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SummaryStatisticsComponent } from './summary-statistics.component';
+
+describe('SummaryStatisticsComponent', () => {
+  let component: SummaryStatisticsComponent;
+  let fixture: ComponentFixture<SummaryStatisticsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SummaryStatisticsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SummaryStatisticsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/indicator-sharing/summary-statistics/summary-statistics.component.spec.ts
+++ b/src/app/indicator-sharing/summary-statistics/summary-statistics.component.spec.ts
@@ -1,14 +1,67 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 
 import { SummaryStatisticsComponent } from './summary-statistics.component';
+import { IndicatorSharingService } from '../indicator-sharing.service';
 
 describe('SummaryStatisticsComponent', () => {
   let component: SummaryStatisticsComponent;
   let fixture: ComponentFixture<SummaryStatisticsComponent>;
 
+  const indicatorSharingServiceMock = {
+    getSummaryStatistics: () => {
+      return Observable.of([
+        {
+          _id: 'identity--1234',
+          count: 2.0,
+          views: 2,
+          likes: 1,
+          comments: 1.0
+        },
+        {
+          _id: 'identity--5678',
+          count: 1.0,
+          views: 1,
+          likes: 3,
+          comments: 3.0
+        }
+      ]);
+    },
+    getIdentities: () => {
+      return Observable.of([
+        {
+          id: 'identity--1234',
+          type: 'identity',
+          attributes: {
+            id: 'identity--1234',
+            name: 'testorg1',
+            identity_class: 'organization'
+          }          
+        },
+        {
+          id: 'identity--5678',
+          type: 'identity',
+          attributes: {
+            id: 'identity--5678',
+            name: 'testorg2',
+            identity_class: 'organization'
+          }
+        }
+      ]);
+    }
+  };
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SummaryStatisticsComponent ]
+      declarations: [ SummaryStatisticsComponent ],
+      providers: [
+        {
+          provide: IndicatorSharingService,
+          useValue: indicatorSharingServiceMock
+        }
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   }));
@@ -21,5 +74,25 @@ describe('SummaryStatisticsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have correct mostIndicators', () => {
+    expect(component.mostIndicators.org).toEqual('testorg1');
+    expect(component.mostIndicators.number).toEqual(2);
+  });
+
+  it('should have correct mostViews', () => {
+    expect(component.mostViewed.org).toEqual('testorg1');
+    expect(component.mostViewed.number).toEqual(2);
+  });
+
+  it('should have correct mostLiked', () => {
+    expect(component.mostLiked.org).toEqual('testorg2');
+    expect(component.mostLiked.number).toEqual(3);
+  });
+
+  it('should have correct mostComments', () => {
+    expect(component.mostComments.org).toEqual('testorg2');
+    expect(component.mostComments.number).toEqual(3);
   });
 });

--- a/src/app/indicator-sharing/summary-statistics/summary-statistics.component.ts
+++ b/src/app/indicator-sharing/summary-statistics/summary-statistics.component.ts
@@ -1,0 +1,104 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { IndicatorSharingService } from '../indicator-sharing.service';
+import { IndicatorSharingSummaryStatistics } from '../models/summary-statistics';
+import { RxjsHelpers } from '../../global/static/rxjs-helpers';
+
+interface OrgNumber {
+  org: string;
+  number: number;
+}
+
+@Component({
+  selector: 'indicator-sharing-summary-statistics',
+  templateUrl: './summary-statistics.component.html',
+  styleUrls: ['./summary-statistics.component.scss']
+})
+export class SummaryStatisticsComponent implements OnInit {
+
+  public mostIndicators: OrgNumber;
+  public mostViewed: OrgNumber;
+  public mostLiked: OrgNumber;
+  public mostComments: OrgNumber;
+  public serverCallComplete: boolean = false;
+  private identities: any[] = [];
+
+  constructor(private indicatorSharingService: IndicatorSharingService) {}
+
+  ngOnInit() {
+    const getStats$ = Observable.forkJoin(
+      this.indicatorSharingService.getSummaryStatistics(), 
+      this.indicatorSharingService.getIdentities().map(RxjsHelpers.mapArrayAttributes)
+    )
+      .subscribe(
+        ([stats, identities]: [IndicatorSharingSummaryStatistics[], any]) => {
+          this.serverCallComplete = true;
+          this.identities = identities;
+          stats.forEach((stat: IndicatorSharingSummaryStatistics, i: number) => {
+            if (i === 0) {
+              this.mostIndicators = {
+                org: this.getOrgName(stat._id),
+                number: stat.count
+              };
+              this.mostViewed = {
+                org: this.getOrgName(stat._id),
+                number: stat.views
+              };
+              this.mostLiked = {
+                org: this.getOrgName(stat._id),
+                number: stat.likes
+              };
+              this.mostComments = {
+                org: this.getOrgName(stat._id),
+                number: stat.comments
+              };
+            } else {
+              if (stat.count > this.mostIndicators.number) {
+                this.mostIndicators = {
+                  org: this.getOrgName(stat._id),
+                  number: stat.count
+                };
+              }
+              if (stat.views > this.mostViewed.number) {
+                this.mostViewed = {
+                  org: this.getOrgName(stat._id),
+                  number: stat.views
+                };
+              }
+              if (stat.likes > this.mostLiked.number) {
+                this.mostLiked = {
+                  org: this.getOrgName(stat._id),
+                  number: stat.likes
+                };
+              }
+              if (stat.comments > this.mostComments.number) {
+                this.mostComments = {
+                  org: this.getOrgName(stat._id),
+                  number: stat.comments
+                };
+              }
+            }
+          });
+        },
+        (err) => {
+          console.log(err);
+        },
+        () => {
+          if (getStats$) {
+            getStats$.unsubscribe();
+          }
+        }
+      );
+  }
+
+  private getOrgName(orgId: string): string {
+    const findOrg = this.identities.find((identity) => identity.id === orgId);
+    if (findOrg) {
+      return findOrg.name;
+    } else {
+      return 'Unknown';
+    }
+  }
+
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -4,6 +4,7 @@
 
 $dark-text-default: rgba(0, 0, 0, 0.87);
 $dark-text-dimmed: rgba(1, 1, 1, .54);
+$label-color: #9e9e9e;
 $light-text-default: #ffffff;
 $light-text-slightly-dimmed: rgba(255, 255, 255, .87);
 $light-text-dimmed: rgba(255, 255, 255, .54);

--- a/src/styles/partials/_styles.scss
+++ b/src/styles/partials/_styles.scss
@@ -276,6 +276,10 @@ a {
     color: $neutral-color;
 }
 
+.labelColor {
+    color: $label-color;
+}
+
 /**
  * STIX Icons
  *


### PR DESCRIPTION
Requirements: `issue-849` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/121

Instructions: Restart stack.  Go to analytic exchange, click stats icon to the right of results count

If you have not liked or commented on any analytics, these stats will be limited. 

An optional step would be to add indicators under a different organization.

fixes unfetter-discover/unfetter#849