### PR TITLE
added updated & improved validation errors to all STIX CRUD create pages

### DIFF
--- a/src/app/components/component.module.ts
+++ b/src/app/components/component.module.ts
@@ -23,6 +23,7 @@ import { LinkNodeGraphComponent } from './link-node-graph/link-node-graph.compon
 import { LabelComponent } from './labels/label.component';
 import { GlobalModule } from '../global/global.module';
 import { StixTextArrayComponent } from './stix-text-array/stix-text-array.component';
+import { ValidationErrorsComponent } from './validation-errors/validation-errors.component';
 
 @NgModule({
   declarations: [
@@ -42,7 +43,8 @@ import { StixTextArrayComponent } from './stix-text-array/stix-text-array.compon
     ButtonsFilterComponent,
     LinkNodeGraphComponent,
     LabelComponent,
-    StixTextArrayComponent
+    StixTextArrayComponent,
+    ValidationErrorsComponent
   ],
   imports: [
     CommonModule,
@@ -77,7 +79,8 @@ import { StixTextArrayComponent } from './stix-text-array/stix-text-array.compon
     ButtonsFilterComponent,
     LinkNodeGraphComponent,
     LabelComponent,
-    StixTextArrayComponent
+    StixTextArrayComponent,
+    ValidationErrorsComponent
   ],
   providers: [BaseComponentService],
   entryComponents: [ConfirmationDialogComponent]

--- a/src/app/components/validation-errors/validation-errors.component.html
+++ b/src/app/components/validation-errors/validation-errors.component.html
@@ -1,0 +1,8 @@
+<div class="validationErrorsComponent">
+  <div *ngIf="validationErrorMessages && validationErrorMessages.length">
+    <h4>Validation Messages:</h4>
+    <ul>
+      <li *ngFor="let validationErrorMessage of validationErrorMessages">{{ validationErrorMessage }}</li>
+    </ul>
+  </div>
+</div>

--- a/src/app/components/validation-errors/validation-errors.component.spec.ts
+++ b/src/app/components/validation-errors/validation-errors.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ValidationErrorsComponent } from './validation-errors.component';
+
+describe('ValidationErrorsComponent', () => {
+  let component: ValidationErrorsComponent;
+  let fixture: ComponentFixture<ValidationErrorsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ValidationErrorsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ValidationErrorsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/validation-errors/validation-errors.component.ts
+++ b/src/app/components/validation-errors/validation-errors.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'validation-errors',
+  templateUrl: './validation-errors.component.html',
+  styleUrls: ['./validation-errors.component.scss']
+})
+export class ValidationErrorsComponent {
+  @Input() public validationErrorMessages: string[] = [];
+
+  constructor() { }
+}

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-new/attack-pattern-new.component.html
@@ -42,8 +42,9 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                     <button  id="canel-btn"  mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                    <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveAttackPattern()" [disabled]="!attackPattern.attributes.name || !attackPattern.attributes.created_by_ref">SAVE</button>
-
+                    <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveAttackPattern()" [disabled]="invalidate(attackPattern)">SAVE</button>
                 </div>
             </div>
           </div>
+
+          <validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.html
+++ b/src/app/settings/stix-objects/campaigns/campaigns-new/campaigns-new.component.html
@@ -79,8 +79,10 @@
         <div class="button-row pull-right">
 
                  <button  id="cancel-btn" mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                 <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveCampaign()" [disabled]="!campaign.attributes.name || !campaign.attributes.created_by_ref">SAVE</button>
+                 <button id="save-btn" type="submit"  color="primary" mat-raised-button (click)="saveCampaign()" [disabled]="invalidate(campaign)">SAVE</button>
 
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.html
+++ b/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.html
@@ -29,10 +29,11 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                         <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                        <button mat-raised-button (click)="saveCourceOfAction()" [disabled]="!courseOfAction.attributes.name || !courseOfAction.attributes.created_by_ref" color="primary">SAVE</button>
+                        <button mat-raised-button (click)="saveCourseOfAction()" [disabled]="invalidate(courseOfAction)" color="primary">SAVE</button>
 
                 </div>
             </div>
         </div>
+        <validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>
     </div>
 </div>

--- a/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.ts
+++ b/src/app/settings/stix-objects/course-of-actions/course-of-action-new/course-of-action-new.component.ts
@@ -28,7 +28,7 @@ export class CourseOfActionNewComponent extends CourseOfActionEditComponent impl
         this.courseOfAction  = new CourseOfAction();
     }
 
-    public saveCourceOfAction(): void {
+    public saveCourseOfAction(): void {
        let subscription = super.create(this.courseOfAction).subscribe(
             (stixObject) => {
                 this.location.back();

--- a/src/app/settings/stix-objects/identities/identity-new/identity-new.component.html
+++ b/src/app/settings/stix-objects/identities/identity-new/identity-new.component.html
@@ -44,7 +44,9 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveIdentity()" [disabled]="!identity.attributes.name" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveIdentity()" [disabled]="invalidate(identity)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/indicators/indicator-new/indicator-new.component.html
+++ b/src/app/settings/stix-objects/indicators/indicator-new/indicator-new.component.html
@@ -78,9 +78,11 @@
             <div class="col-md-12">
                 <div class="button-row pull-right">
                         <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                        <button mat-raised-button (click)="saveIndicator()" [disabled]="!indicator.attributes.name || !indicator.attributes.pattern || !indicator.attributes.created_by_ref" color="primary">SAVE</button>
+                        <button mat-raised-button (click)="saveIndicator()" [disabled]="invalidate(indicator)" color="primary">SAVE</button>
                 </div>
             </div>
         </div>
+
+        <validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>
     </div>
 </div>

--- a/src/app/settings/stix-objects/intrusion-sets/intrusion-set-new/intrusion-set-new.component.html
+++ b/src/app/settings/stix-objects/intrusion-sets/intrusion-set-new/intrusion-set-new.component.html
@@ -127,8 +127,10 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!intrusionSet.attributes.name || !intrusionSet.attributes.created_by_ref" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="invalidate(intrusionSet)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>
 

--- a/src/app/settings/stix-objects/malwares/malware-new/malware-new.component.html
+++ b/src/app/settings/stix-objects/malwares/malware-new/malware-new.component.html
@@ -81,7 +81,9 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveMalware()" [disabled]="!malware.attributes.name || !malware.attributes.created_by_ref" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveMalware()" [disabled]="invalidate(malware)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/relationships/relationship-new/relationship-new.component.html
+++ b/src/app/settings/stix-objects/relationships/relationship-new/relationship-new.component.html
@@ -68,3 +68,5 @@
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/reports/report-new/report-new.component.html
+++ b/src/app/settings/stix-objects/reports/report-new/report-new.component.html
@@ -67,7 +67,9 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="!report.attributes.name || !report.attributes.created_by_ref" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveButtonClicked()" [disabled]="invalidate(report)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/sensors/sensor-new/sensor-new.component.html
+++ b/src/app/settings/stix-objects/sensors/sensor-new/sensor-new.component.html
@@ -37,7 +37,9 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button class=" " mat-raised-button (click)="saveNewSensor()" [disabled]="!sensor.attributes.name ||!sensor.attributes.created_by_ref" color="primary">SAVE</button>
+                <button class=" " mat-raised-button (click)="saveNewSensor()" [disabled]="invalidate(sensor)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/sightings/sighting-new/sighting-new.component.html
+++ b/src/app/settings/stix-objects/sightings/sighting-new/sighting-new.component.html
@@ -54,3 +54,4 @@
             </div>
     </div>
 </div>
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/threat-actors/threat-actor-new/threat-actor-new.component.html
+++ b/src/app/settings/stix-objects/threat-actors/threat-actor-new/threat-actor-new.component.html
@@ -40,8 +40,10 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button mat-raised-button (click)="saveThreatActor()" [disabled]="!threatActor.attributes.name" color="primary">SAVE</button>
+                <button mat-raised-button (click)="saveThreatActor()" [disabled]="invalidate(threatActor)" color="primary">SAVE</button>
 
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>

--- a/src/app/settings/stix-objects/tools/tool-new/tool-new.component.html
+++ b/src/app/settings/stix-objects/tools/tool-new/tool-new.component.html
@@ -80,7 +80,9 @@
     <div class="col-md-12">
         <div class="button-row pull-right">
                 <button mat-button (click)="cancelButtonClicked()">CANCEL</button>
-                <button class=" " mat-raised-button (click)="saveNewTool()" [disabled]="!tool.attributes.name || !tool.attributes.created_by_ref" color="primary">SAVE</button>
+                <button class=" " mat-raised-button (click)="saveNewTool()" [disabled]="invalidate(tool)" color="primary">SAVE</button>
         </div>
     </div>
 </div>
+
+<validation-errors [validationErrorMessages]="validationErrorMessages"></validation-errors>


### PR DESCRIPTION
Please note this is `issue-875-2`, with a 2.

Instructions: Use STIX crud pages to create new objects, confirm Save button disables/enables at proper times, and that the new validation messages (under the save button) display properly.

fixes unfetter-discover/unfetter#875