### PR TITLE
updated stix permissions for demo mode

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -41,7 +41,7 @@
             <div class="appItemText">API Explorer</div>
           </a>
         </span>
-        <span class="appLinkWrapper" *ngIf="authService.isAdmin()">
+        <span class="appLinkWrapper" *ngIf="authService.isAdmin() || runMode === 'DEMO'">
           <a routerLink="./stix/attack-patterns" class="appLink" (click)="showAppMenu = false">
             <img src="{{ stixIcon }}" class="appItemImg">
             <div class="appItemText">STIX</div>

--- a/src/app/global/static/stix-permissions.spec.ts
+++ b/src/app/global/static/stix-permissions.spec.ts
@@ -3,6 +3,7 @@ import { StixPermissions } from './stix-permissions';
 import { Stix } from '../../models/stix/stix';
 import { testUser } from '../../testing/test-user';
 import { UserRole } from '../../models/user/user-role.enum';
+import { environment } from '../../../environments/environment';
 
 const admin: UserProfile | any = testUser.userData;
 const standardUser = { ...admin, role: UserRole.STANDARD_USER };
@@ -25,9 +26,14 @@ const sameOrgStix = { ...unpublishedStix, created_by_ref: standardUser.organizat
 const stixPermissionsAdmin = new StixPermissions(admin);
 const stixPermissionsStandard = new StixPermissions(standardUser);
 
-describe('StixPermissions', () => {  
 
-    describe('Static functions', () => {
+describe('StixPermissions', () => {
+    beforeEach(() => {
+        // Need to ensure that run mode is not in DEMO
+        spyOn(environment, 'runMode').and.returnValue('UAC');
+    });
+    
+    describe('Static functions', () => {        
         it('should allow all operations for an admin, but not standard user', () => {
             expect(StixPermissions.canReadStatic(unpublishedStix, admin)).toBeTruthy();
             expect(StixPermissions.canCrudStatic(unpublishedStix, admin)).toBeTruthy();

--- a/src/app/global/static/stix-permissions.ts
+++ b/src/app/global/static/stix-permissions.ts
@@ -1,6 +1,7 @@
 import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { UserRole } from '../../models/user/user-role.enum';
+import { environment } from '../../../environments/environment';
 
 /**
  * @param  {Stix} stix
@@ -9,6 +10,9 @@ import { UserRole } from '../../models/user/user-role.enum';
  * @description Determines if the create_by_ref of a STIX object is in a user's organizations
  */
 function orgPermissions (stix: Stix, user: UserProfile): boolean {
+    if (environment.runMode === 'DEMO') {
+        return true;
+    }
     // TODO - How to handle no created_by_ref?
     return user.organizations && 
         user.organizations.length && 


### PR DESCRIPTION
Instructions
- Bring the application up in demo mode 
- Edit `unfetter/docker-compose.development.yml` `RUN_MODE` to `DEMO`, and launch UI with `serve:docker:dev:demo`
- Confirm all dashboards work as expected for demo mode

fixes unfetter-discover/unfetter#945