### PR TITLE
Issue 789

### DIFF
--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -13,6 +13,7 @@ export class UsersService {
     private identitiesUrl = Constance.IDENTITIES_URL;
     private orgUrl = Constance.ORGANIZATIONS_URL;
     private refreshTokenUrl = Constance.REFRESH_TOKEN_URL;
+    private authUrl = Constance.AUTH_URL;
 
     constructor(private genericApi: GenericApi) { }
 
@@ -51,5 +52,17 @@ export class UsersService {
         return this.genericApi.get(this.refreshTokenUrl)
             .pluck('attributes')
             .pluck('token');
+    }
+
+    public emailAvailable(email: string): Observable<boolean> {
+        return this.genericApi.get(`${this.authUrl}/email-available/${email}`)
+            .pluck('attributes')
+            .pluck('available');
+    }
+
+    public userNameAvailable(userName: string): Observable<boolean> {
+        return this.genericApi.get(`${this.authUrl}/username-available/${userName}`)
+            .pluck('attributes')
+            .pluck('available');
     }
 }

--- a/src/app/users/login-callback/login-callback.component.ts
+++ b/src/app/users/login-callback/login-callback.component.ts
@@ -22,7 +22,7 @@ export class LoginCallbackComponent implements OnInit {
             .subscribe((params) => {
                 const token = `Bearer ${params.token}`;
                 this.store.dispatch(new userActions.SetToken(token));             
-                this.store.dispatch(new userActions.FetchUser(token));                           
+                this.store.dispatch(new userActions.FetchUser(token));              
             },
             (err) => {
                 console.log(err);                

--- a/src/app/users/register/register.component.html
+++ b/src/app/users/register/register.component.html
@@ -55,6 +55,10 @@
                                             Username is
                                             <strong>required</strong>
                                         </mat-error>
+                                        <mat-error *ngIf="form.get('unfetterInformation').get('userName').hasError('userNameTaken')">
+                                            Username is
+                                            <strong>taken</strong>
+                                        </mat-error>
                                     </mat-form-field>
 
                                     <mat-form-field class="full-width mb-10">
@@ -65,6 +69,10 @@
                                         <mat-error *ngIf="form.get('unfetterInformation').get('email').hasError('required')">
                                             Email is
                                             <strong>required</strong>
+                                        </mat-error>
+                                        <mat-error *ngIf="form.get('unfetterInformation').get('email').hasError('emailTaken')">
+                                            Email is 
+                                            <strong>taken</strong>
                                         </mat-error>
                                     </mat-form-field>
                                 </div>

--- a/src/app/users/register/register.component.html
+++ b/src/app/users/register/register.component.html
@@ -1,8 +1,14 @@
 <div id="registerComponent" class="container">
-    <div class="row mt-20 mb-10">
-        <div class="col-xs-12 col-lg-6 col-lg-offset-3">
+    <div class="row mt-20">
+        <div class="col-xs-12 col-md-8 col-md-offset-2">
             <h3>Finalize Registration</h3>
             <p class="lead">You are almost ready to use Unfetter.  Please verify and fill out the following information.</p>
+        </div>
+    </div>
+
+    <div class="row mb-10">
+        <div class="col-xs-12 col-md-8 col-md-offset-2">
+            <help-window [helpHtml]="helpHtml"></help-window>
         </div>
     </div>
 
@@ -15,8 +21,8 @@
         </div>
     </div>
 
-    <div class="row" *ngIf="!submitError">
-        <div class="col-xs-12 col-lg-6 col-lg-offset-3">
+    <div class="row mb-15" *ngIf="!submitError">
+        <div class="col-xs-12 col-md-8 col-md-offset-2">
             <mat-card *ngIf="form !== undefined" class="uf-mat-card">
 
                 <mat-card-header>
@@ -106,9 +112,18 @@
                             <mat-step label="STIX Identity" [stepControl]="form.get('identity')">
                                 <div id="identityForm">
                                     <div class="uf-well mt-3">
-                                        <p>STIX Identities are how you will be represented in STIX documents.  This form is for your personal/individual  STIX Identity.</p>
-                                    </div>                                
-                                    <!-- TODO add option to import identity -->
+                                        <h4>STIX Identities</h4>
+                                        <p>STIX identities are how you will be represented in STIX documents.  This form is for your personal/individual STIX identity.</p>
+                                        <h4>Import Identity</h4>
+                                        <p>If you have an existing individual STIX identity, you may import it into Unfetter.  Acceptable formats include a standalone STIX identity and a STIX identity wrapped in a STIX bundle.</p>
+                                    </div> 
+                                    
+                                    <div class="uf-well-warn mt-3" *ngIf="importErrorMsg !== ''">{{ importErrorMsg }}</div>
+                                    
+                                    <div class="mb-3">
+                                        <button mat-raised-button type="button" color="primary" id="uploadButton" (click)="openFileUpload()">Import STIX Identity</button>
+                                        <input #importStix id="fileInput" name="file" type="file" class="displayNone" (change)="fileChanged($event)">
+                                    </div>
                                 
                                     <div formGroupName="identity">
                                         <mat-form-field class="full-width mb-10">

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
@@ -20,9 +20,22 @@ export class RegisterComponent implements OnInit {
     public userReturn: any;
     public registrationSubmitted: boolean = false;
     public submitError: boolean = false;
+    public importErrorMsg: string = '';
 
     public identityClasses: string[] = [];
     public identitySectors: string[] = [];
+
+    @ViewChild('importStix')
+    public importStixEl: ElementRef;
+
+    public helpHtml: string = `
+        <h4>Approval Process</h4>
+        <p>After completing registration, an Unfetter administrator will have to approve your account before you can use the application.</p>
+        <h4>Organizations</h4>
+        <p>To get the most out of Unfetters, users should be in one or more organizations.  After being approved to the application, you may apply to join organizations in the users settings dashboard.  An organization leader or an Unfetter administrator has to approve organization applicant.</p>
+    `;
+
+    private importedStixIdentity: any = {};
 
     constructor(
         private usersService: UsersService, 
@@ -98,7 +111,10 @@ export class RegisterComponent implements OnInit {
             }            
         }  
 
-        this.userReturn.identity = cleanObjectProperties({}, { ...this.form.get('identity').value });
+        this.userReturn.identity = { 
+            ...this.importedStixIdentity, 
+            ...cleanObjectProperties({}, { ...this.form.get('identity').value }) 
+        };
         this.userReturn.registrationInformation = cleanObjectProperties({}, { ...this.form.get('registrationInformation').value });
         
         const submitRegistration$ = this.usersService.finalizeRegistration(this.userReturn)
@@ -126,6 +142,54 @@ export class RegisterComponent implements OnInit {
                     }
                 }
             );             
+    }
+
+    public openFileUpload() {
+        this.importStixEl.nativeElement.click();
+    }
+
+    public fileChanged(event: UIEvent) {       
+        this.importErrorMsg = '';
+        this.importedStixIdentity = {};
+        try {
+            const reader: FileReader = new FileReader();
+            reader.onload = (e: any) => {
+                try {                    
+                    const stixContent = JSON.parse(e.target.result);
+                    this.processImportedIdentity(stixContent);
+                } catch (error) {
+                    this.importErrorMsg = 'File is not JSON, please upload a STIX bundle or identity';
+                }
+            };
+            const file = this.importStixEl.nativeElement.files[0];
+            const fileContents = reader.readAsText(file, 'UTF-8');
+        } catch (error) {
+            this.importErrorMsg = 'Unable to read file';
+        }        
+    }
+
+    private processImportedIdentity(stixContent: any) {
+        if (stixContent.type) {
+            if (stixContent.type === 'bundle' && stixContent.objects && stixContent.objects.length && stixContent.objects[0].type === 'identity') {
+                if (stixContent.objects[0].identity_class === 'individual') {
+                    this.importedStixIdentity = stixContent.objects[0];
+                    this.form.get('identity').patchValue(stixContent.objects[0]);
+                } else {
+                    this.importErrorMsg = 'Only individual identities can be accepted';
+                }
+            } else if (stixContent.type === 'identity') {
+                if (stixContent.identity_class === 'individual') {
+                    this.importedStixIdentity = stixContent;
+                    this.form.get('identity').patchValue(stixContent);
+                } else {
+                    this.importErrorMsg = 'Only individual identities can be accepted';
+                }
+            } else {
+                this.importErrorMsg = 'Only STIX identities, or STIX identities in bundles may be processed';
+            }
+        } else {
+            this.importErrorMsg = 'File does not appear to be STIX';
+        }
     }
 
     private validateEmail(emailCtrl: FormControl): Observable<any> {

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
 
 import { UsersService } from '../../core/services/users.service';
 import { AuthService } from '../../core/services/auth.service';
@@ -42,11 +43,11 @@ export class RegisterComponent implements OnInit {
                             unfetterInformation: new FormGroup({
                                 firstName: new FormControl(user.firstName ? user.firstName : '', Validators.required),
                                 lastName: new FormControl(user.lastName ? user.lastName : '', Validators.required),
-                                userName: new FormControl(user.userName ? user.userName : user.github.userName ? user.github.userName : '', Validators.required),
+                                userName: new FormControl(user.userName ? user.userName : user.github.userName ? user.github.userName : '', Validators.required, this.validateUserName.bind(this)),
                                 email: new FormControl(user.email ? user.email : '', [
                                     Validators.required,
                                     Validators.email
-                                ]),
+                                ], this.validateEmail.bind(this)),
                             }),
                             registrationInformation: new FormGroup({
                                 applicationNote: new FormControl(''),
@@ -125,5 +126,17 @@ export class RegisterComponent implements OnInit {
                     }
                 }
             );             
+    }
+
+    private validateEmail(emailCtrl: FormControl): Observable<any> {
+        return Observable.timer(50)
+            .switchMap(() => this.usersService.emailAvailable(emailCtrl.value))
+            .map((emailAvailable: boolean) => emailAvailable ? null : { 'emailTaken': true });
+    }
+
+    private validateUserName(userNameCtrl: FormControl): Observable<any> {
+        return Observable.timer(50)
+            .switchMap(() => this.usersService.userNameAvailable(userNameCtrl.value))
+            .map((userNameAvailable: boolean) => userNameAvailable ? null : { 'userNameTaken': true });
     }
 }

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -91,6 +91,7 @@ export const Constance = {
   X_UNFETTER_ASSESSMENT3_URL: 'api/x-unfetter-object-assessments',
   X_UNFETTER_ASSESSMENT3_TYPE: 'x-unfetter-object-assessment',
 
+  AUTH_URL: 'api/auth',
   USER_FROM_TOKEN_URL: 'api/auth/user-from-token',
   FINALIZE_REGISTRATION_URL: 'api/auth/finalize-registration',
   PROFILE_BY_ID_URL: 'api/auth/profile',

--- a/src/styles/partials/_styles.scss
+++ b/src/styles/partials/_styles.scss
@@ -21,6 +21,10 @@ label {
     cursor: pointer !important;
 }
 
+.displayNone {
+    display: none !important;
+}
+
 .hideFooter .footer {
     display: none;
 }


### PR DESCRIPTION
Requirements: `issue-789` on `unfetter-ui` and `unfetter-store`, two github accounts, and two STIX JSON files

File 1: 
```
{
  "name": "Test User Standalone",
  "identity_class": "individual",
  "id": "identity--e240b251-5c41-402e-a0e8-7b81ecc1c01a",
  "description": "Test User Standalone",
  "type": "identity",
  "modified": "2017-11-01T18:42:35.073Z",
  "created": "2017-11-01T18:36:59.472Z"
}
```

File 2: 

```
{
  "type": "bundle",
  "id": "stix-archive-bundle",
  "spec_version": "2.0",
  "objects": [{
      "name": "Test User Bundle",
      "identity_class": "individual",
      "id": "identity--e240b251-5c41-402e-a0e8-7b81ecc1c01a",
      "description": "Test user Bundle",
      "type": "identity",
      "modified": "2017-11-01T18:42:35.073Z",
      "created": "2017-11-01T18:36:59.472Z"
    }]
}
```
Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/137

Instructions:
- If the 2nd user is already registered, delete his account
- Login with 2nd user
- Test new `email` validation by attempting to use the same email as user 1
- Test new `User Name` validation by attempting to use the same userName as user 1
- in the STIX identity portion of the stepper run the following tests:
- 1 attempt to load a non-JSON file
- 2 Load a random (non-stix) JSON file
- Confirm error messages display properly for 1 and 2
- 3 Load file 1
- 4 Load file 2
- Edit the description
- Register, and check mongo via `db.getCollection('user').find({})` to confirm that the informaiton was loaded correctly

fixes unfetter-discover/unfetter#789
