### PR TITLE
fixes unfetter-discover/discover#861

### DIFF
--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -1,4 +1,5 @@
-<div id="newAssessmentsSummary" *ngIf="finishedLoading === true; else loadingBlock" class="fadeIn">
+<div id="newAssessmentsSummary" *ngIf="finishedLoading && finishedLoadingKCD 
+  && finishedLoadingRBAP && finishedLoadingSAD; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="summary !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">


### PR DESCRIPTION
There are 4 calls to the backend to get all the data for the page. There is a loading block that is used while waiting for the calls to return, but it was only waiting until the first response came back. That left the charts with nothing to show. But afterwards you could get them to render by changing the risk threshold slider.

The fix was to wait until we have the data to render the page.