### PR TITLE
More code coverage tests

### DIFF
--- a/src/app/components/list-stix-objects/link-stix-objects.component.spec.ts
+++ b/src/app/components/list-stix-objects/link-stix-objects.component.spec.ts
@@ -1,23 +1,38 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ActivatedRoute, Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Location } from '@angular/common';
 import { By } from '@angular/platform-browser';
+import { Observable } from 'rxjs/Observable';
 
 import { FormsModule } from '@angular/forms';
 import { DataListModule } from 'primeng/primeng';
 import { MatChipsModule, MatIconModule, MatDialog } from '@angular/material';
 
 import { ListStixObjectComponent } from './list-stix-objects.component';
-import { ActivatedRoute, Router } from '@angular/router';
 
 describe('ListStixObjectComponent', () => {
 
     let component: ListStixObjectComponent;
     let fixture: ComponentFixture<ListStixObjectComponent>;
 
+    const routes: Routes = [{path: 'test', component: ListStixObjectComponent}];
+    const mockRouter = {
+        navigate: (paths: string[]) => {},
+    }
+    const mockDialog = {
+        open: () => {
+            return {
+                afterClosed: () => Observable.of({})
+            };
+        },
+        closeAll: () => {},
+    };
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [
-                RouterTestingModule,
+                RouterTestingModule.withRoutes(routes),
                 DataListModule,
                 MatChipsModule,
                 MatIconModule,
@@ -27,9 +42,9 @@ describe('ListStixObjectComponent', () => {
             ],
             providers: [
                 { provide: ActivatedRoute, useValue: {} },
-                { provide: Router, useValue: {} },
-                { provide: MatDialog, useValue: {} },
-                { provide: Location, useValue: {} },
+                { provide: Router, useValue: mockRouter },
+                { provide: MatDialog, useValue: mockDialog },
+                { provide: Location, useValue: {back: () => {}} },
             ]
         })
         .compileComponents();
@@ -45,9 +60,32 @@ describe('ListStixObjectComponent', () => {
         expect(component).toBeTruthy();
     });
 
+    describe('should perform BaseComponent actions:', () => {
+
+        it('route to new view', () => {
+            const router = TestBed.get(Router);
+            const location = TestBed.get(Location);
+            const spy = spyOn(router, 'navigate');
+            component['gotoView']([routes[0].path]);
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it('open confirmation dialogs', () => {
+            component['openDialog']('test');
+            component['dialog'].closeAll();
+        });
+
+        it('handle cancel button clicks', () => {
+            const router = TestBed.get(Router);
+            const location = TestBed.get(Location);
+            const spy = spyOn(location, 'back');
+            component['cancelButtonClicked']();
+            expect(spy).toHaveBeenCalled();
+        });
+
+    });
+
     /**
-     * @todo add Base Component tests
-     * 
      * @todo lots more LinkStixObjects tests to add
      */
 

--- a/src/app/core/services/auth-interceptor.service.spec.ts
+++ b/src/app/core/services/auth-interceptor.service.spec.ts
@@ -1,15 +1,14 @@
 import { TestBed, async, inject } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { HttpClientModule, HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS, HttpClient, HttpHeaders } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { StoreModule } from '@ngrx/store';
 
 import { AuthInterceptor } from './auth-interceptor.service';
 import { reducers } from '../../root-store/app.reducers';
-import * as fromUsers from '../../root-store/users/users.reducers';
 import * as userActions from '../../root-store/users/user.actions';
 
-fdescribe('Auth-interceptor should', () => {
+describe('Auth-interceptor should', () => {
 
     let interceptor: AuthInterceptor;
     let userStore: any;
@@ -37,23 +36,16 @@ fdescribe('Auth-interceptor should', () => {
     beforeEach(() => {
         interceptor = TestBed.get(AuthInterceptor);
         userStore = interceptor['store'].select('users');
+        localStorage.clear();
     });
 
-    fit('should not apply any token if none is found', inject([HttpClient, HttpTestingController],
+    it('should not apply any token if none is found', inject([HttpClient, HttpTestingController],
         (http: HttpClient, httpMock: HttpTestingController) => {
             const user = { userData: {}, token: undefined };
             userStore.dispatch(new userActions.LoginUser(user));
-            http.get('/test').subscribe((response: any) => {
-                console.log('output response', response);
-                expect(response).toBeDefined();
-                expect(response.request).toBeDefined();
-                console.log('output request', response.request);
-                expect(response.request.headers).toBeDefined();
-                console.log('output headers', response.request.headers);
-                expect(response.request.headers.size()).toBe(0);
-            });
+            http.get('/test').subscribe((response: any) => expect(response).toBeDefined());
             const request = httpMock.expectOne(req => !req.headers.has('Authorization'));
-            request.flush(request);
+            request.flush({});
             httpMock.verify();
     }));
 
@@ -61,17 +53,10 @@ fdescribe('Auth-interceptor should', () => {
         (http: HttpClient, httpMock: HttpTestingController) => {
             const user = { userData: {}, token: 'pass' };
             userStore.dispatch(new userActions.LoginUser(user));
-            http.get('/test').subscribe((response: any) => {
-                console.log('output response', response);
-                expect(response).toBeDefined();
-                expect(response.request).toBeDefined();
-                expect(response.request.headers).toBeDefined();
-                expect(response.request.headers.size()).toBe(1);
-                expect(response.request.headers.get(0)).toEqual(user.token);
-            });
+            http.get('/test').subscribe((response: any) => expect(response).toBeDefined());
             const request = httpMock.expectOne(req =>
                     req.headers.has('Authorization') && (req.headers.get('Authorization') === user.token));
-            request.flush(request);
+            request.flush({});
             httpMock.verify();
     }));
 
@@ -80,18 +65,11 @@ fdescribe('Auth-interceptor should', () => {
             const token = 'unfetter';
             localStorage.setItem('unfetterUiToken', token);
             const user = { userData: {}, token: undefined };
-            userStore.dispatch(new userActions.LoginUser(undefined));
-            http.get('/test').subscribe((response: any) => {
-                console.log('output response', response);
-                expect(response).toBeDefined();
-                expect(response.request).toBeDefined();
-                expect(response.request.headers).toBeDefined();
-                expect(response.request.headers.size()).toBe(1);
-                expect(response.request.headers.get(0)).toEqual(token);
-            });
+            userStore.dispatch(new userActions.LoginUser(user));
+            http.get('/test').subscribe((response: any) => expect(response).toBeDefined());
             const request = httpMock.expectOne(req =>
                     req.headers.has('Authorization') && (req.headers.get('Authorization') === token));
-            request.flush(request);
+            request.flush({});
             httpMock.verify();
     }));
 

--- a/src/app/core/services/auth-interceptor.service.spec.ts
+++ b/src/app/core/services/auth-interceptor.service.spec.ts
@@ -1,0 +1,98 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientModule, HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { StoreModule } from '@ngrx/store';
+
+import { AuthInterceptor } from './auth-interceptor.service';
+import { reducers } from '../../root-store/app.reducers';
+import * as fromUsers from '../../root-store/users/users.reducers';
+import * as userActions from '../../root-store/users/user.actions';
+
+fdescribe('Auth-interceptor should', () => {
+
+    let interceptor: AuthInterceptor;
+    let userStore: any;
+
+    // async beforeEach
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                StoreModule.forRoot(reducers),
+                HttpClientTestingModule,
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [
+                AuthInterceptor,
+                {
+                    provide: HTTP_INTERCEPTORS,
+                    useClass: AuthInterceptor,
+                    multi: true,
+                },
+            ]
+        });
+    }));
+
+    // synchronous beforeEach
+    beforeEach(() => {
+        interceptor = TestBed.get(AuthInterceptor);
+        userStore = interceptor['store'].select('users');
+    });
+
+    fit('should not apply any token if none is found', inject([HttpClient, HttpTestingController],
+        (http: HttpClient, httpMock: HttpTestingController) => {
+            const user = { userData: {}, token: undefined };
+            userStore.dispatch(new userActions.LoginUser(user));
+            http.get('/test').subscribe((response: any) => {
+                console.log('output response', response);
+                expect(response).toBeDefined();
+                expect(response.request).toBeDefined();
+                console.log('output request', response.request);
+                expect(response.request.headers).toBeDefined();
+                console.log('output headers', response.request.headers);
+                expect(response.request.headers.size()).toBe(0);
+            });
+            const request = httpMock.expectOne(req => !req.headers.has('Authorization'));
+            request.flush(request);
+            httpMock.verify();
+    }));
+
+    it('should add a token if the current user has one', inject([HttpClient, HttpTestingController],
+        (http: HttpClient, httpMock: HttpTestingController) => {
+            const user = { userData: {}, token: 'pass' };
+            userStore.dispatch(new userActions.LoginUser(user));
+            http.get('/test').subscribe((response: any) => {
+                console.log('output response', response);
+                expect(response).toBeDefined();
+                expect(response.request).toBeDefined();
+                expect(response.request.headers).toBeDefined();
+                expect(response.request.headers.size()).toBe(1);
+                expect(response.request.headers.get(0)).toEqual(user.token);
+            });
+            const request = httpMock.expectOne(req =>
+                    req.headers.has('Authorization') && (req.headers.get('Authorization') === user.token));
+            request.flush(request);
+            httpMock.verify();
+    }));
+
+    it('should use the token in local storage if the user lacks one', inject([HttpClient, HttpTestingController],
+        (http: HttpClient, httpMock: HttpTestingController) => {
+            const token = 'unfetter';
+            localStorage.setItem('unfetterUiToken', token);
+            const user = { userData: {}, token: undefined };
+            userStore.dispatch(new userActions.LoginUser(undefined));
+            http.get('/test').subscribe((response: any) => {
+                console.log('output response', response);
+                expect(response).toBeDefined();
+                expect(response.request).toBeDefined();
+                expect(response.request.headers).toBeDefined();
+                expect(response.request.headers.size()).toBe(1);
+                expect(response.request.headers.get(0)).toEqual(token);
+            });
+            const request = httpMock.expectOne(req =>
+                    req.headers.has('Authorization') && (req.headers.get('Authorization') === token));
+            request.flush(request);
+            httpMock.verify();
+    }));
+
+});

--- a/src/app/core/services/auth.guard.spec.ts
+++ b/src/app/core/services/auth.guard.spec.ts
@@ -10,9 +10,6 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthGuard } from './auth.guard';
 import { reducers } from '../../root-store/app.reducers';
-
-import * as fromUsers from '../../root-store/users/users.reducers';
-import * as fromApp from '../../root-store/app.reducers';
 import * as userActions from '../../root-store/users/user.actions';
 
 describe('Auth guard should', () => {

--- a/src/app/core/services/auth.guard.spec.ts
+++ b/src/app/core/services/auth.guard.spec.ts
@@ -16,6 +16,7 @@ import * as fromApp from '../../root-store/app.reducers';
 import * as userActions from '../../root-store/users/user.actions';
 
 describe('Auth guard should', () => {
+
     let authGuard: AuthGuard;
     let userStore: any;
     let router = {
@@ -43,8 +44,8 @@ describe('Auth guard should', () => {
     // synchronous beforeEach
     beforeEach(() => {
         authGuard = TestBed.get(AuthGuard);
-        authGuard.demoMode = false;
-        userStore = authGuard.store.select('users');
+        authGuard['demoMode'] = false;
+        userStore = authGuard['store'].select('users');
     });
 
     it('Return true when user is logged in and is an admin', async () => {
@@ -88,4 +89,5 @@ describe('Auth guard should', () => {
                 expect(res).toBe(false);
             });
     });
+
 });

--- a/src/app/core/services/auth.guard.ts
+++ b/src/app/core/services/auth.guard.ts
@@ -10,11 +10,11 @@ import { environment } from '../../../environments/environment';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-    public demoMode: boolean = (environment.runMode === 'DEMO');
+    private demoMode: boolean = (environment.runMode === 'DEMO');
 
     constructor(
         private router: Router,
-        public store: Store<fromApp.AppState>
+        private store: Store<fromApp.AppState>
     ) { }
 
     public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -1,0 +1,352 @@
+import { TestBed, async } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { Router, RouterStateSnapshot, ActivatedRouteSnapshot } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StoreModule } from '@ngrx/store';
+import { encodeTestToken } from 'angular2-jwt/angular2-jwt-test-helpers';
+
+import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
+import { reducers } from '../../root-store/app.reducers';
+import * as userActions from '../../root-store/users/user.actions';
+
+describe('AuthService should', () => {
+
+    let service: AuthService;
+    let userStore: any;
+
+    const handleJWTError = (ex) => {
+        if (!/JWT must have 3 parts/.test(ex)) {
+            throw ex;
+        }
+    }
+
+    // async beforeEach
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                StoreModule.forRoot(reducers),
+                RouterTestingModule,
+                HttpClientTestingModule
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [AuthService]
+        });
+    }));
+
+    // synchronous beforeEach
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe('allow access when in demo mode', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'DEMO';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: true,
+                    locked: false,
+                    role: 'ADMIN'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            service.setToken(user.token);
+            expect(service.getUser()).toBeDefined();
+            expect(service.getToken()).toEqual(user.token); // coverage
+            expect(service.getStixPermissions()).not.toBeNull(); // coverage
+        });
+
+        it('user is logged in (even though there is no user)', async () => {
+            expect(service.loggedIn()).toBeTruthy();
+        });
+
+        it('user has no admin rights (even though there is no user)', async () => {
+            expect(service.isAdmin()).toBeFalsy();
+        });
+
+    });
+
+    describe('prevent access when no user logged in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+            userStore = service['store'].select('users');
+            expect(service.getUser()).toBeNull();
+            service.setToken(encodeTestToken({}));
+        });
+
+        it('user is not logged in (since there is no user)', async () => {
+            expect(service.loggedIn()).toBeFalsy();
+        });
+
+        it('user has no admin rights (since there is no user)', async () => {
+            expect(service.isAdmin()).toBeFalsy();
+        });
+
+        it('user has no org leader rights (since there is no user)', async () => {
+            expect(service.isOrgLeader()).toBeFalsy();
+        });
+
+        it('user is not pending approval (since there is no user)', async () => {
+            try {
+                expect(service.pendingApproval()).toBeFalsy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+        it('user is not locked (since there is no user)', async () => {
+            try {
+                expect(service.userLocked()).toBeFalsy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+    });
+
+    describe('prevent access when new (unapproved) user logs in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: false,
+                    locked: false,
+                    role: 'STANDARD_USER'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            expect(service.getUser()).toBeDefined();
+            service.setToken(user.token);
+        });
+
+        it('user is not logged in (since they are not approved)', async () => {
+            expect(service.loggedIn()).toBeFalsy();
+        });
+
+        it('user has no admin rights (since they are not approved)', async () => {
+            expect(service.isAdmin()).toBeFalsy();
+        });
+
+        it('user has no org leader rights (since they are not approved)', async () => {
+            expect(service.isOrgLeader()).toBeFalsy();
+        });
+
+        it('user is pending approval (since they are)', async () => {
+            try {
+                expect(service.pendingApproval()).toBeTruthy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+    });
+
+    describe('prevent access when a locked user logs in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: true,
+                    locked: true,
+                    role: 'STANDARD_USER'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            expect(service.getUser()).toBeDefined();
+            service.setToken(user.token);
+        });
+
+        it('user is logged in (since they are... ish)', async () => {
+            expect(service.loggedIn()).toBeTruthy();
+        });
+
+        it('user is locked (since they definitely are)', async () => {
+            try {
+                expect(service.userLocked()).toBeTruthy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+        it('user is not pending approval', async () => {
+            try {
+                expect(service.pendingApproval()).toBeFalsy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+    });
+
+    describe('check access when a regular user logs in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: true,
+                    locked: false,
+                    role: 'STANDARD_USER'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            expect(service.getUser()).toBeDefined();
+            service.setToken(user.token);
+        });
+
+        it('user is logged in', async () => {
+            expect(service.loggedIn()).toBeTruthy();
+            expect(service.hasRole(['STANDARD_USER'])).toBeTruthy();
+        });
+
+        it('user has no admin rights', async () => {
+            expect(service.isAdmin()).toBeFalsy();
+            expect(service.hasRole(['ADMIN'])).toBeFalsy();
+        });
+
+        it('user has no org leader rights', async () => {
+            expect(service.isOrgLeader()).toBeFalsy();
+            expect(service.hasRole(['ORG_LEADER'])).toBeFalsy();
+        });
+
+        it('user is not locked', async () => {
+            try {
+                expect(service.userLocked()).toBeFalsy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+        it('user is not pending approval', async () => {
+            try {
+                expect(service.pendingApproval()).toBeFalsy();
+            } catch (ex) {
+                // Ignore the unhandled promise rejection the JwtHelper.tokenNotExpired throws
+                handleJWTError(ex);
+            }
+        });
+
+        it('test plucking the user from storage', async () => {
+            const user = service['user']; // the beforeEach() method already ensures we have a user set
+            service.setUser(user);
+            service['user'] = undefined;  // clear out the locak variable to force pulling from local storage
+            expect(service.getUser()).toEqual(user);
+
+            // do it again, but clear local storage first
+            localStorage.clear();
+            service['user'] = undefined;
+            expect(service.getUser()).toBeNull();
+        });
+
+    });
+
+    describe('check access when an org leader user logs in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: true,
+                    locked: false,
+                    role: 'ORG_LEADER'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            expect(service.getUser()).toBeDefined();
+            service.setToken(user.token);
+        });
+
+        it('user is logged in', async () => {
+            expect(service.loggedIn()).toBeTruthy();
+            expect(service.hasRole(['STANDARD_USER'])).toBeFalsy();
+        });
+
+        it('user has no admin rights', async () => {
+            expect(service.isAdmin()).toBeFalsy();
+            expect(service.hasRole(['ADMIN'])).toBeFalsy();
+        });
+
+        it('user has org leader rights', async () => {
+            expect(service.isOrgLeader()).toBeTruthy();
+            expect(service.hasRole(['ORG_LEADER'])).toBeTruthy();
+        });
+
+    });
+
+    describe('check access when an admin user logs in', () => {
+
+        beforeEach(() => {
+            environment['runMode'] = 'LIVE';
+            service = TestBed.get(AuthService);
+
+            const user = {
+                userData: {
+                    approved: true,
+                    locked: false,
+                    role: 'ADMIN'
+                },
+                token: undefined
+            };
+            user.token = encodeTestToken(user);
+            userStore = service['store'].select('users');
+            userStore.dispatch(new userActions.LoginUser(user));
+            expect(service.getUser()).toBeDefined();
+            service.setToken(user.token);
+        });
+
+        it('user is logged in', async () => {
+            expect(service.loggedIn()).toBeTruthy();
+            expect(service.hasRole(['STANDARD_USER'])).toBeFalsy();
+        });
+
+        it('user has admin rights', async () => {
+            expect(service.isAdmin()).toBeTruthy();
+            expect(service.hasRole(['ADMIN'])).toBeTruthy();
+        });
+
+        it('user has org leader rights', async () => {
+            expect(service.isOrgLeader()).toBeTruthy();
+            expect(service.hasRole(['ORG_LEADER'])).toBeFalsy();
+        });
+
+    });
+
+});

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -66,11 +66,11 @@ export class AuthService {
         if (this.runMode === 'DEMO') {
             return true;
         } else {
-            let tokenExpiried: boolean = true;
+            let tokenExpired: boolean = true;
             try {
-                tokenExpiried = tokenNotExpired('unfetterUiToken');
+                tokenExpired = tokenNotExpired('unfetterUiToken');
             } catch (e) { }
-            return tokenExpiried && this.getUser() !== null && this.getUser().approved === true;
+            return tokenExpired && this.getUser() !== null && this.getUser().approved === true;
         }
     }
 

--- a/src/app/core/services/config.service.spec.ts
+++ b/src/app/core/services/config.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StoreModule } from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+
+import { ConfigService } from './config.service';
+import { reducers } from '../../root-store/app.reducers';
+import * as fromConfig from '../../root-store/config/config.reducers';
+import * as configActions from '../../root-store/config/config.actions';
+import { GenericApi } from './genericapi.service';
+
+describe('ConfigService', () => {
+
+    let service: ConfigService;
+
+    // async beforeEach
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                StoreModule.forRoot(reducers),
+                HttpClientTestingModule
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [ConfigService, GenericApi]
+        });
+    }));
+
+    // synchronous beforeEach
+    beforeEach(() => {
+        service = TestBed.get(ConfigService);
+    });
+
+    it('initializes with new configuration', () => {
+        service.configSet = false;
+        service.configurations = {};
+        service['store'].dispatch(new configActions.AddConfig({
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3',
+            'key4': 'value4',
+        }));
+        const spy = spyOn(console, 'log');
+        service.initConfig();
+        expect(service.configSet).toBeTruthy();
+        expect(Object.keys(service.configurations).length).toBe(4);
+        expect(service.configurations.key1).toEqual('value1');
+    });
+
+    it('initializes but with already has configuration', () => {
+        service.configSet = true;
+        service.configurations = {
+            'keya': 'valuea',
+        };
+        service['store'].dispatch(new configActions.AddConfig({
+            'keyb': 'valueb',
+            'keyc': 'valuec',
+            'keyd': 'valued',
+        }));
+        service.initConfig();
+        expect(service.configSet).toBeTruthy();
+        expect(Object.keys(service.configurations).length).toBe(1);
+        expect(service.configurations.keya).toEqual('valuea');
+        expect(service.configurations.keyb).toBeUndefined();
+    });
+
+    it('gets remote configuration', inject([GenericApi], (api: GenericApi) => {
+        spyOn(api, 'get').and.returnValue(Observable.of({
+            'keyx': 'valuex',
+        }));
+        service.getConfig().subscribe(cfg => {
+            expect(cfg).toBeDefined();
+            expect(cfg['keyx']).toEqual('valuex');
+        });
+    }));
+
+    it('gets remote public configuration', inject([GenericApi], (api: GenericApi) => {
+        spyOn(api, 'get').and.returnValue(Observable.of({
+            'keyz': 'valuez',
+        }));
+        service.getPublicConfig().subscribe(cfg => {
+            expect(cfg).toBeDefined();
+            expect(cfg['keyz']).toEqual('valuez');
+        });
+    }));
+
+});

--- a/src/app/core/services/config.service.ts
+++ b/src/app/core/services/config.service.ts
@@ -27,7 +27,7 @@ export class ConfigService {
 
     public initConfig() {
         this.getConfigPromise()
-            .then((res) => console.log('Configurations sucessfully initialized'))
+            .then((res) => console.log('Configurations successfully initialized'))
             .catch((err) => console.log('Unable to initalize configurations ', err))
     }
 

--- a/src/app/core/services/genericapi.service.spec.ts
+++ b/src/app/core/services/genericapi.service.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { GenericApi } from './genericapi.service';
+import { JsonApiData } from '../../models/json/jsonapi-data';
+import { StixLabelEnum } from '../../models/stix/stix-label.enum';
+
+describe('GenericApi service', () => {
+
+    let httpMock: HttpTestingController;
+
+    interface WhatsIt {
+        animal?: any,
+        vegetable?: any,
+        mineral?: any,
+    }
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [GenericApi],
+        });
+        httpMock = TestBed.get(HttpTestingController);
+    });
+
+    it('should GET', inject([GenericApi], (api: GenericApi) => {
+        api.get('/testdata', 'nao').subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response.success).toBeUndefined();
+            expect(response.length).toBe(2);
+            expect(response[0]['key1']).toEqual('value1');
+            expect(response[1]['key2']).toEqual('value2');
+        });
+        const req = httpMock.expectOne(`/testdata/nao`);
+        expect(req.request.method).toBe('GET');
+        req.flush({
+            success: true,
+            data: [
+                {'key1': 'value1'},
+                {'key2': 'value2'},
+            ]
+        });
+        httpMock.verify();
+    }));
+
+    it('should GET as a type', inject([GenericApi], (api: GenericApi) => {
+        api.getAs<JsonApiData<WhatsIt>>('/isit', 'animal').subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response.type).toEqual('animal');
+            expect(response.attributes['animal']).toEqual('pangolin');
+        });
+        const req = httpMock.expectOne(`/isit/animal`);
+        expect(req.request.method).toBe('GET');
+        req.flush({
+            data: {
+                type: 'animal',
+                attributes: {'animal': 'pangolin'}
+            },
+        });
+        httpMock.verify();
+    }));
+
+    it('should POST', inject([GenericApi], (api: GenericApi) => {
+        api.post('/testdork', {'when': 'nao'}).subscribe((response) => {
+            expect(response).toEqual('never');
+        });
+        const req = httpMock.expectOne(`/testdork`);
+        expect(req.request.method).toBe('POST');
+        req.flush({
+            success: false,
+            data: 'never'
+        });
+        httpMock.verify();
+    }));
+
+    it('should POST as a type', inject([GenericApi], (api: GenericApi) => {
+        const kumquat = {
+            'common-name': 'kumquat',
+            'scientific-name' : 'fortunella',
+        }
+        api.postAs<JsonApiData<WhatsIt>>('/guess', kumquat).subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response['vegetable']).toBe(kumquat);
+        });
+        const req = httpMock.expectOne(`/guess`);
+        expect(req.request.method).toBe('POST');
+        req.flush({ data: {vegetable: kumquat} });
+        httpMock.verify();
+    }));
+
+    it('should PATCH', inject([GenericApi], (api: GenericApi) => {
+        api.patch('/testderp', {'question': 'why'}).subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response.answer).toEqual('because');
+        });
+        const req = httpMock.expectOne(`/testderp`);
+        expect(req.request.method).toBe('PATCH');
+        req.flush({
+            success: false,
+            data: { answer: 'because' }
+        });
+        httpMock.verify();
+    }));
+
+    it('should PATCH as a type', inject([GenericApi], (api: GenericApi) => {
+        const fluorite = {
+            hardness: 4,
+            luster: 'vitreous'
+        };
+        api.patchAs<JsonApiData<WhatsIt>>('/minerals/fluorite', {'hardness': 4}).subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response['mineral']['luster']).toEqual('vitreous');
+        });
+        const req = httpMock.expectOne(`/minerals/fluorite`);
+        expect(req.request.method).toBe('PATCH');
+        req.flush({ data: {mineral: fluorite} });
+        httpMock.verify();
+    }));
+
+    it('should DELETE', inject([GenericApi], (api: GenericApi) => {
+        api.delete('/marbles', 'all').subscribe((response) => {
+            expect(response).toBeDefined();
+            expect(response.marbles).toBeDefined();
+            expect(response.marbles.length).toBe(0);
+        });
+        const req = httpMock.expectOne(`/marbles/all`);
+        expect(req.request.method).toBe('DELETE');
+        req.flush({
+            data: { marbles: [] }
+        });
+        httpMock.verify();
+    }));
+
+    it('should get latest by type', inject([GenericApi], (api: GenericApi) => {
+        api.getLatestByType(StixLabelEnum.IDENTITY).subscribe(ids => {
+            expect(ids).toBeDefined();
+            expect(ids.length).toEqual(3);
+            expect(ids[0].id).toEqual('THX-1138');
+        });
+        const req = httpMock.expectOne(`/latest/type/${StixLabelEnum.IDENTITY}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({
+            data: [
+                {id: 'THX-1138', name: 'Robert Duvall', type: 'drama', modified: '1971'},
+                {id: 'R2D2', name: 'Kenny Baker', type: 'sci-fi', modified: '1977'},
+                {id: 'V', name: 'Hugo Weaving', type: 'thriller', modified: '2005'},
+            ]
+        });
+        httpMock.verify();
+    }));
+
+    it('should get latest by type for a creator', inject([GenericApi], (api: GenericApi) => {
+        api.getLatestByTypeAndCreatorId(StixLabelEnum.SENSOR, 'RFC').subscribe(ids => {
+            expect(ids).toBeDefined();
+            expect(ids.length).toEqual(2);
+            expect(ids[1].modified).toEqual('1988');
+        });
+        const req = httpMock.expectOne(`/latest/type/${StixLabelEnum.SENSOR}/creator/RFC`);
+        expect(req.request.method).toBe('GET');
+        req.flush({
+            data: [
+                {
+                    id: 'SMTP',
+                    type: 'mail',
+                    name: 'Simple Mail Transfer Protocol',
+                    modified: '1982',
+                    created_by_ref: 'RFC 821'
+                },
+                {
+                    id: 'POP3',
+                    type: 'mail',
+                    name: 'Post Office Protocol',
+                    modified: '1988',
+                    created_by_ref: 'RFC 1081'
+                },
+            ]
+        });
+        httpMock.verify();
+    }));
+
+});

--- a/src/app/core/services/user-preferences.service.spec.ts
+++ b/src/app/core/services/user-preferences.service.spec.ts
@@ -1,15 +1,14 @@
-import { TestBed, async, inject } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed, async, inject } from '@angular/core/testing';
 import { StoreModule } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-
-import { UserPreferencesService } from './user-preferences.service';
+import { UserProfile } from '../../models/user/user-profile';
 import { reducers } from '../../root-store/app.reducers';
-import * as fromConfig from '../../root-store/config/config.reducers';
-import * as configActions from '../../root-store/config/config.actions';
 import { GenericApi } from './genericapi.service';
+import { UserPreferencesService } from './user-preferences.service';
+import { UserProfileMockFactory } from '../../models/user/user-profile.mock';
+
 
 describe('UserPreferencesService', () => {
 
@@ -33,25 +32,9 @@ describe('UserPreferencesService', () => {
     });
 
     it('gets remote public configuration', inject([GenericApi], (api: GenericApi) => {
-        const preferences = {
-            killchain: 'TacticXYZ'
-        };
-        const profile = {
-            _id: '1',
-            email: 'bob@company.com',
-            userName: 'bob',
-            lastName: 'B',
-            firstName: 'Bo',
-            created: '2018',
-            identity: {
-                id: '2',
-                name: 'bob',
-            },
-            registered: true,
-            preferences: preferences,
-        };
-        spyOn(api, 'postAs').and.returnValue(Observable.of({attributes: profile}));
-        service.setUserPreferences('bob', preferences).subscribe(response => expect(response).toEqual(profile));
+        const profile = UserProfileMockFactory.mockOne();
+        spyOn(api, 'postAs').and.returnValue(Observable.of({ attributes: profile }));
+        service.setUserPreferences('bob', profile.preferences).subscribe(response => expect(response).toEqual(profile));
     }));
 
     it('handles missing user id', () => {

--- a/src/app/core/services/user-preferences.service.spec.ts
+++ b/src/app/core/services/user-preferences.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StoreModule } from '@ngrx/store';
+import { Observable } from 'rxjs/Observable';
+
+import { UserPreferencesService } from './user-preferences.service';
+import { reducers } from '../../root-store/app.reducers';
+import * as fromConfig from '../../root-store/config/config.reducers';
+import * as configActions from '../../root-store/config/config.actions';
+import { GenericApi } from './genericapi.service';
+
+describe('UserPreferencesService', () => {
+
+    let service: UserPreferencesService;
+
+    // async beforeEach
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                StoreModule.forRoot(reducers),
+                HttpClientTestingModule
+            ],
+            schemas: [NO_ERRORS_SCHEMA],
+            providers: [UserPreferencesService, GenericApi]
+        });
+    }));
+
+    // synchronous beforeEach
+    beforeEach(() => {
+        service = TestBed.get(UserPreferencesService);
+    });
+
+    it('gets remote public configuration', inject([GenericApi], (api: GenericApi) => {
+        const preferences = {
+            killchain: 'TacticXYZ'
+        };
+        const profile = {
+            _id: '1',
+            email: 'bob@company.com',
+            userName: 'bob',
+            lastName: 'B',
+            firstName: 'Bo',
+            created: '2018',
+            identity: {
+                id: '2',
+                name: 'bob',
+            },
+            registered: true,
+            preferences: preferences,
+        };
+        spyOn(api, 'postAs').and.returnValue(Observable.of({attributes: profile}));
+        service.setUserPreferences('bob', preferences).subscribe(response => expect(response).toEqual(profile));
+    }));
+
+    it('handles missing user id', () => {
+        const spy = spyOn(console, 'log');
+        service.setUserPreferences(undefined, undefined);
+        expect(spy).toHaveBeenCalledWith('cannot update preferences on empty user id');
+    });
+
+});

--- a/src/app/events/ipgeo.service.spec.ts
+++ b/src/app/events/ipgeo.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
 import { HttpClientModule } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { IPGeoService } from './ipgeo.service';
 import { GenericApi } from '../core/services/genericapi.service';
@@ -9,12 +9,15 @@ describe('ipgeo service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientModule],
+            imports: [HttpClientModule, HttpClientTestingModule],
             providers: [IPGeoService, GenericApi],
         });
     });
 
-    it('should lookup a machine', inject([IPGeoService, GenericApi], (service: IPGeoService, api: GenericApi) => {
+    /**
+     * Disabled this. We don't want bad connections to kill our builds or Travis runs.
+     */
+    xit('should lookup a machine', inject([IPGeoService, GenericApi], (service: IPGeoService, api: GenericApi) => {
         const ipaddr = '205.175.221.58'; // one of the services shows a sample using this ip
         service.lookup(ipaddr).subscribe(
             (response) => {
@@ -27,6 +30,29 @@ describe('ipgeo service', () => {
             },
             (err) => expect(false).toBeTruthy(`We got an error looking up an IP: ${err}`),
         );
+    }));
+
+    it('should fake lookup a machine', inject([IPGeoService], (service: IPGeoService) => {
+        const ipaddr = '205.175.221.58'; // one of the services shows a sample using this ip
+        const httpMock = TestBed.get(HttpTestingController);
+        service.lookup(ipaddr).subscribe(
+            (response) => {
+                console.log('We received an IP address lookup response:', response); // leaving this here for other devs
+                expect(response).toBeDefined();
+                expect(response.length).toBe(1);
+                expect(response[0].success).toBeTruthy();
+                expect(response[0].ip).toEqual(ipaddr);
+                expect(response[0].city).toBeDefined();
+            },
+            (err) => expect(false).toBeTruthy(`We got an error looking up an IP: ${err}`),
+        );
+        const ipRequest = httpMock.expectOne(`https://ipapi.co/${ipaddr}/json/`);
+        ipRequest.flush({
+            ip: ipaddr,
+            city: 'New Test City',
+            country: 'United Earth'
+        });
+        httpMock.verify();
     }));
 
     it('should hate bad IP addresses', inject([IPGeoService, GenericApi], (service: IPGeoService, api: GenericApi) => {

--- a/src/app/models/user/user-preferences.mock.ts
+++ b/src/app/models/user/user-preferences.mock.ts
@@ -1,0 +1,11 @@
+import { Mock } from '../mock';
+import { UserPreferences } from './user-preferences';
+
+export class UserPreferencesMock extends Mock<UserPreferences> {
+    public mockOne(): UserPreferences {
+        const tmp = new UserPreferences();
+        tmp.killchain = 'TacticXYZ';
+        return tmp;
+    }
+}
+export const UserPreferencesMockFactory = new UserPreferencesMock();

--- a/src/app/models/user/user-profile.mock.ts
+++ b/src/app/models/user/user-profile.mock.ts
@@ -1,0 +1,28 @@
+import { Mock } from '../mock';
+import { UserPreferencesMockFactory } from './user-preferences.mock';
+import { UserProfile } from './user-profile';
+
+export class UserProfileMock extends Mock<UserProfile> {
+    public mockOne(): UserProfile {
+        const tmp = new UserProfile();
+        const preferences = UserPreferencesMockFactory.mockOne();
+        const identity = {
+            id: '2',
+            name: 'bob',
+        };
+
+        const profile = {
+            _id: '1',
+            email: 'bob@company.com',
+            userName: 'bob',
+            lastName: 'B',
+            firstName: 'Bo',
+            created: '2018',
+            identity,
+            registered: true,
+            preferences,
+        };
+        return tmp;
+    }
+}
+export const UserProfileMockFactory = new UserProfileMock();


### PR DESCRIPTION
Supports unfetter-discover/unfetter#728.

Code coverage and unit tests for most of core/services.

Removes external-URL test on IPGeoService to prevent build problems.