### PR TITLE
Turn analytics exchange heatmap into a filter

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.spec.ts
+++ b/src/app/global/components/heatmap/heatmap.component.spec.ts
@@ -147,7 +147,7 @@ describe('HeatmapComponent', () => {
 
         let rects: NodeList = fixture.nativeElement.querySelectorAll('.heat-map svg g.heat-map-cell rect');
         expect(Array.from(rects)
-            .filter(rect => rect.attributes['fill'].nodeValue ===
+            .filter((rect: any) => rect.attributes['fill'].nodeValue ===
                     component.options.color.heatColors['true'].bg).length).toEqual(9);
     });
 
@@ -275,7 +275,7 @@ describe('HeatmapComponent', () => {
         trect.parentElement.dispatchEvent(new Event('mouseover'));
         fixture.whenStable().then(() => {
             expect(spy).not.toBeNull();
-            expect(spy.row).toBe(target);
+            expect(spy.row.title).toBe(target.title);
             trect.dispatchEvent(new Event('mouseout'));
             trect.parentElement.dispatchEvent(new Event('mouseout'));
             expect(spy).toBeNull();
@@ -296,7 +296,7 @@ describe('HeatmapComponent', () => {
         expect(trect).not.toBeNull();
         trect.parentElement.dispatchEvent(new Event('click'));
         expect(spy).not.toBeNull();
-        expect(spy.row).toBe(target);
+        expect(spy.row.title).toBe(target.title);
     });
 
 });

--- a/src/app/global/components/heatmap/heatmap.component.ts
+++ b/src/app/global/components/heatmap/heatmap.component.ts
@@ -599,14 +599,19 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
                 .on('mouseout', () => this.offCellHover());
         }
 
+        const bg = color.bg as string;
         const rect = cell
             .append('rect')
                 .attr('x', bounds.workspace.xPosition)
                 .attr('y', y)
                 .attr('width', bounds.cellWidth)
                 .attr('height', bounds.cellHeight)
-                .style('padding-right', bounds.workspace.betweenPadding)
-                .attr('fill', color.bg as string);
+                .style('padding-right', bounds.workspace.betweenPadding);
+        if (bg.startsWith('.')) {
+            rect.attr('class', bg.substring(1));
+        } else {
+            rect.attr('fill', bg);
+        }
         if (!isMini) {
             rect
                 .on('mouseover', ev => this.onRectHover(d3.event.target))
@@ -723,6 +728,9 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
         }
     }
 
+    /**
+     * @description determine how much width the current text in the given cell requires
+     */
     private textWidth(span: D3Selection) {
         return (span.node() as any).getComputedTextLength() + 4;
     }
@@ -754,7 +762,7 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
     private onRectHover(rect: any) {
         if (!this.options.hover.hoverColor) {
         } else if ((this.options.hover.hoverColor.bg as string).startsWith('.')) {
-            rect.setAttribute('class', this.options.hover.hoverColor.bg);
+            rect.setAttribute('class', (this.options.hover.hoverColor.bg as string).substring(1));
         } else {
             rect.setAttribute('fill', this.options.hover.hoverColor.bg);
         }
@@ -766,7 +774,7 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
     private offRectHover(rect: any, bg: string) {
         if (!this.options.hover.hoverColor) {
         } else if (bg.startsWith('.')) {
-            rect.setAttribute('class', bg);
+            rect.setAttribute('class', bg.substring(1));
         } else {
             rect.setAttribute('fill', bg);
         }
@@ -872,6 +880,9 @@ export class HeatmapComponent implements OnInit, AfterViewInit, DoCheck, OnDestr
         }
     }
 
+    /**
+     * @description handle single- and double-clicks inside the minimap
+     */
     private doMinimapClick(event) {
         const scale = d3.zoomTransform(this.minimap.workspace.panner.node()).k;
         if (scale < 1) { // don't bother if we are already zoomed all the way out

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.html
@@ -1,51 +1,40 @@
-<div id="indicator-analytic-heat-map">
-
-    <div id="indicator-heat-map">
-
-        <unf-heatmap [heatMapData]="heatmap" [options]="heatmapOptions"
-                (onHover)="onTooltip($event)" (onClick)="highlightAttackPatternAnalytics($event)"></unf-heatmap>
-
-        <ng-template #tooltipTemplate>
-            <div class="col-md-12 attack-pattern-tooltip">
-                <mat-card>
-                    <mat-card-subtitle>
-                        <div class="flex1"><label>{{attackPattern.name}}</label></div>
-                    </mat-card-subtitle>
-                    <mat-card-content>
-                        <div class="row" *ngIf="attackPattern.description">
-                            <div class="col-md-3"><label>Description</label></div>
-                            <div class="col-md-8 attack-pattern-desc" [innerHTML]="attackPattern.description"></div>
-                        </div>
-                        <div class="row" *ngIf="attackPattern.sources">
-                            <div class="col-md-3"><label>Data Sources</label></div>
-                            <div class="col-md-9 attack-pattern-sources">{{attackPattern.sources.join(', ')}}</div>
-                        </div>
-                        <div class="row" *ngIf="attackPattern.platforms">
-                            <div class="col-md-3"><label>Platforms</label></div>
-                            <div class="col-md-9 attack-pattern-platforms">{{attackPattern.platforms.join(', ')}}</div>
-                        </div>
-                        <div class="row" *ngIf="attackPattern.phases">
-                            <div class="col-md-3"><label>Phases</label></div>
-                            <div class="col-md-9 attack-pattern-phases">{{attackPattern.phases.join(', ') | capitalize}}</div>
-                        </div>
-                    </mat-card-content>
-                </mat-card>
-            </div>
-        </ng-template>
-
-    </div>
-
-    <div [hidden]="displayIndicators.length === 0" id="indicators" class="col-xs-12">
-        <h4 id="indicators-header">Analytics Using These Patterns</h4>
-        <div #indicatorsGrid id="indicators-grid">
-            <div *ngFor="let indicator of displayIndicators" id="{{indicator.id}}"
-                    class="indicator cursor-pointer" [class.selected]="selectedPatterns.length > 0"
-                    routerLink="indicator-sharing/single/{{ indicator.id }}">{{indicator.name}}</div>
+<h2 mat-dialog-title>Select Attack Patterns</h2>
+<mat-dialog-content>
+    <div id="indicator-analytic-heat-map">
+        <div id="indicator-heat-map">
+            <unf-heatmap #heatmapView [heatMapData]="heatmap" [options]="heatmapOptions"
+                    (onHover)="onTooltip($event)" (onClick)="toggleAttackPattern($event)"></unf-heatmap>
+            <ng-template #tooltipTemplate>
+                <div class="col-md-12 attack-pattern-tooltip">
+                    <mat-card>
+                        <mat-card-subtitle>
+                            <div class="flex1"><label>{{attackPattern.name}}</label></div>
+                        </mat-card-subtitle>
+                        <mat-card-content>
+                            <div class="row" *ngIf="attackPattern.description">
+                                <div class="col-md-3"><label>Description</label></div>
+                                <div class="col-md-8 attack-pattern-desc" [innerHTML]="attackPattern.description"></div>
+                            </div>
+                            <div class="row" *ngIf="attackPattern.sources">
+                                <div class="col-md-3"><label>Data Sources</label></div>
+                                <div class="col-md-9 attack-pattern-sources">{{attackPattern.sources.join(', ')}}</div>
+                            </div>
+                            <div class="row" *ngIf="attackPattern.platforms">
+                                <div class="col-md-3"><label>Platforms</label></div>
+                                <div class="col-md-9 attack-pattern-platforms">{{attackPattern.platforms.join(', ')}}</div>
+                            </div>
+                            <div class="row" *ngIf="attackPattern.phases">
+                                <div class="col-md-3"><label>Phases</label></div>
+                                <div class="col-md-9 attack-pattern-phases">{{attackPattern.phases.join(', ') | capitalize}}</div>
+                            </div>
+                        </mat-card-content>
+                    </mat-card>
+                </div>
+            </ng-template>
         </div>
     </div>
-
-    <div [hidden]="displayIndicators.length > 0" id="no-indicators" class="col-xs-12">
-        <h4 id="indicators-header">There are No Analytics Using the Selected Pattern(s)</h4>
-    </div>
-
-</div>
+</mat-dialog-content>
+<mat-dialog-actions>
+    <button mat-button [mat-dialog-close]="false">Cancel</button>
+    <button mat-button [mat-dialog-close]="close()">Accept</button>
+</mat-dialog-actions>

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
@@ -11,9 +11,7 @@ $white: #FFFFFF;
 }
 
 :host ::ng-deep {
-
     background-color: $white;
-
     unf-heatmap {
         div.heat-map {
             width: 100%;
@@ -21,16 +19,14 @@ $white: #FFFFFF;
             margin: 0;
             padding: 0;
             background: white;
-
-            .heat-map-header rect.odd, .heat-map-batch rect.odd {
-                fill: $analytic-exchange-primary-lightest;
-            }
-            .heat-map-cell rect.selected {
-                fill: $analytic-exchange-primary;
-            }
+        }
+        .heat-map-header rect.odd, .heat-map-batch rect.odd {
+            fill: $analytic-exchange-primary-lightest;
+        }
+        .heat-map-cell rect.selected {
+            fill: $analytic-exchange-primary;
         }
     }
-
 }
 
 .attack-pattern-tooltip {

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.scss
@@ -17,46 +17,20 @@ $white: #FFFFFF;
     unf-heatmap {
         div.heat-map {
             width: 100%;
-            height: 300px;
+            height: 350px;
             margin: 0;
             padding: 0;
             background: white;
 
-            rect.selected {
+            .heat-map-header rect.odd, .heat-map-batch rect.odd {
+                fill: $analytic-exchange-primary-lightest;
+            }
+            .heat-map-cell rect.selected {
                 fill: $analytic-exchange-primary;
             }
         }
     }
 
-}
-
-#indicators, #no-indicators {
-    flex: 1;
-    margin: 10px 0 60px 0;
-    padding: 0px;
-    height: 100%;
-    overflow-y: auto;
-}
-#indicators-header {
-    text-decoration: underline;
-}
-#indicators-grid {
-    display: grid;
-    grid-template-columns: auto auto auto auto;
-}
-.indicator {
-    margin: 4px;
-    padding: 6px;
-    font-size: 14px;
-    background-color: $analytic-exchange-primary-lightest;
-    border: 1px solid $analytic-exchange-primary-lighter;
-    border-radius: 4px;
-    &:focus {
-        outline: none;
-    }
-}
-.indicator.selected {
-    background-color: $analytic-exchange-primary;
 }
 
 .attack-pattern-tooltip {

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.spec.ts
@@ -1,7 +1,6 @@
 import { ComponentFixture, TestBed, async, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { By } from '@angular/platform-browser';
-import { ActionReducerMap, StoreModule } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 
 import { MatCardModule, MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
@@ -9,8 +8,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 
 import { IndicatorHeatMapComponent } from './indicator-heat-map.component';
 import { HeatmapComponent } from '../../global/components/heatmap/heatmap.component';
-import { makeMockIndicatorSharingStore, mockIndicators, mockAttackPatterns } from '../../testing/mock-store';
-import { indicatorSharingReducer } from '../store/indicator-sharing.reducers';
+import { mockAttackPatterns } from '../../testing/mock-store';
 import { CapitalizePipe } from '../../global/pipes/capitalize.pipe';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -19,11 +17,6 @@ describe('IndicatorHeatMapComponent', () => {
 
     let fixture: ComponentFixture<IndicatorHeatMapComponent>;
     let component: IndicatorHeatMapComponent;
-    let store;
-
-    let mockReducer: ActionReducerMap<any> = {
-        indicatorSharing: indicatorSharingReducer
-    };
 
     const mockAttackPatternData = [
         {
@@ -61,7 +54,6 @@ describe('IndicatorHeatMapComponent', () => {
                     MatDialogModule,
                     HttpClientTestingModule,
                     RouterTestingModule,
-                    StoreModule.forRoot(mockReducer),
                 ],
                 declarations: [
                     IndicatorHeatMapComponent,
@@ -72,7 +64,7 @@ describe('IndicatorHeatMapComponent', () => {
                     GenericApi,
                     {
                         provide: MAT_DIALOG_DATA,
-                        useValue: {indicators: mockIndicators}
+                        useValue: {active: []}
                     },
                     {
                         provide: MatDialogRef,
@@ -91,8 +83,6 @@ describe('IndicatorHeatMapComponent', () => {
         heatmap.nativeElement.style.width = '300px';
         heatmap.nativeElement.style.height = '500px';
         component = fixture.componentInstance;
-        store = component.store;
-        makeMockIndicatorSharingStore(store);
         let mockApi = spyOn(component.genericApi, 'get').and.returnValue(Observable.of(mockAttackPatternData));
         fixture.detectChanges();
     });
@@ -100,7 +90,6 @@ describe('IndicatorHeatMapComponent', () => {
     it('should initialize', async(() => {
         expect(component).toBeTruthy();
         expect(component.heatmap.length).toBe(2);
-        expect(component.displayIndicators.length).toBe(3);
     }));
 
     it('should allow hover tooltips', fakeAsync(() => {
@@ -125,28 +114,6 @@ describe('IndicatorHeatMapComponent', () => {
         tick(1000); // skip a second into the future to spawn the tooltip
         fixture.detectChanges();
         expect(component.attackPattern).toBeNull();
-    }));
-
-    it('should filter analytics', async(() => {
-        const first = fixture.nativeElement.querySelector('g.heat-map-cell rect');
-        expect(first).not.toBeNull();
-        // TODO i'd rather invoke a mouseclick event on the above rect object, but can't seem to tell jasmine to do that
-        component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].cells[0],
-            event: {path: [first]}
-        });
-        fixture.detectChanges();
-        expect(component.selectedPatterns.length).toBe(1);
-        expect(component.displayIndicators.length).toBe(2);
-
-        // click it again to see that it handle deselects
-        component.highlightAttackPatternAnalytics({
-            row: component.heatmap[0].cells[0],
-            event: {path: [first]}
-        });
-        fixture.detectChanges();
-        expect(component.selectedPatterns.length).toBe(0);
-        expect(component.displayIndicators.length).toBe(3);
     }));
 
 });

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -16,6 +16,7 @@ import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 
 import { IndicatorSharingFeatureState } from '../store/indicator-sharing.reducers';
+import { HeatmapComponent } from '../../global/components/heatmap/heatmap.component';
 import { HeatMapOptions } from '../../global/components/heatmap/heatmap.data';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { Constance } from '../../utils/constance';
@@ -28,6 +29,7 @@ import { Constance } from '../../utils/constance';
 export class IndicatorHeatMapComponent implements OnInit {
 
     public heatmap: any[] = [];
+    @ViewChild('heatmapView') private heatmapView: HeatmapComponent;
     @Input() heatmapOptions: HeatMapOptions = {
         color: {
             batchColors: [
@@ -240,25 +242,20 @@ export class IndicatorHeatMapComponent implements OnInit {
             if (index < 0) {
                 // pattern was not previously selected; select it
                 this.selectedPatterns.push(clicked.row);
-                if (clicked.event && clicked.event.path && clicked.event.path.length) {
-                    const rect = clicked.event.path.find(node => node && (node.localName === 'rect'));
-                    if (rect) {
-                        const cls = document.createAttribute('class');
-                        cls.value = 'selected';
-                        rect.attributes.setNamedItem(cls);
-                    }
-                }
             } else {
                 // remove the pattern from our selection list
                 newValue = 'inactive';
                 this.selectedPatterns.splice(index, 1);
-                if (clicked.event && clicked.event.path && clicked.event.path.length) {
-                    const rect = clicked.event.path.find(node => node && (node.localName === 'rect'));
-                    if (rect) {
-                        rect.attributes.removeNamedItem('class');
-                    }
-                }
             }
+            this.heatmap.forEach(batch => {
+                batch.cells.forEach(cell => {
+                    if (cell.title === clicked.row.title) {
+                        cell.value = newValue;
+                    }
+                });
+                return batch;
+            });
+            this.heatmapView.updateCells();
         }
     }
 

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -56,8 +56,6 @@ export class IndicatorHeatMapComponent implements OnInit {
     private overlayRef: OverlayRef;
     private portal: TemplatePortal<any>;
 
-    @ViewChild('indicatorsGrid') indicatorsGrid: ElementRef;
-
     constructor(
         public dialogRef: MatDialogRef<IndicatorHeatMapComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any,

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heat-map.component.ts
@@ -10,7 +10,6 @@ import {
         ChangeDetectorRef,
     } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Store } from '@ngrx/store';
 
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
@@ -60,7 +59,6 @@ export class IndicatorHeatMapComponent implements OnInit {
     @ViewChild('indicatorsGrid') indicatorsGrid: ElementRef;
 
     constructor(
-        public store: Store<IndicatorSharingFeatureState>,
         public dialogRef: MatDialogRef<IndicatorHeatMapComponent>,
         @Inject(MAT_DIALOG_DATA) public data: any,
         public genericApi: GenericApi,

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.html
@@ -17,11 +17,17 @@
           <mat-option value="{{phase}}" *ngFor="let phase of killChainPhases$ | async">{{ phase | capitalize }}</mat-option>
         </mat-select>
       </mat-form-field>
-      <mat-form-field class="full-width mb-9">
-        <mat-select placeholder="Indicated Attack Patterns" [multiple]="true" formControlName="attackPatterns">
-          <mat-option value="{{ap.id}}" *ngFor="let ap of (store.select('indicatorSharing').pluck('attackPatterns') | async) | sortByField:'name':'ascending'">{{ ap.name }}</mat-option>
-        </mat-select>
-      </mat-form-field>
+      <div style="display:flex; flex-direction:row; align-items:baseline;">
+        <mat-form-field class="full-width mb-9">
+          <mat-select placeholder="Indicated Attack Patterns" [multiple]="true" formControlName="attackPatterns">
+            <mat-option value="{{ap.id}}" *ngFor="let ap of (store.select('indicatorSharing').pluck('attackPatterns') | async) | sortByField:'name':'ascending'">{{ ap.name }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button mat-icon-button id="heatmapToggle" [class.open]="heatmapVisible"
+            matTooltip="Show Heat Map" (click)="toggleHeatMapDialog()">
+          <i class="material-icons mat-24 labelColor">view_comfy</i>
+        </button>
+      </div>
       <mat-form-field class="full-width mb-9">
         <mat-select placeholder="Sensors" [multiple]="true" formControlName="sensors">
           <mat-option value="{{sensor.id}}" *ngFor="let sensor of store.select('indicatorSharing').pluck('sensors') | async">{{ sensor.name | capitalize }}</mat-option>
@@ -39,7 +45,7 @@
   <hr class="mt-0 mb-0">
 
   <p class="text-right p-24">
-    <button mat-button color="primary" (click)="clearSearchParamaters()">CLEAR FILTERS</button>
+    <button mat-button color="primary" (click)="clearSearchParameters()">CLEAR FILTERS</button>
   </p>
 
 </div>

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.scss
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.scss
@@ -1,0 +1,15 @@
+@import '../../../styles/_variables.scss';
+
+:host ::ng-deep {
+    button#heatmapToggle span.mat-button-wrapper {
+        padding: 0 2px;
+        border-left: 2px solid transparent;
+        border-right: 2px solid transparent;
+    }
+    button#heatmapToggle.open span.mat-button-wrapper {
+        border-right-color: $analytic-exchange-primary-lighter;
+    }
+    button#heatmapToggle.open span.mat-button-wrapper i {
+        color: $analytic-exchange-primary-lighter;
+    }
+}

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.spec.ts
@@ -1,8 +1,7 @@
 import { async, ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
-import { MatCardModule, MatSelectModule, MatInputModule } from '@angular/material';
+import { MatCardModule, MatSelectModule, MatInputModule, MatDialogModule } from '@angular/material';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { ActionReducerMap, StoreModule } from '@ngrx/store';
-
 
 import { IndicatorSharingFiltersComponent } from './indicator-sharing-filters.component';
 import { indicatorSharingReducer } from '../store/indicator-sharing.reducers';
@@ -34,6 +33,7 @@ describe('IndicatorSharingFiltersComponent', () => {
             ],
             imports: [
                 MatCardModule,
+                MatDialogModule,
                 MatSelectModule,
                 MatInputModule,
                 ReactiveFormsModule,

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
@@ -20,7 +20,7 @@ export class IndicatorSharingFiltersComponent implements OnInit {
   public searchForm: FormGroup;
   public killChainPhases$: Observable<any>;
   public labels$: Observable<any>;
-  private heatmapVisible = false;
+  public heatmapVisible = false;
 
   constructor(
     public dialog: MatDialog,

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
@@ -3,9 +3,12 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { Observable } from 'rxjs/Observable';
 import { Store } from '@ngrx/store';
 
+import { MatDialog } from '@angular/material';
+
 import * as fromIndicatorSharing from '../store/indicator-sharing.reducers';
 import * as indicatorSharingActions from '../store/indicator-sharing.actions';
 import { SearchParameters } from '../models/search-parameters';
+import { IndicatorHeatMapComponent } from '../indicator-heat-map/indicator-heat-map.component';
 
 @Component({
   selector: 'indicator-sharing-filters',
@@ -17,8 +20,10 @@ export class IndicatorSharingFiltersComponent implements OnInit {
   public searchForm: FormGroup;
   public killChainPhases$: Observable<any>;
   public labels$: Observable<any>;
+  private heatmapVisible = false;
 
   constructor(
+    public dialog: MatDialog,
     public store: Store<fromIndicatorSharing.IndicatorSharingFeatureState>, 
     private fb: FormBuilder
   ) {
@@ -68,9 +73,42 @@ export class IndicatorSharingFiltersComponent implements OnInit {
       });
   }
 
-  public clearSearchParamaters() {
+  public clearSearchParameters() {
     this.searchForm.reset(fromIndicatorSharing.initialSearchParameters);
     this.store.dispatch(new indicatorSharingActions.ClearSearchParameters());
+  }
+
+  /**
+   * @description Displays a slide-out that shows the user a heat map of all attack patterns for filtering
+   */
+  public toggleHeatMapDialog() {
+    if (this.heatmapVisible) {
+      this.heatmapVisible = false;
+      this.dialog.closeAll();
+    } else {
+      this.heatmapVisible = true;
+      this.dialog.open(IndicatorHeatMapComponent, {
+        width: 'calc(100vw - 400px)',
+        height: '500px',
+        hasBackdrop: true,
+        disableClose: false,
+        closeOnNavigation: true,
+        position: {
+          left: '345px',
+        },
+        data: {
+          active: this.searchForm.value.attackPatterns,
+        },
+      }).afterClosed().subscribe(
+        result => {
+          if (result) {
+            this.searchForm.get('attackPatterns').patchValue(result);
+          }
+          this.heatmapVisible = false;
+        },
+        (err) => console.log(err),
+      );
+    }
   }
 
 }

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -39,9 +39,6 @@
                             <label class="mb-0">Results: {{ (store.select('indicatorSharing').pluck('filteredIndicators') | async).length }} / {{ store.select('indicatorSharing').pluck('totalIndicatorCount') | async }}</label>
                             <label class="spacer" id="spacer2">&nbsp;|&nbsp;</label>
                             <span id="listControlBtns">
-                                <button mat-icon-button id="showAttackPatternHeatMap" (click)="viewHeatMapDialog($event)" matTooltip="Show Heat Map">
-                                    <i class="material-icons mat-24 labelColor">view_comfy</i>
-                                </button>
                                 <button mat-icon-button matTooltip="{{ showSummaryStats ? 'Hide' : 'Show' }} Statistics" (click)="toggleShowStatistics()">
                                     <i class="material-icons mat-24" [ngClass]="{'labelColor': !showSummaryStats}">equalizer</i>
                                 </button>

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -217,19 +217,4 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
         this.changeDetectorRef.markForCheck();
     }
 
-    /**
-     * @description Displays a popup that shows the user a heat map of all attack patterns used by all the
-     *              currently-filtered analytics.
-     */
-    public viewHeatMapDialog(ev?: UIEvent) {
-        this.dialog.open(IndicatorHeatMapComponent, {
-            width: 'calc(100vw - 150px)',
-            height: 'calc(100vh - 100px)',
-            data: {
-                indicators: this.filteredIndicators,
-                indicatorsToAttackPatternMap: this.indicatorToAttackPatternMap,
-            }
-        });
-    }
-
 }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#926.

The analytics exchange heatmap is now a filter that slides out from the sidenav. The attack pattern select, which still exists, now has a button to display the heatmap, to use as an alternative chooser. It should stay in sync with the select filter, so changes to the select box should show in the heatmap, and vice versa.