### PR TITLE
Issue 918

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,7 +11,7 @@ import { environment } from '../environments/environment';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { Themes } from './global/enums/themes.enum';
 import { Constance } from './utils/constance';
-import { mockUser } from './testing/mock-user';
+import { demoUser } from './testing/demo-user';
 
 @Component({
   selector: 'unf-app',
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit {
         this.store.dispatch(new userActions.FetchUser(token));
       } else {
         this.store.dispatch(new userActions.LoginUser({
-          userData: mockUser, 
+          userData: demoUser, 
           token: '1234'
         }));
       }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { environment } from '../environments/environment';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { Themes } from './global/enums/themes.enum';
 import { Constance } from './utils/constance';
+import { mockUser } from './testing/mock-user';
 
 @Component({
   selector: 'unf-app',
@@ -49,19 +50,8 @@ export class AppComponent implements OnInit {
         this.store.dispatch(new userActions.FetchUser(token));
       } else {
         this.store.dispatch(new userActions.LoginUser({
-          userData: {
-            _id: '1234',
-            userName: 'Demo-User',
-            firstName: 'Demo',
-            lastName: 'User',
-            organizations: [
-              {
-                'id': Constance.UNFETTER_OPEN_ID,
-                'approved': true,
-                'role': 'STANDARD_USER'
-              }
-            ],
-          }, token: '1234'
+          userData: mockUser, 
+          token: '1234'
         }));
       }
       this.store.dispatch(new configActions.FetchConfig(false));

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -2,10 +2,10 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AuthGuard } from './core/services/auth.guard';
 import { LandingPageComponent } from './global/components/landing-page/landing-page.component';
-import { UserRoles } from './global/enums/user-roles.enum';
 import { NoContentComponent } from './no-content';
 import { PartnersComponent } from './partners/partners.component';
 import { SelectivePreloadingStrategy } from './selective-preloading-strategy';
+import { UserRole } from './models/user/user-role.enum';
 
 const appRoutes: Routes = [
   { path: 'home', component: LandingPageComponent },
@@ -24,8 +24,8 @@ const appRoutes: Routes = [
     canActivate: [AuthGuard],
     data: {
       ROLES: [
-        UserRoles.ORG_LEADER,
-        UserRoles.ADMIN
+        UserRole.ORG_LEADER,
+        UserRole.ADMIN
       ]
     }
   },
@@ -35,7 +35,7 @@ const appRoutes: Routes = [
     canActivate: [AuthGuard],
     data: {
       ROLES: [
-        UserRoles.ADMIN
+        UserRole.ADMIN
       ]
     }
   },
@@ -45,7 +45,7 @@ const appRoutes: Routes = [
     canActivate: [AuthGuard],
     data: {
       ROLES: [
-        UserRoles.ADMIN
+        UserRole.ADMIN
       ]
     },
   },

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -3,21 +3,20 @@ import { Router } from '@angular/router';
 import { tokenNotExpired } from 'angular2-jwt';
 import { Store } from '@ngrx/store';
 
-import { GenericApi } from './genericapi.service';
 import { environment } from '../../../environments/environment';
 import { Constance } from '../../utils/constance';
 import { UserProfile } from '../../models/user/user-profile';
 import * as fromRoot from '../../root-store/app.reducers';
+import { StixPermissions } from '../../global/static/stix-permissions';
 
 @Injectable()
 export class AuthService {
 
-    public user: UserProfile;
     public readonly runMode = environment.runMode;
+    private user: UserProfile;
 
     constructor(
         private router: Router,
-        private genericApi: GenericApi,
         private store: Store<fromRoot.AppState>
     ) { 
         const getUser$ = this.store.select('users')
@@ -37,21 +36,21 @@ export class AuthService {
             );
     }
 
-    public setToken(token) {
+    public setToken(token): void {
         localStorage.removeItem('unfetterUiToken');
         localStorage.setItem('unfetterUiToken', token);
     }
 
-    public getToken() {
+    public getToken(): string {
         return localStorage.getItem('unfetterUiToken');
     }
 
-    public setUser(user) {
+    public setUser(user): void {
         localStorage.removeItem('user');
         localStorage.setItem('user', JSON.stringify(user));
     }    
 
-    public getUser(): any {
+    public getUser(): UserProfile {
         if (!this.user) {
             let storedUser = localStorage.getItem('user');
             if (storedUser) {
@@ -63,7 +62,7 @@ export class AuthService {
         return this.user;         
     }
 
-    public loggedIn() {
+    public loggedIn(): boolean {
         if (this.runMode === 'DEMO') {
             return true;
         } else {
@@ -75,7 +74,7 @@ export class AuthService {
         }
     }
 
-    public isAdmin() {
+    public isAdmin(): boolean {
         if (this.runMode === 'DEMO') {
             return false;
         } else {
@@ -83,7 +82,7 @@ export class AuthService {
         }
     }
 
-    public isOrgLeader() {
+    public isOrgLeader(): boolean {
         return this.loggedIn() && (this.getUser().role === 'ADMIN' || this.getUser().role === 'ORG_LEADER');
     }
 
@@ -94,13 +93,17 @@ export class AuthService {
     public userLocked(): boolean {
         return tokenNotExpired('unfetterUiToken') && this.getUser() !== null && this.getUser().locked === true;
     }
+    
+    public hasRole(allowedRoles): boolean {
+        return allowedRoles.find((role) => role === this.getUser().role) !== undefined;
+    }
 
-    public logOut() {
+    public logOut(): void {
         localStorage.clear();
         this.router.navigate(['/']);
     }
 
-    public hasRole(allowedRoles) {
-        return allowedRoles.find((role) => role === this.getUser().role) !== undefined;
+    public getStixPermissions(): StixPermissions {
+        return new StixPermissions(this.getUser());
     }
 }

--- a/src/app/global/components/landing-page/landing-page.component.spec.ts
+++ b/src/app/global/components/landing-page/landing-page.component.spec.ts
@@ -5,11 +5,17 @@ import { LandingPageComponent } from './landing-page.component';
 import { AuthService } from '../../../core/services/auth.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GenericApi } from '../../../core/services/genericapi.service';
 
 describe('LandingPageComponent', () => {
   let component: LandingPageComponent;
   let fixture: ComponentFixture<LandingPageComponent>;
+
+  const mockAuthService = {
+    logOut: () => {},
+    userLocked: () => false,
+    loggedIn: () => false,
+    pendingApproval: () => false
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -20,8 +26,10 @@ describe('LandingPageComponent', () => {
         declarations: [ LandingPageComponent ],
         schemas: [ NO_ERRORS_SCHEMA ],
         providers: [ 
-            AuthService,
-            GenericApi
+            { 
+              provide: AuthService, 
+              useValue: mockAuthService
+            }
         ]
     })
     .compileComponents();

--- a/src/app/global/enums/user-roles.enum.ts
+++ b/src/app/global/enums/user-roles.enum.ts
@@ -1,5 +1,0 @@
-export const enum UserRoles {
-    STANDARD_USER = 'STANDARD_USER',
-    ORG_LEADER = 'ORG_LEADER',
-    ADMIN = 'ADMIN'
-}

--- a/src/app/global/static/stix-permissions.spec.ts
+++ b/src/app/global/static/stix-permissions.spec.ts
@@ -1,0 +1,42 @@
+import { UserProfile } from '../../models/user/user-profile';
+import { StixPermissions } from './stix-permissions';
+import { Stix } from '../../models/stix/stix';
+import { testUser } from '../../testing/test-user';
+import { UserRole } from '../../models/user/user-role.enum';
+
+describe('StixPermissions', () => {
+    const admin: UserProfile | any = testUser.userData;
+    const standardUser = { ...admin, role: UserRole.STANDARD_USER };
+
+    const unpublishedStix: Stix | any = {
+        created_by_ref: 'not-a-real-num',
+        metaProperties: {
+            published: false
+        }
+    };
+    const publishedStix = { 
+        ...unpublishedStix, 
+        metaProperties: { 
+            ...unpublishedStix.metaProperties, 
+            published: true 
+        } 
+    };
+    const sameOrgStix = { ...unpublishedStix, created_by_ref: standardUser.organizations[0].id };
+    
+    it('should allow all operations for an admin, but not standard user', () => {
+        expect(StixPermissions.canRead(unpublishedStix, admin)).toBeTruthy();
+        expect(StixPermissions.canCrud(unpublishedStix, admin)).toBeTruthy();
+        expect(StixPermissions.canRead(unpublishedStix, standardUser)).toBeFalsy();
+        expect(StixPermissions.canCrud(unpublishedStix, standardUser)).toBeFalsy();
+    });
+
+    it('should allow read only for standard user on published stix', () => {
+        expect(StixPermissions.canRead(publishedStix, standardUser)).toBeTruthy();
+        expect(StixPermissions.canCrud(publishedStix, standardUser)).toBeFalsy();
+    });
+
+    it('should allow all operations for a standard user in same org', () => {
+        expect(StixPermissions.canRead(sameOrgStix, standardUser)).toBeTruthy();
+        expect(StixPermissions.canCrud(sameOrgStix, standardUser)).toBeTruthy();
+    });
+});

--- a/src/app/global/static/stix-permissions.spec.ts
+++ b/src/app/global/static/stix-permissions.spec.ts
@@ -4,39 +4,64 @@ import { Stix } from '../../models/stix/stix';
 import { testUser } from '../../testing/test-user';
 import { UserRole } from '../../models/user/user-role.enum';
 
-describe('StixPermissions', () => {
-    const admin: UserProfile | any = testUser.userData;
-    const standardUser = { ...admin, role: UserRole.STANDARD_USER };
+const admin: UserProfile | any = testUser.userData;
+const standardUser = { ...admin, role: UserRole.STANDARD_USER };
 
-    const unpublishedStix: Stix | any = {
-        created_by_ref: 'not-a-real-num',
-        metaProperties: {
-            published: false
-        }
-    };
-    const publishedStix = { 
-        ...unpublishedStix, 
-        metaProperties: { 
-            ...unpublishedStix.metaProperties, 
-            published: true 
-        } 
-    };
-    const sameOrgStix = { ...unpublishedStix, created_by_ref: standardUser.organizations[0].id };
-    
-    it('should allow all operations for an admin, but not standard user', () => {
-        expect(StixPermissions.canReadStatic(unpublishedStix, admin)).toBeTruthy();
-        expect(StixPermissions.canCrudStatic(unpublishedStix, admin)).toBeTruthy();
-        expect(StixPermissions.canReadStatic(unpublishedStix, standardUser)).toBeFalsy();
-        expect(StixPermissions.canCrudStatic(unpublishedStix, standardUser)).toBeFalsy();
+const unpublishedStix: Stix | any = {
+    created_by_ref: 'not-a-real-num',
+    metaProperties: {
+        published: false
+    }
+};
+const publishedStix = {
+    ...unpublishedStix,
+    metaProperties: {
+        ...unpublishedStix.metaProperties,
+        published: true
+    }
+};
+const sameOrgStix = { ...unpublishedStix, created_by_ref: standardUser.organizations[0].id };
+
+const stixPermissionsAdmin = new StixPermissions(admin);
+const stixPermissionsStandard = new StixPermissions(standardUser);
+
+describe('StixPermissions', () => {  
+
+    describe('Static functions', () => {
+        it('should allow all operations for an admin, but not standard user', () => {
+            expect(StixPermissions.canReadStatic(unpublishedStix, admin)).toBeTruthy();
+            expect(StixPermissions.canCrudStatic(unpublishedStix, admin)).toBeTruthy();
+            expect(StixPermissions.canReadStatic(unpublishedStix, standardUser)).toBeFalsy();
+            expect(StixPermissions.canCrudStatic(unpublishedStix, standardUser)).toBeFalsy();
+        });
+        
+        it('should allow read only for standard user on published stix', () => {
+            expect(StixPermissions.canReadStatic(publishedStix, standardUser)).toBeTruthy();
+            expect(StixPermissions.canCrudStatic(publishedStix, standardUser)).toBeFalsy();
+        });
+        
+        it('should allow all operations for a standard user in same org', () => {
+            expect(StixPermissions.canReadStatic(sameOrgStix, standardUser)).toBeTruthy();
+            expect(StixPermissions.canCrudStatic(sameOrgStix, standardUser)).toBeTruthy();
+        });
     });
 
-    it('should allow read only for standard user on published stix', () => {
-        expect(StixPermissions.canReadStatic(publishedStix, standardUser)).toBeTruthy();
-        expect(StixPermissions.canCrudStatic(publishedStix, standardUser)).toBeFalsy();
-    });
+    describe('instantiated Object', () => {
+        it('should allow all operations for an admin, but not standard user', () => {
+            expect(stixPermissionsAdmin.canRead(unpublishedStix)).toBeTruthy();
+            expect(stixPermissionsAdmin.canCrud(unpublishedStix)).toBeTruthy();
+            expect(stixPermissionsStandard.canRead(unpublishedStix)).toBeFalsy();
+            expect(stixPermissionsStandard.canCrud(unpublishedStix)).toBeFalsy();
+        });
 
-    it('should allow all operations for a standard user in same org', () => {
-        expect(StixPermissions.canReadStatic(sameOrgStix, standardUser)).toBeTruthy();
-        expect(StixPermissions.canCrudStatic(sameOrgStix, standardUser)).toBeTruthy();
+        it('should allow read only for standard user on published stix', () => {
+            expect(stixPermissionsStandard.canRead(publishedStix)).toBeTruthy();
+            expect(stixPermissionsStandard.canCrud(publishedStix)).toBeFalsy();
+        });
+
+        it('should allow all operations for a standard user in same org', () => {
+            expect(stixPermissionsStandard.canRead(sameOrgStix)).toBeTruthy();
+            expect(stixPermissionsStandard.canCrud(sameOrgStix)).toBeTruthy();
+        });
     });
 });

--- a/src/app/global/static/stix-permissions.spec.ts
+++ b/src/app/global/static/stix-permissions.spec.ts
@@ -24,19 +24,19 @@ describe('StixPermissions', () => {
     const sameOrgStix = { ...unpublishedStix, created_by_ref: standardUser.organizations[0].id };
     
     it('should allow all operations for an admin, but not standard user', () => {
-        expect(StixPermissions.canRead(unpublishedStix, admin)).toBeTruthy();
-        expect(StixPermissions.canCrud(unpublishedStix, admin)).toBeTruthy();
-        expect(StixPermissions.canRead(unpublishedStix, standardUser)).toBeFalsy();
-        expect(StixPermissions.canCrud(unpublishedStix, standardUser)).toBeFalsy();
+        expect(StixPermissions.canReadStatic(unpublishedStix, admin)).toBeTruthy();
+        expect(StixPermissions.canCrudStatic(unpublishedStix, admin)).toBeTruthy();
+        expect(StixPermissions.canReadStatic(unpublishedStix, standardUser)).toBeFalsy();
+        expect(StixPermissions.canCrudStatic(unpublishedStix, standardUser)).toBeFalsy();
     });
 
     it('should allow read only for standard user on published stix', () => {
-        expect(StixPermissions.canRead(publishedStix, standardUser)).toBeTruthy();
-        expect(StixPermissions.canCrud(publishedStix, standardUser)).toBeFalsy();
+        expect(StixPermissions.canReadStatic(publishedStix, standardUser)).toBeTruthy();
+        expect(StixPermissions.canCrudStatic(publishedStix, standardUser)).toBeFalsy();
     });
 
     it('should allow all operations for a standard user in same org', () => {
-        expect(StixPermissions.canRead(sameOrgStix, standardUser)).toBeTruthy();
-        expect(StixPermissions.canCrud(sameOrgStix, standardUser)).toBeTruthy();
+        expect(StixPermissions.canReadStatic(sameOrgStix, standardUser)).toBeTruthy();
+        expect(StixPermissions.canCrudStatic(sameOrgStix, standardUser)).toBeTruthy();
     });
 });

--- a/src/app/global/static/stix-permissions.ts
+++ b/src/app/global/static/stix-permissions.ts
@@ -1,0 +1,85 @@
+import { Stix } from '../../models/stix/stix';
+import { UserProfile } from '../../models/user/user-profile';
+import { UserRole } from '../../models/user/user-role.enum';
+
+function orgPermissions (stix: Stix, user: UserProfile): boolean {
+    return user.organizations && 
+        user.organizations.length && 
+        user.organizations.map((org) => org.id).includes(stix.created_by_ref);
+}
+
+function isPublished(stix: Stix) {
+    return stix.metaProperties && stix.metaProperties.published !== undefined && stix.metaProperties.published === true;
+}
+
+function isAdmin(user: UserProfile): boolean {
+    return user.role === UserRole.ADMIN;
+}
+
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if a user has permission to read a STIX document
+ */
+export const canRead = (stix: Stix, user: UserProfile): boolean => {
+    return isAdmin(user) || isPublished(stix) || orgPermissions(stix, user);
+}
+
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if a user has permission to edit a STIX document
+ */
+export const canEdit = (stix: Stix, user: UserProfile): boolean => {
+    return isAdmin(user) || orgPermissions(stix, user);
+}
+
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if a user has permission to delete a STIX document
+ */
+export const canDelete = (stix: Stix, user: UserProfile): boolean => {
+    return isAdmin(user) || orgPermissions(stix, user);
+}
+
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if a user has permission to create a STIX document
+ */
+export const canCreate = (stix: Stix, user: UserProfile): boolean => {
+    return isAdmin(user) || orgPermissions(stix, user);
+}
+
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if a user has permission to do all CRUD operations on a STIX document
+ */
+export const canCrud = (stix: Stix, user: UserProfile): boolean => {
+    return isAdmin(user) || orgPermissions(stix, user);
+}
+
+export class StixPermissions {
+    public static canRead(stix: Stix, user: UserProfile): boolean {
+        return canRead(stix, user);
+    }
+    public static canEdit(stix: Stix, user: UserProfile): boolean {
+        return canEdit(stix, user);
+    }
+    public static canDelete(stix: Stix, user: UserProfile): boolean {
+        return canDelete(stix, user);
+    }
+    public static canCreate(stix: Stix, user: UserProfile): boolean {
+        return canCreate(stix, user);
+    }
+    public static canCrud(stix: Stix, user: UserProfile): boolean {
+        return canCrud(stix, user);
+    }
+}

--- a/src/app/global/static/stix-permissions.ts
+++ b/src/app/global/static/stix-permissions.ts
@@ -2,16 +2,32 @@ import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { UserRole } from '../../models/user/user-role.enum';
 
+/**
+ * @param  {Stix} stix
+ * @param  {UserProfile} user
+ * @returns boolean
+ * @description Determines if the create_by_ref of a STIX object is in a user's organizations
+ */
 function orgPermissions (stix: Stix, user: UserProfile): boolean {
+    // TODO - How to handle no created_by_ref?
     return user.organizations && 
         user.organizations.length && 
         user.organizations.map((org) => org.id).includes(stix.created_by_ref);
 }
 
-function isPublished(stix: Stix) {
+/**
+ * @param  {Stix} stix
+ * @returns boolean
+ * @description Determines if published exists and is `true`
+ */
+function isPublished(stix: Stix): boolean {
     return stix.metaProperties && stix.metaProperties.published !== undefined && stix.metaProperties.published === true;
 }
 
+/**
+ * @param  {UserProfile} user
+ * @returns boolean
+ */
 function isAdmin(user: UserProfile): boolean {
     return user.role === UserRole.ADMIN;
 }
@@ -67,19 +83,49 @@ export const canCrud = (stix: Stix, user: UserProfile): boolean => {
 }
 
 export class StixPermissions {
-    public static canRead(stix: Stix, user: UserProfile): boolean {
+    private user: UserProfile;
+
+    public static canReadStatic(stix: Stix, user: UserProfile): boolean {
         return canRead(stix, user);
     }
-    public static canEdit(stix: Stix, user: UserProfile): boolean {
+    public static canEditStatic(stix: Stix, user: UserProfile): boolean {
         return canEdit(stix, user);
     }
-    public static canDelete(stix: Stix, user: UserProfile): boolean {
+    public static canDeleteStatic(stix: Stix, user: UserProfile): boolean {
         return canDelete(stix, user);
     }
-    public static canCreate(stix: Stix, user: UserProfile): boolean {
+    public static canCreateStatic(stix: Stix, user: UserProfile): boolean {
         return canCreate(stix, user);
     }
-    public static canCrud(stix: Stix, user: UserProfile): boolean {
+    public static canCrudStatic(stix: Stix, user: UserProfile): boolean {
         return canCrud(stix, user);
+    }
+
+    public canRead(stix: Stix): boolean {
+        return canRead(stix, this.user);
+    }
+    public canEdit(stix: Stix): boolean {
+        return canEdit(stix, this.user);
+    }
+    public canDelete(stix: Stix): boolean {
+        return canDelete(stix, this.user);
+    }
+    public canCreate(stix: Stix): boolean {
+        return canCreate(stix, this.user);
+    }
+    public canCrud(stix: Stix): boolean {
+        return canCrud(stix, this.user);
+    }
+
+    /**
+     * @param  {UserProfile} user?
+     * @description This should only be instantiated in auth.service.ts
+     */
+    constructor(user: UserProfile) {
+        if (user) {
+            this.user = user;
+        } else {
+            console.log('StixPermissions class WARNING: non-static functions will not work properly unless a user object is based into the contructor');
+        }
     }
 }

--- a/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.html
+++ b/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.html
@@ -3,7 +3,7 @@
     <mat-chip-list style="margin-right: 5px;">
       <mat-chip *ngFor="let ap of existingAttackPatterns" class="chipListChip" [selected]="apSelected(ap.id)">{{ ap.name }}</mat-chip>
     </mat-chip-list>
-    <button mat-mini-fab color="accent" (click)="showAddAp = !showAddAp">
+    <button mat-mini-fab color="accent" (click)="showAddAp = !showAddAp" *ngIf="canCrud">
       <i class="material-icons mat-24" [ngClass]="{'showAddAp': showAddAp}">add</i>
     </button>
   </div>

--- a/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.ts
+++ b/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.ts
@@ -15,6 +15,7 @@ export class AddAttackPatternComponent implements OnInit {
   @Input() public indicatorId: string;
   @Input() public createdByRef: string;
   @Input() public existingAttackPatterns: any[] = [];
+  @Input() public canCrud: boolean = false;
   public selectedAttackPatterns: any[] = [];
   public displayedAttackPatterns$: any;
   public filteredAttackPatterns: any[];

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -1,4 +1,8 @@
-<p mat-dialog-title class="lead mb-6">Add Analytic</p>
+<p mat-dialog-title class="lead mb-6">
+    <span *ngIf="!editMode">Add</span>
+    <span *ngIf="editMode">Edit</span>
+    <span>Analytic</span>
+</p>
 
 <mat-dialog-content id="addIndicator">
     <form [formGroup]="form" novalidate (ngSubmit)="submitIndicator()">

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -7,7 +7,7 @@
                 <mat-icon>more_vert</mat-icon>
             </button>
             <mat-menu #menu="matMenu">
-                <button mat-menu-item (click)="publishIndicator()" *ngIf="!readOnlyMode && indicator.metaProperties && indicator.metaProperties.published === false">
+                <button mat-menu-item (click)="publishIndicator()" *ngIf="canCrud && indicator.metaProperties && indicator.metaProperties.published === false">
                     <mat-icon>share</mat-icon>
                     <span>Publish</span>
                 </button>
@@ -15,11 +15,11 @@
                     <mat-icon>file_download</mat-icon>
                     <span>Download</span>
                 </button>
-                <button mat-menu-item (click)="editIndicator()" *ngIf="!readOnlyMode">
+                <button mat-menu-item (click)="editIndicator()" *ngIf="canCrud">
                     <mat-icon>create</mat-icon>
                     <span>Edit</span>
                 </button>
-                <button mat-menu-item (click)="deleteIndicator()" *ngIf="!readOnlyMode">
+                <button mat-menu-item (click)="deleteIndicator()" *ngIf="canCrud">
                     <mat-icon>delete</mat-icon>
                     <span>Delete</span>
                 </button>
@@ -41,16 +41,16 @@
             <code [innerHtml]="whitespaceToBreak(indicator.pattern)" class="inlineBlock"></code>
         </p>
 
-        <label>Labels</label>
+        <label *ngIf="(indicator.labels && indicator.labels.length) || canCrud">Labels</label>
         <div class="flex flexItemsCenter">
             <mat-chip-list>
                 <mat-chip *ngFor="let label of indicator.labels" [selected]="labelSelected(label)" class="cursor-pointer chipListChip">{{label | capitalize}}</mat-chip>
             </mat-chip-list>
-            <add-label-reactive [stixType]="'indicator'" (labelAdded)="addLabel($event)" [currentLabels]="indicator.labels"></add-label-reactive>
+            <add-label-reactive [stixType]="'indicator'" (labelAdded)="addLabel($event)" [currentLabels]="indicator.labels" *ngIf="canCrud"></add-label-reactive>
         </div>
 
-        <label>Indicated Attack Patterns</label>
-        <add-attack-pattern [existingAttackPatterns]="attackPatterns" [indicatorId]="indicator.id" [createdByRef]="indicator.created_by_ref"></add-attack-pattern>
+        <label *ngIf="(attackPatterns && attackPatterns.length > 0) || canCrud">Indicated Attack Patterns</label>
+        <add-attack-pattern [existingAttackPatterns]="attackPatterns" [indicatorId]="indicator.id" [createdByRef]="indicator.created_by_ref" [canCrud]="canCrud"></add-attack-pattern>
 
         <div *ngIf="attackPatterns && attackPatterns.length > 0">
             <div class="uf-collapsible-control mb-10 mt-6" (click)="showAttackPatternDetails = !showAttackPatternDetails">

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
@@ -11,6 +11,7 @@ import { environment } from '../../../environments/environment';
 import { downloadBundle } from '../../global/static/stix-bundle';
 import { generateStixRelationship } from '../../global/static/stix-relationship';
 import { StixRelationshipTypes } from '../../global/enums/stix-relationship-types.enum';
+import { canCrud } from '../../global/static/stix-permissions';
 
 @Component({
     selector: 'indicator-card',
@@ -40,7 +41,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit {
     public alreadyInteracted: boolean = false;
     public alreadyCommented: boolean = false;
     public showAttackPatternDetails: boolean = false;
-    public readOnlyMode: boolean = true;
+    public canCrud: boolean = false;
 
     public readonly copyText: string = 'Copied';
     public readonly runMode = environment.runMode;
@@ -58,10 +59,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit {
 
     public ngOnInit() {
         this.user = this.authService.getUser();
-        
-        if (!this.indicator.created_by_ref || this.user.organizations.map((org) => org.id).includes(this.indicator.created_by_ref)) {
-            this.readOnlyMode = false;
-        }
+        this.canCrud = canCrud(this.indicator, this.user);
 
         if (this.indicator.metaProperties !== undefined && this.indicator.metaProperties.likes !== undefined && this.indicator.metaProperties.likes.length > 0) {
             const alreadyLiked = this.indicator.metaProperties.likes.find((like) => like.user.id === this.user._id);

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
@@ -39,7 +39,8 @@
         <h4 id="indicators-header">Analytics Using These Patterns</h4>
         <div #indicatorsGrid id="indicators-grid">
             <div *ngFor="let indicator of displayIndicators" id="{{indicator.id}}"
-                    class="indicator" [class.selected]="selectedPatterns.length > 0">{{indicator.name}}</div>
+                    class="indicator cursor-pointer" [class.selected]="selectedPatterns.length > 0"
+                    routerLink="indicator-sharing/single/{{ indicator.id }}">{{indicator.name}}</div>
         </div>
     </div>
 

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
@@ -51,6 +51,9 @@ $white: #FFFFFF;
     background-color: $analytic-exchange-primary-lightest;
     border: 1px solid $analytic-exchange-primary-lighter;
     border-radius: 4px;
+    &:focus {
+        outline: none;
+    }
 }
 .indicator.selected {
     background-color: $analytic-exchange-primary;

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -13,6 +13,7 @@ import { makeMockIndicatorSharingStore, mockIndicators, mockAttackPatterns } fro
 import { indicatorSharingReducer } from '../store/indicator-sharing.reducers';
 import { CapitalizePipe } from '../../global/pipes/capitalize.pipe';
 import { GenericApi } from '../../core/services/genericapi.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('IndicatorHeatMapComponent', () => {
 
@@ -59,6 +60,7 @@ describe('IndicatorHeatMapComponent', () => {
                     OverlayModule,
                     MatDialogModule,
                     HttpClientTestingModule,
+                    RouterTestingModule,
                     StoreModule.forRoot(mockReducer),
                 ],
                 declarations: [

--- a/src/app/models/user/user-role.enum.ts
+++ b/src/app/models/user/user-role.enum.ts
@@ -4,5 +4,6 @@
  */
 export enum UserRole {
     STANDARD_USER = 'STANDARD_USER',
+    ORG_LEADER = 'ORG_LEADER',
     ADMIN = 'ADMIN'
 }

--- a/src/app/testing/demo-user.ts
+++ b/src/app/testing/demo-user.ts
@@ -3,7 +3,7 @@ import { UserRole } from '../models/user/user-role.enum';
 import { UserIdentity } from '../models/user/user-identity';
 import { Constance } from '../utils/constance';
 
-export const mockUser: UserProfile = {
+export const demoUser: UserProfile = {
     _id: '1234',
     userName: 'Demo-User',
     firstName: 'Demo',

--- a/src/app/testing/mock-store.ts
+++ b/src/app/testing/mock-store.ts
@@ -31,7 +31,7 @@ export const mockConfig = {
     ]
 };
 
-export const mockUser = {
+export const mockStoreUser = {
     userData: {
         _id: '1234',
         __v: 0,

--- a/src/app/testing/mock-store.ts
+++ b/src/app/testing/mock-store.ts
@@ -5,7 +5,7 @@ import * as fromIndicatorSharing from '../indicator-sharing/store/indicator-shar
 import * as configActions from '../root-store/config/config.actions';
 import * as indicatorSharingActions from '../indicator-sharing/store/indicator-sharing.actions';
 import * as userActions from '../root-store/users/user.actions';
-import { mockOrganizations } from './mock-organizations';
+import { testUser } from './test-user';
 
 // ~~~ root ~~~
 
@@ -31,49 +31,9 @@ export const mockConfig = {
     ]
 };
 
-export const mockStoreUser = {
-    userData: {
-        _id: '1234',
-        __v: 0,
-        email: 'fake@fake.com',
-        userName: 'fake',
-        lastName: 'fakey',
-        firstName: 'faker',
-        created: '2017-11-24T17:52:13.032Z',
-        identity: {
-            name: 'a',
-            id: 'identity--1234',
-            type: 'identity',
-            sectors: [],
-            identity_class: 'individual'
-        },
-        github: {
-            userName: 'fake',
-            avatar_url: 'https://avatars2.githubusercontent.com/u/1234?v=4',
-            id: '1234'
-        },
-        role: 'ADMIN',
-        locked: false,
-        approved: true,
-        registered: true,
-        organizations: mockOrganizations.map((org) => {
-            return {
-                id: org.id,
-                subsrcibed: true,
-                approved: true,
-                role: 'STANDARD_USER'
-            };
-        })
-    },
-    token: 'Bearer 123',
-    authenticated: true,
-    approved: true,
-    role: 'ADMIN'
-};
-
 export function makeRootMockStore(store: Store<fromRoot.AppState>) {
     store.dispatch(new configActions.AddConfig(mockConfig));
-    store.dispatch(new userActions.LoginUser(mockUser));
+    store.dispatch(new userActions.LoginUser(testUser));
 }
 
 // ~~~ Indicator Sharing ~~~

--- a/src/app/testing/mock-user.ts
+++ b/src/app/testing/mock-user.ts
@@ -1,0 +1,26 @@
+import { UserProfile } from '../models/user/user-profile';
+import { UserRole } from '../models/user/user-role.enum';
+import { UserIdentity } from '../models/user/user-identity';
+import { Constance } from '../utils/constance';
+
+export const mockUser: UserProfile = {
+    _id: '1234',
+    userName: 'Demo-User',
+    firstName: 'Demo',
+    lastName: 'User',
+    organizations: [
+        {
+            id: Constance.UNFETTER_OPEN_ID,
+            approved: true,
+            role: UserRole.STANDARD_USER,
+            subscribed: true
+        }
+    ],
+    email: 'demo@user.com',
+    created: '2017-11-24T17:52:13.032Z',
+    registered: true,
+    approved: true,
+    locked: false,
+    role: UserRole.STANDARD_USER,
+    identity: new UserIdentity()
+};

--- a/src/app/testing/test-user.ts
+++ b/src/app/testing/test-user.ts
@@ -1,0 +1,41 @@
+import { mockOrganizations } from './mock-organizations';
+
+export const testUser = {
+    userData: {
+        _id: '1234',
+        __v: 0,
+        email: 'fake@fake.com',
+        userName: 'fake',
+        lastName: 'fakey',
+        firstName: 'faker',
+        created: '2017-11-24T17:52:13.032Z',
+        identity: {
+            name: 'a',
+            id: 'identity--1234',
+            type: 'identity',
+            sectors: [],
+            identity_class: 'individual'
+        },
+        github: {
+            userName: 'fake',
+            avatar_url: 'https://avatars2.githubusercontent.com/u/1234?v=4',
+            id: '1234'
+        },
+        role: 'ADMIN',
+        locked: false,
+        approved: true,
+        registered: true,
+        organizations: mockOrganizations.map((org) => {
+            return {
+                id: org.id,
+                subsrcibed: true,
+                approved: true,
+                role: 'STANDARD_USER'
+            };
+        })
+    },
+    token: 'Bearer 123',
+    authenticated: true,
+    approved: true,
+    role: 'ADMIN'
+};


### PR DESCRIPTION
Requirements: 2 github accounts, user1 must be in a group that user2 is not in (lets call it group-b), user2 must be a standard user

Instructions:
- Create an analytic with user1 in group-b, and *uncheck* the "Publish" checkbox
- Confirm the analytic displays when filtering by `Publish Status > draft`
- Confirm that user2 can't see it, and that the results counter is accurate on both screens (eg, user1's counter should be higher)
- With user1, click the options / vert menu on the analytic card and selecting publish
- For user2, confirm 'read only' mode is working by: 1) He can now see the analytic 2) fabs to add labels or attack patterns don't show and 3) The only option in the options / vert menu is download

fixes unfetter-discover/unfetter#918
