### PR TITLE
restricted stix dashboard to admins

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -40,6 +40,12 @@
             <div class="appItemText">API Explorer</div>
           </a>
         </span>
+        <span class="appLinkWrapper" *ngIf="authService.isAdmin()">
+          <a routerLink="./stix/attack-patterns" class="appLink" (click)="showAppMenu = false">
+            <img src="{{ stixIcon }}" class="appItemImg">
+            <div class="appItemText">STIX</div>
+          </a>
+        </span>
         <span class="appLinkWrapper" *ngIf="authService.isOrgLeader()">
           <a routerLink="./organizations" class="appLink" (click)="showAppMenu = false">
             <img src="{{ orgLeaderIcon }}" class="appItemImg">

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -45,13 +45,7 @@ export class HeaderNavigationComponent {
       title: 'Intrusion Set Dashboard',
       // Placeholder icon
       icon: Constance.LOGO_IMG_THREAT_DASHBOARD
-    },
-    {
-      url: 'stix/attack-patterns',
-      title: 'STIX',
-      // Placeholder icon
-      icon: Constance.LOGO_IMG_THREAT_DASHBOARD
-    },
+    },    
     {
       url: 'partners',
       title: 'Partners',
@@ -72,6 +66,7 @@ export class HeaderNavigationComponent {
   public apiDocsIcon: string = Constance.LOGO_IMG_THREAT_DASHBOARD;
   public orgLeaderIcon: string = Constance.LOGO_IMG_THREAT_DASHBOARD;
   public adminIcon: string = Constance.LOGO_IMG_THREAT_DASHBOARD;
+  public stixIcon: string = Constance.LOGO_IMG_THREAT_DASHBOARD;
   public encodedToken: string = '';
   @Input() public title;
 

--- a/src/app/settings/stix-routing.module.ts
+++ b/src/app/settings/stix-routing.module.ts
@@ -107,10 +107,16 @@ import {
 } from './stix-objects/sensors';
 
 import { AuthGuard } from '../core/services/auth.guard';
+import { UserRoles } from '../global/enums/user-roles.enum';
 
 const stixRoutes: Routes = [{
     path: 'stix',
     canActivate: [AuthGuard],
+    data: {
+      ROLES: [
+        UserRoles.ADMIN
+      ]
+    },
     component: StixHomeComponent,
     children: [
       {


### PR DESCRIPTION
Requirements: Access to both an admin and standard user account.  This can be done with two accounts, or by modifying mongo directly and logging out and back in.

If you want to use mongo, the commands are: `db.getCollection('user').update({"_id" : ObjectId("(your users mongo ID)")}, {  $set: { role: 'STANDARD_USER'} } )` and `db.getCollection('user').update({"_id" : ObjectId("(your users mongo ID)")}, {  $set: { role: 'ADMIN'} } )`

Instructions:
- Confirm 'STIX' icon in App Menu displays for admins but not standard users
- Confirm STIX dashboard still works for admins
- Confirm standard user cant force route to STIX dashboard

fixes unfetter-discover/unfetter#785