### PR TITLE
show correct attack patterns

### DIFF
--- a/src/app/global/components/stix-table/stix-table.component.html
+++ b/src/app/global/components/stix-table/stix-table.component.html
@@ -7,7 +7,7 @@
                 <div class="flex flexItemsCenter">
                     <span class="flex1">
                         <a routerLink="{{element.id}}">{{element.name}}</a>
-                        <chip-links [data]="element.external_references" maxChips="3" nameField="source_name" urlField="url"></chip-links>
+                        <chip-links [data]="element.external_references || []" maxChips="3" nameField="source_name" urlField="url"></chip-links>
                     </span>
                     <span class="buttonGrp text-right">
                         <button mat-button routerLink="edit/{{element.id}}">

--- a/src/app/settings/stix-objects/attack-patterns/attack-pattern-list/attack-pattern-list.component.html
+++ b/src/app/settings/stix-objects/attack-patterns/attack-pattern-list/attack-pattern-list.component.html
@@ -15,7 +15,7 @@
 
     <div class="col-md-12 scroll-area">
         <mat-accordion class="unfetterAngularMaterialAccordion">
-            <mat-expansion-panel *ngFor="let key of phaseNameGroupKeys">
+            <mat-expansion-panel *ngFor="let key of phaseNameGroupKeys; trackBy: trackByFn">
                 <mat-expansion-panel-header>
                     <mat-panel-title>
                         {{key | capitalize }}&nbsp;


### PR DESCRIPTION
supports unfetter-discover/unfetter#855

## Problem
* allow attack patterns from different frameworks to live in unfetter
* specifically the stix attack pattern page breaks if currently listing other attack patterns

## Approach
* dont break if attack patterns have empty external references
* filter for the users current preferred framework

## Test
* verify travis
* pull this branch
* uncomment the ntctf attack patterns in the `docker-compose.yml` processor section
* restart the stack
* go to webapp in the settings in uac, change your framework to ntctf
* visit the stix attack pattern page
* verify 

![screen shot 2018-04-12 at 3 08 49 pm](https://user-images.githubusercontent.com/30807406/38699549-4ef1e7da-3e66-11e8-8bd4-b391bdf4c314.png)

