### PR TITLE
Adds a minimap capability to the heatmap.

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.html
+++ b/src/app/global/components/heatmap/heatmap.component.html
@@ -1,2 +1,5 @@
-<div #heatmap class="col-xs-1 heat-map" (mousewheel)="stopScroll($event)"></div>
+<div class="heatmap-with-minimap">
+    <div #heatmap class="heat-map" (mousewheel)="stopScroll($event)"></div>
+    <div #minimap class="mini-map" [hidden]="!options.hasMinimap" (mousewheel)="stopScroll($event)"></div>
+</div>
 <div style="clear:both;"></div>

--- a/src/app/global/components/heatmap/heatmap.component.scss
+++ b/src/app/global/components/heatmap/heatmap.component.scss
@@ -1,11 +1,25 @@
 @import '../../../../styles/_variables.scss';
 
+div.heatmap-with-minimap {
+    display: flex;
+    flex-direction: row;
+}
 div.heat-map {
-    width: 100%;
+    flex: 1;
     height: 400px;
     margin: 0;
     padding: 0;
-    background: $app-background-color;
+    background-color: $app-background-color;
+}
+div.mini-map {
+    width: 200px;
+    height: 200px;
+    margin: 36px 5px 0 10px;
+    padding: 0;
+    background-color: transparent;
+    svg {
+        background-color: $app-background-color;
+    }
 }
 
 :host ::ng-deep {

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -37,7 +37,8 @@ export class IndicatorHeatMapComponent implements OnInit {
             'false': {bg: '#ccc', fg: 'black'},
             'selected': {bg: '#33a0b0', fg: 'black'},
         },
-        showText: false
+        showText: false,
+        hasMinimap: true,
     }
 
     public attackPatterns = {};

--- a/src/app/intrusion-set-dashboard/attack-patterns-heatmap/attack-patterns-heatmap.component.ts
+++ b/src/app/intrusion-set-dashboard/attack-patterns-heatmap/attack-patterns-heatmap.component.ts
@@ -42,6 +42,7 @@ export class AttackPatternsHeatmapComponent implements OnInit, DoCheck {
         heatColors: {'false': this.noColor},
         noColor: this.noColor,
         showText: true,
+        hasMinimap: true,
     };
     public showHeatMap = false;
 

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.scss
@@ -140,6 +140,9 @@ $white: #FFFFFF;
         height: 400px;
         background: $white;
     }
+    unf-heatmap div.mini-map svg {
+        background: $white;
+    }
 
 }
 

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.ts
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.ts
@@ -71,6 +71,7 @@ export class KillChainTableComponent implements OnInit, OnDestroy, AfterViewInit
   public heatMapData: Array<HeatMapData> = [];
   public readonly heatMapOptions: HeatMapOptions = {
     showText: false,
+    hasMinimap: true,
   };
   public showHeatMap = true;
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#853.

For testing, applied minimap to kill chain table on the threat dashboard.

Minimap should be in sync with heatmap, for zooming in and out, and panning. Clicking on minimap should jump the panning frame to that location. Double-clicking should zoom out completely.

No new spec tests were added for this feature due to how hard it is to get details from, let alone manipulate, svg components in the tests. Will be adding them in a separate coverage-test issue.