### PR TITLE
heatmap gradients

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.html
+++ b/src/app/global/components/heatmap/heatmap.component.html
@@ -1,5 +1,5 @@
 <div class="heatmap-with-minimap">
     <div #heatmap class="heat-map" (mousewheel)="stopScroll($event)"></div>
-    <div #minimap class="mini-map" [hidden]="!options.hasMinimap" (mousewheel)="stopScroll($event)"></div>
+    <div #minimap class="mini-map" [hidden]="!options.zoom.hasMinimap" (mousewheel)="stopScroll($event)"></div>
 </div>
 <div style="clear:both;"></div>

--- a/src/app/global/components/heatmap/heatmap.component.spec.ts
+++ b/src/app/global/components/heatmap/heatmap.component.spec.ts
@@ -35,6 +35,7 @@ describe('HeatmapComponent', () => {
         heatmap.nativeElement.style.height = '100px';
         expect(heatmap).toBeTruthy();
         component = fixture.componentInstance;
+        component.options = {};
         fixture.detectChanges();
     });
 
@@ -87,7 +88,7 @@ describe('HeatmapComponent', () => {
         console.log('rects', rects);
         expect(Array.from(rects)
             .filter(rect => rect.attributes['fill'].nodeValue ===
-                    component.options.heatColors['true'].bg).length).toEqual(9);
+                    component.options.color.heatColors['true'].bg).length).toEqual(9);
     });
 
 });

--- a/src/app/global/components/heatmap/heatmap.component.spec.ts
+++ b/src/app/global/components/heatmap/heatmap.component.spec.ts
@@ -44,35 +44,35 @@ describe('HeatmapComponent', () => {
 
     it('should accept input heatmap data, default settings', async() => {
         component.heatMapData = [
-            {batch: 'The Americas', active: null, columns: [[
-                {batch: 'Canada', active: false},
-                {batch: 'America', active: true},
-                {batch: 'Mexico', active: false},
-                {batch: 'Brazil', active: true},
-            ]]},
-            {batch: 'Eurasia', active: null, columns: [[
-                {batch: 'Britain', active: true},
-                {batch: 'France', active: false},
-                {batch: 'Germany', active: true},
-                {batch: 'Russia', active: false},
-                {batch: 'China', active: false},
-                {batch: 'India', active: false},
-                {batch: 'Arabia', active: false},
-                {batch: 'Greece', active: true},
-                {batch: 'Italy', active: false},
-            ]]},
-            {batch: 'Africa', active: null, columns: [[
-                {batch: 'Egypt', active: false},
-                {batch: 'Congo', active: false},
-            ]]},
-            {batch: 'Australonesia', active: null, columns: [[
-                {batch: 'Australia', active: true},
-                {batch: 'New Zealand', active: false},
-                {batch: 'Indonesia', active: false},
-                {batch: 'Philippines', active: true},
-                {batch: 'Fiji', active: true},
-                {batch: 'Bali', active: true},
-            ]]},
+            {title: 'The Americas', value: null, cells: [
+                {title: 'Canada', value: false},
+                {title: 'America', value: true},
+                {title: 'Mexico', value: false},
+                {title: 'Brazil', value: true},
+            ]},
+            {title: 'Eurasia', value: null, cells: [
+                {title: 'Britain', value: true},
+                {title: 'France', value: false},
+                {title: 'Germany', value: true},
+                {title: 'Russia', value: false},
+                {title: 'China', value: false},
+                {title: 'India', value: false},
+                {title: 'Arabia', value: false},
+                {title: 'Greece', value: true},
+                {title: 'Italy', value: false},
+            ]},
+            {title: 'Africa', value: null, cells: [
+                {title: 'Egypt', value: false},
+                {title: 'Congo', value: false},
+            ]},
+            {title: 'Australonesia', value: null, cells: [
+                {title: 'Australia', value: true},
+                {title: 'New Zealand', value: false},
+                {title: 'Indonesia', value: false},
+                {title: 'Philippines', value: true},
+                {title: 'Fiji', value: true},
+                {title: 'Bali', value: true},
+            ]},
         ];
         component.ngOnInit();
         fixture.detectChanges();

--- a/src/app/global/components/heatmap/heatmap.data.ts
+++ b/src/app/global/components/heatmap/heatmap.data.ts
@@ -1,0 +1,290 @@
+import { Dictionary } from '../../../models/json/dictionary';
+
+/**
+ * This is the format of the data to be provided to the component.
+ */
+export interface HeatCellData {
+    /**
+     * Value displayed in the text; also identifies which cell triggered a hover or click event.
+     */
+    title: string,
+
+    /**
+     * This value corresponds to the name of a heat color specified in the heatmap options.
+     */
+    value: boolean | string,
+}
+
+export interface HeatBatchData {
+    /**
+     * Header name for a batch (group) of cells.
+     */
+    title: string,
+
+    /**
+     * Batches are normally displayed using alternating background (and maybe foreground) colors. You can, however,
+     * specify a heat that would match a name in the heatmap options; thus creating custom colors for each batch.
+     */
+    value: string | null,
+
+    /**
+     * The cells that make up this batch. One day, perhaps, we can make these cells and/or nested batches. Fun!
+     */
+    cells?: Array<HeatCellData>,
+}
+
+/**
+ * Used to specify the color of your cell data. Each value can be either a color string ('white' or '#334455', etc.),
+ * or a CSS class prefixed with a period (.). You optionally specify heat colors in the options object you provide to
+ * the component.
+ */
+export interface HeatColor {
+    bg: string | string[],
+    fg: string,
+}
+
+/**
+ * Each batch (groups of cells) has colors for the header, the body background, and the border style. You optionally
+ * specify batch colors in the options object you provide to the component.
+ */
+export interface BatchColor {
+    header: HeatColor,
+    body: HeatColor,
+    border?: string,
+}
+
+/**
+ * Options specific to the display (sizes, viewability, padding, etc.) of the headers, batches and cells.
+ */
+export interface ViewRules {
+    /**
+     * The height of the header bar for rendering batch titles. Defaults to a whopping 48 pixels.
+     */
+    headerHeight?: number,
+
+    /**
+     * The minimum padding on both the left and right side of the chart. Defaults to 1 pixel. After all calculations
+     * are done, if there is _extra_ space, then the padding will be _increased_ so we can center the chart.
+     */
+    minSidePadding?: number,
+
+    /**
+     * This is guaranteed padding at the bottom of the chart. Useful if you want to draw a border.
+     */
+    minBottomPadding?: number,
+}
+
+/**
+ * Options specific to the use of colors in the headers, batches and cells.
+ */
+interface ColorRules {
+    /**
+     * This array colors the batches and their headers. The list of colors rotates for each batch (not each column).
+     * The defaults are reddish-brown header on white background, and very light gray on very light gray.
+     */
+    batchColors?: Array<BatchColor>,
+
+    /**
+     * This array colors the batches and their headers. The property names correspond to the value of the 'active'
+     * property in the heatmap data, which can just be any string or boolean value. So you can have 'active' values
+     * of true/false, or strings like 'S', 'M', 'L', etc. Be sure your data has colors for all the possible values.
+     */
+    heatColors?: Dictionary<HeatColor>,
+
+    /**
+     * Default color when no heat value matches.
+     */
+    noColor?: HeatColor,
+
+    /**
+     * Whether to shade cells with multiple heat values using a gradient of those heat colors. The default is true,
+     * but bear in mind that anything over three colors (really, it depends on the calculated cell width) tends to
+     * look bad. If you turn gradients off, and a cell has multiple heats, the default gradient color (which may
+     * also be a gradient) will be used instead, or the no-color value if you don't provide a default gradient. Note
+     * that another problem with gradients is that it makes it difficult to determine which text color to use, so
+     * either: Turn off the foreground color (fg == 'transparent'); set the background colors to dark, and foreground
+     * to light or white; or background to light, and foreground to dark or black.
+     */
+    showGradients?: boolean,
+
+    /**
+     * So, even if you do decide to display gradients, you can specify that you want to limit the number of colors to
+     * shade. If the cell exceeds this limit, the default gradient or no-color value is used instead.
+     */
+    maxGradients?: number,
+
+    /**
+     * The default color or color gradient to use for when gradients are turned off or a cell exceeds the maximum
+     * number of heats. Note this is a full HeatColor, so you can specify the foreground color with it.
+     */
+    defaultGradient?: HeatColor,
+}
+
+/**
+ * Options specific to handling hovering over the cells.
+ */
+interface HoverRules {
+    /**
+     * A color to highlight the background of a cell when the mouse hovers over it. Hover colors can never be gradients.
+     */
+    hoverColor?: HeatColor,
+
+    /**
+     * How long to wait, in milliseconds, before firing a hover event over one of the cells. Defaults to 500ms.
+     */
+    hoverDelay?: number,
+}
+
+/**
+ * Options specific to the printing the title of each header and cell.
+ */
+interface TextRules {
+    /**
+     * Whether to display the title of each batch in the header. The default is true.
+     */
+    showHeaderText?: boolean,
+
+    /**
+     * The size, in pixels, for text in the header. Defaults to 14px.
+     */
+    headerFontSize?: number,
+
+    /**
+     * Whether to allow the header text to be split on multiple lines. Note that this is dependent on how tall the
+     * header is (@see ViewRules#headerHeight). Splitting is based on whitespace, slashes (/) and hyphens (-). The
+     * default is true, since the default header height and default font size are good for it.
+     */
+    allowHeaderSplit?: boolean,
+
+    /**
+     * Whether to hyphenate the text in the header if there is no room to fully write it, and if splitting doesn't do
+     * the trick. Hyphenating is based solely on the presence of English consonants. It can only be so robust because
+     * loading an entire dictionary seems like overkill. Note that this is still dependent on how tall the header is
+     * (@see ViewRules#headerHeight). The default is true.
+     */
+    hyphenateHeaders?: boolean,
+
+    /**
+     * Whether to display the title of each cell in the body. The default is false.
+     */
+    showCellText?: boolean,
+
+    /**
+     * The size, in pixels, for text in the cells. Defaults to 6px. Too tiny to read, but affordable when zooming in.
+     */
+    cellFontSize?: number,
+
+    /**
+     * Whether to allow the cell text to be split on multiple lines. This is dependent on the calculated height of the
+     * cells, which in turn is based on the size of viewport, the number of batches, and how many cells are in each
+     * batch. Splitting is done in the same manner as for headers. The default is true, despite the visibility of the
+     * text defaulting to false.
+     */
+    allowCellSplit?: boolean,
+
+    /**
+     * Whether to hyphenate the text in the cells if there is no room to fully write it. Also depends on the available
+     * cell height. If you thought header hyphenation is cheap, cell hyphenation tends to look much worse, based on the
+     * simplistic rule. Hence, the default setting for this value is false.
+     */
+    hyphenateCells?: boolean,
+}
+
+/**
+ * Options specific to the zooming and the display of the minimap.
+ */
+interface ZoomRules {
+    /**
+     * The magnification range for zooming in on the heatmap. Both numbers must be positive (>0), and can be decimal.
+     * A value of 1 means full view, or 1x magnification. Higher numbers mean you are zooming in, and number less than
+     * 1 means you are shrinking the heatmap. The default is [1, 4]. The maximum magnification you want is going to
+     * depend on how much data you have. Extremely large amounts of data will cause your cells to look like pebbles or
+     * even dots, so you will want to bump that number up if that is your situation.
+     */
+    zoomExtent?: [number, number],
+
+    /**
+     * If the cells are really tiny, even rendering the text at a tiny font looks ridiculous. But if you zoom in to
+     * the given magnification, the cell text can be made visible. Note that if you turn cell text off, it overrides
+     * this setting. The default for this value is equal to the lowest zoomExtent value.
+     */
+    cellTitleExtent?: number,
+
+    /**
+     * Whether to draw a minimap beside the heatmap for assistance when zooming in. You will be specifying the
+     * minimap's viewport, either in the HTML or the CSS. The minimap will try to be a 1/4-sized view of the
+     * heatmap, which also shrinks its header by the same amount. The default is false.
+     */
+    hasMinimap?: boolean,
+
+    /**
+     * The minimap can only draw header text; it's nutty to try to draw a 1px font, let alone to write text in each
+     * cell. The minimap's header does not try to be a mirror of the heatmap, it just writes a single line, ellipsed
+     * if necessary, at this tiny font. If the provided font size is too tiny for the minimap header height, the
+     * header title won't be written at all. Defaults to 6px.
+     */
+    minimapFontSize?: number,
+
+    /**
+     * The thickness of the minimap zoom panner (the border that indicates the heatmap zoom area). Defaults to 1px.
+     */
+    minimapPannerWidth?: number,
+
+    /**
+     * The color of the minimap zoom panner. Defaults to black.
+     */
+    minimapPannerColor?: string,
+}
+
+/**
+ * You must provide an options object to the component, even if you do not wish to override any defaults. It's required,
+ * because their is a high likelihood that you won't be fond of the defaults, and to encourage you to use application
+ * colors that match your desired user experience.
+ */
+export class HeatMapOptions {
+    view?: ViewRules;
+    color?: ColorRules;
+    hover?: HoverRules;
+    text?: TextRules;
+    zoom?: ZoomRules;
+
+    static merge(custom: HeatMapOptions, defaults: HeatMapOptions): HeatMapOptions {
+        const merged = new HeatMapOptions();
+        merged.view = Object.assign({}, defaults.view, custom.view);
+        merged.color = Object.assign({}, defaults.color, custom.color);
+        merged.hover = Object.assign({}, defaults.hover, custom.hover);
+        merged.text = Object.assign({}, defaults.text, custom.text);
+        merged.zoom = Object.assign({}, defaults.zoom, custom.zoom);
+
+        // validate values
+        merged.view.headerHeight = Math.max(0, merged.view.headerHeight);
+        merged.view.minSidePadding = Math.max(0, merged.view.minSidePadding);
+        merged.view.minBottomPadding = Math.max(0, merged.view.minBottomPadding);
+        merged.color.maxGradients = Math.max(1, merged.color.maxGradients);
+        merged.hover.hoverDelay = Math.max(1, merged.hover.hoverDelay);
+        merged.text.headerFontSize = Math.max(0, merged.text.headerFontSize);
+        merged.text.cellFontSize = Math.max(0, merged.text.cellFontSize);
+        merged.zoom.minimapFontSize = Math.max(0, merged.zoom.minimapFontSize);
+        merged.zoom.minimapPannerWidth = Math.max(0, merged.zoom.minimapPannerWidth);
+        if (merged.hover.hoverColor && merged.hover.hoverColor.bg && Array.isArray(merged.hover.hoverColor.bg)) {
+            merged.hover.hoverColor.bg = (merged.hover.hoverColor.bg.length > 0)
+                    ? merged.hover.hoverColor.bg[0] : 'transparent';
+        }
+
+        // make sure we have a valid zoom extent, the numbers are valid, and they are sorted
+        let zoom: number[] = merged.zoom.zoomExtent;
+        if (!zoom || (zoom.length < 1)) {
+            zoom = [1, 1];
+        } else if (zoom.length < 2) {
+            zoom = [1, zoom[0]];
+        } else if (zoom.length > 2) {
+            zoom = merged.zoom.zoomExtent.slice(0, 2);
+        }
+        zoom = zoom.map(extent => Math.min(.01, extent)).sort((a, b) => b - a);
+        merged.zoom.cellTitleExtent = Math.min(Math.max(zoom[0], merged.zoom.cellTitleExtent), zoom[1])
+                || zoom[0]; // ensure NaN/null/undefined does not trip us up
+        merged.zoom.zoomExtent = zoom as [number, number];
+
+        return merged;
+    }
+}

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -105,14 +105,15 @@ describe('IndicatorHeatMapComponent', () => {
         expect(component.attackPattern).toBeNull();
 
         const first = fixture.nativeElement.querySelector('g.heat-map-cell');
+        expect(first).not.toBeNull();
         component.onTooltip({
-            row: component.heatmap[0].cells[0][0],
+            row: component.heatmap[0].cells[0],
             event: {target: first}
         });
         tick(1000); // skip a second into the future to spawn the tooltip
         fixture.detectChanges();
         expect(component.attackPattern).not.toBeNull();
-        expect(component.attackPattern.id).toEqual(component.heatmap[0].cells[0][0].id);
+        expect(component.attackPattern.id).toEqual(component.heatmap[0].cells[0].id);
 
         // now simulate moving off the attack pattern
         component.onTooltip({
@@ -126,9 +127,10 @@ describe('IndicatorHeatMapComponent', () => {
 
     it('should filter analytics', async(() => {
         const first = fixture.nativeElement.querySelector('g.heat-map-cell rect');
-        // TODO i'd rather invoke a mouseclick event on the above rect object, but can't seem to tell angular to do that
+        expect(first).not.toBeNull();
+        // TODO i'd rather invoke a mouseclick event on the above rect object, but can't seem to tell jasmine to do that
         component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].cells[0][0],
+            row: component.heatmap[0].cells[0],
             event: {path: [first]}
         });
         fixture.detectChanges();
@@ -137,7 +139,7 @@ describe('IndicatorHeatMapComponent', () => {
 
         // click it again to see that it handle deselects
         component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].cells[0][0],
+            row: component.heatmap[0].cells[0],
             event: {path: [first]}
         });
         fixture.detectChanges();

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -106,13 +106,13 @@ describe('IndicatorHeatMapComponent', () => {
 
         const first = fixture.nativeElement.querySelector('g.heat-map-cell');
         component.onTooltip({
-            row: component.heatmap[0].columns[0][0],
+            row: component.heatmap[0].cells[0][0],
             event: {target: first}
         });
         tick(1000); // skip a second into the future to spawn the tooltip
         fixture.detectChanges();
         expect(component.attackPattern).not.toBeNull();
-        expect(component.attackPattern.id).toEqual(component.heatmap[0].columns[0][0].id);
+        expect(component.attackPattern.id).toEqual(component.heatmap[0].cells[0][0].id);
 
         // now simulate moving off the attack pattern
         component.onTooltip({
@@ -128,7 +128,7 @@ describe('IndicatorHeatMapComponent', () => {
         const first = fixture.nativeElement.querySelector('g.heat-map-cell rect');
         // TODO i'd rather invoke a mouseclick event on the above rect object, but can't seem to tell angular to do that
         component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].columns[0][0],
+            row: component.heatmap[0].cells[0][0],
             event: {path: [first]}
         });
         fixture.detectChanges();
@@ -137,7 +137,7 @@ describe('IndicatorHeatMapComponent', () => {
 
         // click it again to see that it handle deselects
         component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].columns[0][0],
+            row: component.heatmap[0].cells[0][0],
             event: {path: [first]}
         });
         fixture.detectChanges();

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -119,13 +119,11 @@ export class IndicatorHeatMapComponent implements OnInit {
             })
             .subscribe(
                 (results: any[]) => {
-                    console.log('incoming data', results, this.indicators, this.indicatorsToAttackPatternMap);
                     const indicators = this.groupIndicatorsByAttackPatterns();
                     const collects = {attackPatterns: {}, phases: {}};
                     this.attackPatterns = results.reduce(
                         (collect, pattern) => this.collectAttackPatterns(collect, pattern), collects).attackPatterns;
                     this.heatmap = this.groupAttackPatternsByKillchain(collects.phases, indicators);
-                    console.log('resulting heatmap', this.heatmap);
                 },
                 (err) => console.log(err)
             );

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -17,6 +17,7 @@ import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 
 import { IndicatorSharingFeatureState } from '../store/indicator-sharing.reducers';
+import { HeatMapOptions } from '../../global/components/heatmap/heatmap.data';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { Constance } from '../../utils/constance';
 
@@ -28,17 +29,20 @@ import { Constance } from '../../utils/constance';
 export class IndicatorHeatMapComponent implements OnInit {
 
     public heatmap: any[] = [];
-    @Input() heatmapOptions = {
-        batchColors: [
-            {header: {bg: 'transparent', fg: '#333'}, body: {bg: 'transparent', fg: 'black'}},
-        ],
-        heatColors: {
-            'true': {bg: '#b2ebf2', fg: 'black'},
-            'false': {bg: '#ccc', fg: 'black'},
-            'selected': {bg: '#33a0b0', fg: 'black'},
+    @Input() heatmapOptions: HeatMapOptions = {
+        color: {
+            batchColors: [
+                {header: {bg: 'transparent', fg: '#333'}, body: {bg: 'transparent', fg: 'black'}},
+            ],
+            heatColors: {
+                'true': {bg: '#b2ebf2', fg: 'black'},
+                'false': {bg: '#ccc', fg: 'black'},
+                'selected': {bg: '#33a0b0', fg: 'black'},
+            },
         },
-        showText: false,
-        hasMinimap: true,
+        zoom: {
+            hasMinimap: true,
+        },
     }
 
     public attackPatterns = {};
@@ -155,7 +159,7 @@ export class IndicatorHeatMapComponent implements OnInit {
         const name = pattern.attributes.name;
         if (name) {
             collects.attackPatterns[name] = Object.assign({}, {
-                batch: name,
+                title: name,
                 name: name,
                 id: pattern.attributes.id,
                 description: pattern.attributes.description,
@@ -163,7 +167,7 @@ export class IndicatorHeatMapComponent implements OnInit {
                 sources: pattern.attributes.x_mitre_data_sources,
                 platforms: pattern.attributes.x_mitre_platforms,
                 indicators: [],
-                active: false,
+                value: false,
             });
         }
 
@@ -177,9 +181,9 @@ export class IndicatorHeatMapComponent implements OnInit {
                     .replace(/\sAnd\s/g, ' and ')
                     ;
                 collects.phases[p.phase_name] = {
-                    batch: batch,
-                    active: null,
-                    columns: [[]],
+                    title: batch,
+                    value: null,
+                    cells: [],
                 };
             });
 
@@ -194,8 +198,8 @@ export class IndicatorHeatMapComponent implements OnInit {
                     let group = tactics[phase];
                     if (group) {
                         attackPattern.indicators = indicators[attackPattern.name] || [];
-                        attackPattern.active = attackPattern.indicators.length > 0;
-                        group.columns[0].push(attackPattern);
+                        attackPattern.value = attackPattern.indicators.length > 0;
+                        group.cells.push(attackPattern);
                     }
                 });
             }

--- a/src/app/intrusion-set-dashboard/attack-patterns-heatmap/attack-patterns-heatmap.component.ts
+++ b/src/app/intrusion-set-dashboard/attack-patterns-heatmap/attack-patterns-heatmap.component.ts
@@ -14,12 +14,8 @@ import { Observable } from 'rxjs/Observable';
 
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 
-import {
-        HeatmapComponent,
-        HeatMapOptions,
-        BatchData,
-        HeatColor,
-    } from '../../global/components/heatmap/heatmap.component';
+import { HeatmapComponent, } from '../../global/components/heatmap/heatmap.component';
+import { HeatBatchData, HeatColor, HeatMapOptions } from '../../global/components/heatmap/heatmap.data';
 import { IntrusionSetHighlighterService } from '../intrusion-set-highlighter.service';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { AuthService } from '../../core/services/auth.service';
@@ -34,16 +30,22 @@ import { Constance } from '../../utils/constance';
 })
 export class AttackPatternsHeatmapComponent implements OnInit, DoCheck {
 
-    public heatMapData: Array<BatchData> = [];
+    public heatMapData: Array<HeatBatchData> = [];
     private noColor: HeatColor = {bg: '#ccc', fg: 'black'};
     public readonly heatMapOptions: HeatMapOptions = {
-        batchColors: [
-            {header: {bg: '#4db6ac', fg: 'black'}, body: {bg: 'white', fg: 'black'}},
-        ],
-        heatColors: {'false': this.noColor},
-        noColor: this.noColor,
-        showText: true,
-        hasMinimap: true,
+        color: {
+            batchColors: [
+                {header: {bg: '#4db6ac', fg: 'black'}, body: {bg: 'white', fg: 'black'}},
+            ],
+            heatColors: {'false': this.noColor},
+            noColor: this.noColor,
+        },
+        text: {
+            showCellText: true,
+        },
+        zoom: {
+            hasMinimap: true,
+        },
     };
     public showHeatMap = false;
     public hoverTooltip = true;
@@ -154,32 +156,35 @@ export class AttackPatternsHeatmapComponent implements OnInit, DoCheck {
      */
     private createAttackPatternHeatMap() {
         let data = [];
-        this.heatMapOptions.heatColors = {'false': this.noColor};
+        const heats = this.heatMapOptions.color.heatColors = {'false': this.noColor};
 
         this.killChainPhases.forEach(phase => {
             let index = 0;
             if (phase && phase.name && phase.attack_patterns) {
                 const name = this.normalizePhaseName(phase.name);
-                const d = {
-                    batch: name,
-                    active: null,
-                    columns: [[]]
+                const d: HeatBatchData = {
+                    title: name,
+                    value: null,
+                    cells: []
                 };
                 phase.attack_patterns.forEach(attackPattern => {
                     if (attackPattern.name) {
-                        let active: string = 'false';
-                        if (!/#ffffff/i.test(attackPattern.back)) {
-                            active = attackPattern.back;
-                            if (!this.heatMapOptions.heatColors[active]) {
-                                this.heatMapOptions.heatColors[active] = {
-                                    bg: active,
-                                    fg: attackPattern.fore || 'black'
+                        let value: string = 'false', heat = null;
+                        if (attackPattern.intrusion_sets && attackPattern.intrusion_sets.length) {
+                            attackPattern.intrusion_sets
+                                .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+                            value = attackPattern.intrusion_sets.map(is => is.name.toLowerCase()).join('-');
+                            heat = attackPattern.intrusion_sets.map(is => is.color);
+                            if (!heats[value]) {
+                                heats[value] = {
+                                    bg: heat,
+                                    fg: attackPattern.fore || 'transparent'
                                 };
                             }
                         }
-                        d.columns[0].push({
-                            batch: attackPattern.name,
-                            active: active,
+                        d.cells.push({
+                            title: attackPattern.name,
+                            value: value,
                         });
                     }
                 });
@@ -188,7 +193,7 @@ export class AttackPatternsHeatmapComponent implements OnInit, DoCheck {
         });
 
         this.heatMapData = data;
-        this.heatMapView.options.heatColors = this.heatMapOptions.heatColors;
+        this.heatMapView.options.color.heatColors = heats;
     }
 
     public normalizePhaseName(phase: string): string {
@@ -208,7 +213,7 @@ export class AttackPatternsHeatmapComponent implements OnInit, DoCheck {
         if (!selection || !selection.row) {
             this.hideAttackPatternTooltip(this.attackPattern);
         } else {
-            selection.attackPattern = Object.values(this.attackPatterns).find(ptn => ptn.name === selection.row.batch);
+            selection.attackPattern = Object.values(this.attackPatterns).find(ptn => ptn.name === selection.row.title);
             if (!selection.attackPattern) {
                 this.hideAttackPatternTooltip(this.attackPattern);
             } else {

--- a/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.ts
+++ b/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.ts
@@ -145,7 +145,6 @@ export class IntrusionSetDashboardComponent implements OnInit {
                 .subscribe(
                     (data: any) => {
                         this.color(data); // TODO move this to the ap tab?
-                        console.log(new Date().toISOString(), 'colorized data to push to the AP tab', data);
                         this.intrusionSets = data.intrusionSets;
                         this.coursesOfAction = data.coursesOfAction;
                         this.killChainPhases = data.killChainPhases;

--- a/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.ts
+++ b/src/app/threat-dashboard/kill-chain-table/kill-chain-table.component.ts
@@ -28,14 +28,8 @@ import { AttackPattern } from '../../models/attack-pattern';
 import { ThreatDashboard } from '../models/threat-dashboard';
 import { topRightSlide } from '../../global/animations/top-right-slide';
 import { KillChainPhase } from '../../models';
-import { HeatMapOptions } from '../../global/components/heatmap/heatmap.component';
+import { HeatMapOptions, HeatBatchData } from '../../global/components/heatmap/heatmap.data';
 import { Dictionary } from '../../models/json/dictionary';
-
-interface HeatMapData {
-  phase: string,
-  count: number,
-  columns: Array<Array<{name: string, active: boolean}>>
-}
 
 @Component({
   selector: 'unf-kill-chain-table',
@@ -69,10 +63,9 @@ export class KillChainTableComponent implements OnInit, OnDestroy, AfterViewInit
   public treeMapData: Array<any> = [];
   public showTreeMap = false;
 
-  public heatMapData: Array<HeatMapData> = [];
+  public heatMapData: Array<HeatBatchData> = [];
   public readonly heatMapOptions: HeatMapOptions = {
-    showText: false,
-    hasMinimap: true,
+    zoom: { hasMinimap: true, },
   };
   public showHeatMap = true;
 
@@ -304,7 +297,7 @@ export class KillChainTableComponent implements OnInit, OnDestroy, AfterViewInit
    */
   private createAttackPatternHeatMap() {
     // Collect the data.
-    let data = [];
+    let data: HeatBatchData[] = [];
     this.intrusionSetsDashboard.killChainPhases.forEach(phase => {
       let index = 0;
       if (phase && phase.name && phase.attack_patterns) {
@@ -315,16 +308,16 @@ export class KillChainTableComponent implements OnInit, OnDestroy, AfterViewInit
           .join(' ')
           .replace(/\sAnd\s/g, ' and ')
           ;
-        const d = {
-          batch: name,
-          active: null,
-          columns: [[]]
+        const d: HeatBatchData = {
+          title: name,
+          value: null,
+          cells: []
         };
         phase.attack_patterns.forEach(attackPattern => {
           if (attackPattern.name) {
-            d.columns[0].push({
-              batch: attackPattern.name,
-              active: attackPattern.isSelected
+            d.cells.push({
+              title: attackPattern.name,
+              value: attackPattern.isSelected
             });
           }
         });
@@ -343,7 +336,7 @@ export class KillChainTableComponent implements OnInit, OnDestroy, AfterViewInit
         this.hideAttackPatternTooltip(this.attackPattern);
       }
     } else {
-      const patternName: string = selectedPattern.row.batch;
+      const patternName: string = selectedPattern.row.title;
       const rawSelection = this.attackPatternPhases[patternName];
       let attackPattern = null;
       this.intrusionSetsDashboard.killChainPhases.forEach(phase => {

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -519,12 +519,12 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
    * @returns {void}
    */
   public treeRendered(): void {
-    console.log('finished loading tree');
+    console.log(`(${new Date().toISOString()}) finished loading tree`);
     this.treeLoading = false;
   }
 
   public radarRendered(): void {
-    console.log('radar rendered');
+    console.log(`(${new Date().toISOString()}) radar rendered`);
     this.radarLoading = false;
   }
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#910.

Currently the only screen we have where a heatmap can have cells with multiple colors is the intrusion set dashboard. Just pick a couple analytics that target some of the same attack patterns, and you should see them appear "lit up" on the heatmap as gradients. Up to three gradients can be done this way, I need to modify the intrusion set dashboard to have a "more-than-3" color. (Any more than 3 becomes too hard for a person to understand the eye-searing blend.)