### PR TITLE
Issue 875

### DIFF
--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -234,7 +234,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
       .select('assessment')
       .pluck('saved')
       .distinctUntilChanged()
-      .filter((el: SavedState) => el.finished === true)
+      .filter((el: SavedState) => el && el.finished === true)
       .subscribe(
         (saved: SavedState) => {
           const rollupId = saved.rollupId;

--- a/src/app/models/sighting.ts
+++ b/src/app/models/sighting.ts
@@ -23,7 +23,8 @@ export class Sighting {
         where_sighted_refs: [
           string
         ];
-        summary: boolean
+        summary: boolean;
+        created_by_ref: string;
     };
 
      constructor(data?: Sighting) {

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
@@ -41,7 +41,7 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                     <button  id="canel-btn"  mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                    <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveAttackPattern()" [disabled]="!attackPattern.attributes.name">SAVE</button>
+                    <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveAttackPattern()" [disabled]="!attackPattern.attributes.name || !attackPattern.attributes.created_by_ref">SAVE</button>
 
                 </div>
             </div>

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.spec.ts
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-patterns-new.component.spec.ts
@@ -98,8 +98,9 @@ function buttons() {
       expect(de.nativeElement.disabled).toBe(true, 'should disable save button if name field is empty');
     });
 
-    it('should enable save button if name field is not empty', () => {
+    it('should enable save button if name and created_by_ref fields are not empty', () => {
       comp.attackPattern.attributes.name = 'Test Attack Pattern name';
+      comp.attackPattern.attributes.created_by_ref = 'identity-1234';
       fixture.detectChanges(); // runs initial lifecycle hooks
       de = fixture.debugElement.query(By.css('#save-btn'))
       // should not create attack-pattern

--- a/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.html
+++ b/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.html
@@ -76,7 +76,7 @@
         <div class="button-row pull-right">
 
                  <button  id="cancel-btn" mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                 <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveCampaign()" [disabled]="!campaign.attributes.name">SAVE</button>
+                 <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveCampaign()" [disabled]="!campaign.attributes.name || !campaign.attributes.created_by_ref">SAVE</button>
 
         </div>
     </div>

--- a/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.spec.ts
+++ b/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.spec.ts
@@ -48,8 +48,9 @@ function buttons() {
             expect(de.nativeElement.disabled).toBe(true, 'should disable save button if name field is empty');
         });
 
-        it('should enable save button if name field is not empty', () => {
+        it('should enable save button if name and created_by_ref fields are not empty', () => {
             comp.campaign.attributes.name = 'New campaign';
+            comp.campaign.attributes.created_by_ref = 'identity-1234';
             fixture.detectChanges(); // runs initial lifecycle hooks
             de = fixture.debugElement.query(By.css('#save-btn'))
             // should not create campaign

--- a/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.html
+++ b/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.html
@@ -28,7 +28,7 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                         <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                        <button mat-raised-button (click)="saveCourceOfAction()" [disabled]="!courseOfAction.attributes.name" color="primary">SAVE</button>
+                        <button mat-raised-button (click)="saveCourceOfAction()" [disabled]="!courseOfAction.attributes.name || !courseOfAction.attributes.created_by_ref" color="primary">SAVE</button>
 
                 </div>
             </div>

--- a/src/app/settings/stix-objects/indicators/indicator-new/indicator-new.component.html
+++ b/src/app/settings/stix-objects/indicators/indicator-new/indicator-new.component.html
@@ -77,7 +77,7 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                         <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                        <button mat-raised-button (click)="saveIndicator()" [disabled]="!indicator.attributes.name" color="primary">SAVE</button>
+                        <button mat-raised-button (click)="saveIndicator()" [disabled]="!indicator.attributes.name || !indicator.attributes.pattern || !indicator.attributes.created_by_ref" color="primary">SAVE</button>
                 </div>
             </div>
         </div>

--- a/src/app/settings/stix-objects/intrusion-sets/intrusion-set-new/intrusion-set-new.component.html
+++ b/src/app/settings/stix-objects/intrusion-sets/intrusion-set-new/intrusion-set-new.component.html
@@ -126,7 +126,7 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!intrusionSet.attributes.name" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!intrusionSet.attributes.name || !intrusionSet.attributes.created_by_ref" color="primary">SAVE</button>
         </div>
     </div>
 </div>

--- a/src/app/settings/stix-objects/malwares/malware-new/malware-new.component.html
+++ b/src/app/settings/stix-objects/malwares/malware-new/malware-new.component.html
@@ -79,7 +79,7 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveMalware()" [disabled]="!malware.attributes.name" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveMalware()" [disabled]="!malware.attributes.name || !malware.attributes.created_by_ref" color="primary">SAVE</button>
         </div>
     </div>
 </div>

--- a/src/app/settings/stix-objects/reports/report-new/report-new.component.html
+++ b/src/app/settings/stix-objects/reports/report-new/report-new.component.html
@@ -66,7 +66,7 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!report.attributes.name" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!report.attributes.name || !report.attributes.created_by_ref" color="primary">SAVE</button>
         </div>
     </div>
 </div>

--- a/src/app/settings/stix-objects/sensors/sensor-new/sensor-new.component.html
+++ b/src/app/settings/stix-objects/sensors/sensor-new/sensor-new.component.html
@@ -35,7 +35,7 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button class=" " mat-raised-button (click)="saveNewSensor()" [disabled]="!sensor.attributes.name" color="primary">SAVE</button>
+                <button class=" " mat-raised-button (click)="saveNewSensor()" [disabled]="!sensor.attributes.name ||!sensor.attributes.created_by_ref" color="primary">SAVE</button>
         </div>
     </div>
 </div>

--- a/src/app/settings/stix-objects/sightings/sighting-new/sighting-new.component.html
+++ b/src/app/settings/stix-objects/sightings/sighting-new/sighting-new.component.html
@@ -47,7 +47,7 @@
     <div class="col-md-12">
          <div class="button-row pull-right">
                     <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                    <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!sighting.attributes.sighting_of_ref" color="primary">SAVE</button>
+                    <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!sighting.attributes.sighting_of_ref || !sighting.attributes.created_by_ref" color="primary">SAVE</button>
 
             </div>
     </div>

--- a/src/app/settings/stix-objects/tools/tool-new/tool-new.component.html
+++ b/src/app/settings/stix-objects/tools/tool-new/tool-new.component.html
@@ -79,7 +79,7 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button class=" " mat-raised-button (click)="saveNewTool()" [disabled]="!tool.attributes.name" color="primary">SAVE</button>
+                <button class=" " mat-raised-button (click)="saveNewTool()" [disabled]="!tool.attributes.name || !tool.attributes.created_by_ref" color="primary">SAVE</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Instructions: 
- Go to each crud page (minus identity) and confirm that the "SAVE" button will only be enabled after required fields are selected... which will be Submitter Organization and Name for most (but not all) types.

Note that this fix does NOT attempt to fix required feeds of attached documents, like external references etc.