### PR TITLE
Issue 953

### DIFF
--- a/src/app/events/events-content/events-content.component.html
+++ b/src/app/events/events-content/events-content.component.html
@@ -56,9 +56,9 @@
           <mat-card color="primary" class="uf-mat-card card mat-card-scroll-content bottom-card">
             <mat-card-title class="traffic-detail-title">Traffic Detail</mat-card-title>
             <mat-card-content>
-              <mat-table #table [dataSource]="service.dataSource">
+              <mat-table #table [dataSource]="service.dataSource" matSort>
                 <ng-container matColumnDef="{{columnIds[0]}}">
-                  <mat-header-cell *matHeaderCellDef>Date/Time</mat-header-cell>
+                  <mat-header-cell *matHeaderCellDef mat-sort-header>Date/Time</mat-header-cell>
                   <mat-cell *matCellDef="let sighting">{{sighting.attributes.last_seen | date:'medium' }}</mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="{{columnIds[1]}}">

--- a/src/app/events/events-content/events-content.component.html
+++ b/src/app/events/events-content/events-content.component.html
@@ -56,7 +56,7 @@
           <mat-card color="primary" class="uf-mat-card card mat-card-scroll-content bottom-card">
             <mat-card-title class="traffic-detail-title">Traffic Detail</mat-card-title>
             <mat-card-content>
-              <mat-table #table [dataSource]="service.dataSource" matSort>
+              <mat-table #table [dataSource]="service.dataSource" matSort (matSortChange)="service.refreshData($event)">
                 <ng-container matColumnDef="{{columnIds[0]}}">
                   <mat-header-cell *matHeaderCellDef mat-sort-header>Date/Time</mat-header-cell>
                   <mat-cell *matCellDef="let sighting">{{sighting.attributes.last_seen | date:'medium' }}</mat-cell>

--- a/src/app/events/events-content/events-content.component.html
+++ b/src/app/events/events-content/events-content.component.html
@@ -56,7 +56,7 @@
           <mat-card color="primary" class="uf-mat-card card mat-card-scroll-content bottom-card">
             <mat-card-title class="traffic-detail-title">Traffic Detail</mat-card-title>
             <mat-card-content>
-              <mat-table #table [dataSource]="service.dataSource" matSort (matSortChange)="service.refreshData($event)">
+              <mat-table #table [dataSource]="service.dataSource" matSort>
                 <ng-container matColumnDef="{{columnIds[0]}}">
                   <mat-header-cell *matHeaderCellDef mat-sort-header>Date/Time</mat-header-cell>
                   <mat-cell *matCellDef="let sighting">{{sighting.attributes.last_seen | date:'medium' }}</mat-cell>
@@ -64,8 +64,7 @@
                 <ng-container matColumnDef="{{columnIds[1]}}">
                   <mat-header-cell *matHeaderCellDef>Where Sighted</mat-header-cell>
                   <mat-cell *matCellDef="let sighting">
-                    <span>
-                    <!-- *ngIf="sighting.attributes.name && sighting.attributes.ip else unknown"> -->
+                    <span *ngIf="sighting.attributes.x_unfetter_asset.hostname && sighting.attributes.x_unfetter_asset.ip else unknown">
                       {{sighting.attributes.x_unfetter_asset.hostname}} - {{sighting.attributes.x_unfetter_asset.ip}}</span>
                     <ng-template #unknown>
                       Unknown

--- a/src/app/events/events-content/events-content.component.spec.ts
+++ b/src/app/events/events-content/events-content.component.spec.ts
@@ -1,6 +1,6 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { MatCardModule, MatSelectModule, MatTableModule } from '@angular/material';
+import { MatCardModule, MatSelectModule, MatTableModule, MatTableDataSource } from '@angular/material';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ChartsModule } from 'ng2-charts';
 import { EventsService } from '../events.service';
@@ -12,6 +12,9 @@ describe('EventsContentComponent', () => {
 
   const mockService = {
     recentSightings: [],
+    barChartLabels: [],
+    daysOfData: '',
+    dataSource: new MatTableDataSource([]),
   };
 
   let component: EventsContentComponent;

--- a/src/app/events/events-content/events-content.component.ts
+++ b/src/app/events/events-content/events-content.component.ts
@@ -61,6 +61,7 @@ export class EventsContentComponent implements OnInit, AfterViewInit {
       },
     ];
     this.service.daysOfData = this.DEFAULT_CHART_DAYS;
+    this.sort = new MatSort();
     this.sort.sort(<MatSortable>{
       id: this.columnIds[0],
       start: 'desc',

--- a/src/app/events/events-content/events-content.component.ts
+++ b/src/app/events/events-content/events-content.component.ts
@@ -1,14 +1,13 @@
-import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Constance } from '../../utils/constance';
 import { EventsService } from '../events.service';
-import { MatSort } from '@angular/material';
 
 @Component({
   selector: 'events-content',
   templateUrl: './events-content.component.html',
   styleUrls: ['./events-content.component.scss']
 })
-export class EventsContentComponent implements OnInit, AfterViewInit {
+export class EventsContentComponent implements OnInit {
   readonly DEFAULT_CHART_DAYS: string;
   readonly columnIds: string[];
   public barChartOptions: any;
@@ -16,8 +15,6 @@ export class EventsContentComponent implements OnInit, AfterViewInit {
   public readonly barChartType: string;
   public colors: any;
   public daysOfDataValue: string;
-
-  @ViewChild(MatSort) sort: MatSort;
 
   constructor( public service: EventsService) {
     this.columnIds = ['last_seen', 'hostname', 'observed_data_refs_city', 'observed_data_refs_country', 'threat', 'attack_pattern', 'potential actor'];
@@ -63,7 +60,4 @@ export class EventsContentComponent implements OnInit, AfterViewInit {
     this.service.daysOfData = this.DEFAULT_CHART_DAYS;
   }
 
-  ngAfterViewInit() {
-    this.service.sort = this.sort;
-  }
 }

--- a/src/app/events/events-content/events-content.component.ts
+++ b/src/app/events/events-content/events-content.component.ts
@@ -1,13 +1,14 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, AfterViewInit } from '@angular/core';
 import { Constance } from '../../utils/constance';
 import { EventsService } from '../events.service';
+import { MatSort } from '@angular/material';
 
 @Component({
   selector: 'events-content',
   templateUrl: './events-content.component.html',
   styleUrls: ['./events-content.component.scss']
 })
-export class EventsContentComponent implements OnInit {
+export class EventsContentComponent implements OnInit, AfterViewInit {
   readonly DEFAULT_CHART_DAYS: string;
   readonly columnIds: string[];
   public barChartOptions: any;
@@ -16,8 +17,10 @@ export class EventsContentComponent implements OnInit {
   public colors: any;
   public daysOfDataValue: string;
 
+  @ViewChild(MatSort) sort: MatSort;
+
   constructor( public service: EventsService) {
-    this.columnIds = ['date', 'ip', 'city', 'country', 'threat', 'attack_pattern', 'potential actor'];
+    this.columnIds = ['last_seen', 'hostname', 'observed_data_refs_city', 'observed_data_refs_country', 'threat', 'attack_pattern', 'potential actor'];
     this.DEFAULT_CHART_DAYS = '7';
 
     this.barChartType = 'bar';
@@ -58,5 +61,9 @@ export class EventsContentComponent implements OnInit {
       },
     ];
     this.service.daysOfData = this.DEFAULT_CHART_DAYS;
+  }
+
+  ngAfterViewInit() {
+    this.service.sort = this.sort;
   }
 }

--- a/src/app/events/events-content/events-content.component.ts
+++ b/src/app/events/events-content/events-content.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { MatSort, MatSortable } from '@angular/material';
 import { Constance } from '../../utils/constance';
 import { EventsService } from '../events.service';
 
@@ -7,7 +8,7 @@ import { EventsService } from '../events.service';
   templateUrl: './events-content.component.html',
   styleUrls: ['./events-content.component.scss']
 })
-export class EventsContentComponent implements OnInit {
+export class EventsContentComponent implements OnInit, AfterViewInit {
   readonly DEFAULT_CHART_DAYS: string;
   readonly columnIds: string[];
   public barChartOptions: any;
@@ -16,7 +17,9 @@ export class EventsContentComponent implements OnInit {
   public colors: any;
   public daysOfDataValue: string;
 
-  constructor( public service: EventsService) {
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(public service: EventsService) {
     this.columnIds = ['last_seen', 'hostname', 'observed_data_refs_city', 'observed_data_refs_country', 'threat', 'attack_pattern', 'potential actor'];
     this.DEFAULT_CHART_DAYS = '7';
 
@@ -58,6 +61,14 @@ export class EventsContentComponent implements OnInit {
       },
     ];
     this.service.daysOfData = this.DEFAULT_CHART_DAYS;
+    this.sort.sort(<MatSortable>{
+      id: this.columnIds[0],
+      start: 'desc',
+    });
+  }
+
+  ngAfterViewInit() {
+    this.service.dataSource.sort = this.sort;
   }
 
 }

--- a/src/app/events/events.module.ts
+++ b/src/app/events/events.module.ts
@@ -14,6 +14,7 @@ import { RelatedComponent } from './related/related.component';
 import { EventsEffects } from './store/events.effects';
 import { eventsReducer } from './store/events.reducers';
 import { IPGeoService } from './ipgeo.service';
+import { MatSortModule } from '@angular/material';
 
 @NgModule({
   imports: [
@@ -23,6 +24,7 @@ import { IPGeoService } from './ipgeo.service';
     StoreModule.forFeature('sightingsGroup', eventsReducer),
     EffectsModule.forFeature([EventsEffects]),
     ChartsModule,
+    MatSortModule,
   ],
   declarations: [EventsLayoutComponent, EventsComponent, EventsContentComponent, RelatedComponent, FiltersComponent],
   providers: [EventsService, IPGeoService, DatePipe],

--- a/src/app/events/events.service.ts
+++ b/src/app/events/events.service.ts
@@ -1,6 +1,6 @@
 import { _isNumberValue } from '@angular/cdk/coercion';
 import { DatePipe } from '@angular/common';
-import { ApplicationRef, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { MatTableDataSource } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
 import { GenericApi } from '../core/services/genericapi.service';
@@ -49,7 +49,6 @@ export class EventsService {
     constructor(
         private genericApi: GenericApi,
         private datePipe: DatePipe,
-        private ref: ApplicationRef
     ) {
         this.BASE_TEN = 10;
         this.dataSource = new SightingsDataSource(this.recentSightings);

--- a/src/app/events/events.service.ts
+++ b/src/app/events/events.service.ts
@@ -1,13 +1,13 @@
 import { DataSource } from '@angular/cdk/table';
 import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
-import { MatSort } from '@angular/material';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
 import { GenericApi } from '../core/services/genericapi.service';
 import { ChartData } from '../global/models/chart-data';
 import { Sighting } from '../models';
 import { JsonApiData } from '../models/json/jsonapi-data';
+import { OrganizationIdentity } from '../models/user/organization-identity';
 import { Constance } from '../utils/constance';
 
 export class SightingsData {
@@ -29,41 +29,16 @@ export class SightingsData {
     }
 }
 
-export class SightingsDataSource extends DataSource<Sighting> {
-    dataChange: BehaviorSubject<Sighting[]> = new BehaviorSubject<Sighting[]>([]);
-
-    constructor(private sightings: Sighting[], private sortValue: MatSort) {
+export class SightingsDataSource extends DataSource<any> {
+    constructor(private sightingsData: SightingsData) {
         super();
     }
 
     connect(): Observable<Sighting[]> {
-
-        const displayDataChanges = [
-            this.dataChange,
-            this.sortValue.sortChange
-        ];
-
-        return Observable.merge(...displayDataChanges).map(() => {
-            return this.getSortedData();
-        });       
+        return this.sightingsData.dataChange;
     }
 
     disconnect() { }
-
-    getSortedData(): Sighting[] {
-        const data = this.sightings.slice();
-        if (!this.sortValue || !this.sortValue.active || this.sortValue.direction === '') { return data; }
-
-        return data.sort((a, b) => {
-            return (a.attributes.last_seen < b.attributes.last_seen ? -1 : 1) * (this.sortValue.direction === 'asc' ? 1 : -1);
-        });
-    }
-
-    addSighting(newSighting: Sighting) {
-        const copiedData = this.sightings.slice();
-        copiedData.push(newSighting);
-        this.dataChange.next(copiedData);
-    }
 }
 
 @Injectable()
@@ -79,7 +54,6 @@ export class EventsService {
     public readonly barChartData: ChartData[];
     public barChartLabels: string[];
     public daysOfDataValue: string;
-    public sort: MatSort;
 
     public set daysOfData(newSelectedRange: string) {
         this.daysOfDataValue = newSelectedRange;
@@ -92,11 +66,10 @@ export class EventsService {
 
     constructor(
         private genericApi: GenericApi,
-        private datePipe: DatePipe,
-
+        private datePipe: DatePipe
     ) {
         this.BASE_TEN = 10;
-        this.dataSource = new SightingsDataSource(this.recentSightings, this.sort);
+        this.dataSource = new SightingsDataSource(this.dataStore);
         this.barChartData = [
             {
                 data: [],

--- a/src/app/events/events.service.ts
+++ b/src/app/events/events.service.ts
@@ -1,19 +1,26 @@
-import { DataSource } from '@angular/cdk/table';
+import { _isNumberValue } from '@angular/cdk/coercion';
 import { DatePipe } from '@angular/common';
-import { Injectable, ChangeDetectorRef, ApplicationRef } from '@angular/core';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { ApplicationRef, Injectable } from '@angular/core';
+import { MatTableDataSource } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
 import { GenericApi } from '../core/services/genericapi.service';
 import { ChartData } from '../global/models/chart-data';
 import { Sighting } from '../models';
 import { JsonApiData } from '../models/json/jsonapi-data';
-import { OrganizationIdentity } from '../models/user/organization-identity';
 import { Constance } from '../utils/constance';
-import { MatTableDataSource } from '@angular/material';
 
 export class SightingsDataSource extends MatTableDataSource<any> {
     addSighting(newSighting: Sighting) {
         this.data = [...this.data, newSighting];
+    }
+
+    sortingDataAccessor = (sighting: Sighting, sortHeaderId: string): string|number => {
+        if (sortHeaderId === 'last_seen') {
+            const date: any = sighting.attributes.last_seen;
+            return date;
+        }
+        const value: any = sighting[sortHeaderId];
+        return _isNumberValue(value) ? Number(value) : value;
     }
 }
 

--- a/src/app/events/events/events.component.ts
+++ b/src/app/events/events/events.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { EventsService, SightingsData } from '../events.service';
+import { EventsService, SightingsDataSource } from '../events.service';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../root-store/app.reducers';
 import { EventsState } from '../store/events.reducers';
@@ -122,7 +122,7 @@ export class EventsComponent implements OnInit, OnDestroy {
   public addSighting(newSighting) {
     if (this.service.recentSightings) {
       this.transformSighting(newSighting);
-      this.service.dataStore.addSighting(newSighting);
+      this.service.dataSource.addSighting(newSighting);
       let temp = this.service.recentSightings;
       temp.push(newSighting);
       this.service.recentSightings = temp;
@@ -289,8 +289,8 @@ export class EventsComponent implements OnInit, OnDestroy {
 
   public transformSightings() {
     if (!this.sightingsGroup) {
-      this.service.dataStore = new SightingsData([]);
       this.service.recentSightings = new Array<Sighting>();
+      this.service.dataSource = new SightingsDataSource(this.service.recentSightings);
       this.identities = [];
       this.indicators = [];
       this.observedData = [];
@@ -301,7 +301,7 @@ export class EventsComponent implements OnInit, OnDestroy {
       this.observedData = this.sightingsGroup.filter((data: any) => data.attributes.type === 'observed-data');
       for (const sighting of this.service.recentSightings) {
         this.transformSighting(sighting);
-        this.service.dataStore.addSighting(sighting);
+        this.service.dataSource.addSighting(sighting);
       }
     }
   }

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
@@ -180,7 +180,7 @@ describe('IndicatorCardComponent', () => {
         component.indicator = { ...mockIndicator };
         component.searchParameters = { ...mockSearchParams };
         component.collapseAllCardsSubject = mockCollapseAllCards;
-
+        spyOn(component, 'exportIndicator').and.returnValue(true);
         fixture.detectChanges();
     });
 

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
@@ -314,7 +314,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
             ...enhancements
         };
 
-        const downloadData$ = this.indicatorSharingService.getDownloadData(indicatorCopy.id, attackPatternIds, sensorIds)
+        const downloadData$ = this.indicatorSharingService.getDownloadData([indicatorCopy.id], attackPatternIds, sensorIds)
             .subscribe(
                 (downloadData) => {
                     downloadBundle([exportObj, ...sensorRelationships, ...downloadData ], `${this.indicator.name}-enhanced-bundle`);

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -39,6 +39,11 @@
                             <label class="mb-0">Results: {{ (store.select('indicatorSharing').pluck('filteredIndicators') | async).length }} / {{ store.select('indicatorSharing').pluck('totalIndicatorCount') | async }}</label>
                             <label class="spacer" id="spacer2">&nbsp;|&nbsp;</label>
                             <span id="listControlBtns">
+                                <!-- Download bundle -->
+                                <button mat-icon-button matTooltip="Download Results" (click)="downloadResults()">
+                                    <i class="material-icons mat-24 labelColor">file_download</i>
+                                </button>
+                                <!-- Show summary stats -->
                                 <button mat-icon-button matTooltip="{{ showSummaryStats ? 'Hide' : 'Show' }} Statistics" (click)="toggleShowStatistics()">
                                     <i class="material-icons mat-24" [ngClass]="{'labelColor': !showSummaryStats}">equalizer</i>
                                 </button>
@@ -51,7 +56,7 @@
                                 <button mat-icon-button matTooltip="Expand All Cards" (click)="collapseAllCards = false; collapseAllCardsSubject.next(collapseAllCards)"
                                     *ngIf="collapseAllCards">
                                     <i class="material-icons mat-24 labelColor">fullscreen</i>
-                                </button>
+                                </button>                                
                             </span>
                          </div>
                     </div>

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.scss
@@ -67,7 +67,7 @@
   }
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1250px) {
   #listControlFlexWraper {
     flex-direction: column;
     align-items: flex-start;

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.spec.ts
@@ -9,6 +9,8 @@ import { IndicatorSharingListComponent } from './indicator-sharing-list.componen
 import { usersReducer } from '../../root-store/users/users.reducers';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IndicatorSharingService } from '../indicator-sharing.service';
+import { Observable } from 'rxjs/Observable';
 
 
 describe('IndicatorSharingListComponent', () => {
@@ -17,9 +19,15 @@ describe('IndicatorSharingListComponent', () => {
 
     let store;
 
-    let mockReducer: ActionReducerMap<any> = {
+    const mockReducer: ActionReducerMap<any> = {
         users: usersReducer,
         indicatorSharing: indicatorSharingReducer
+    };
+
+    const mockIndicatorSharingService = {
+        getDownloadData: (p1, p2, p3) => {
+            return Observable.of([]);
+        }
     };
 
     beforeEach(async(() => {
@@ -35,6 +43,12 @@ describe('IndicatorSharingListComponent', () => {
                 RouterTestingModule,
                 StoreModule.forRoot(mockReducer)
             ],
+            providers: [
+                {
+                    provide: IndicatorSharingService,
+                    useValue: mockIndicatorSharingService
+                }
+            ],
             schemas: [NO_ERRORS_SCHEMA]
         })
             .compileComponents();
@@ -46,6 +60,8 @@ describe('IndicatorSharingListComponent', () => {
         store = component.store;
         makeRootMockStore(store);
         makeMockIndicatorSharingStore(store);
+        // to prevent downloading
+        spyOn(component, 'downloadResults').and.returnValue(true);
         fixture.detectChanges();
     });
 

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -16,6 +16,10 @@ import { ConfirmationDialogComponent } from '../../components/dialogs/confirmati
 import { initialSearchParameters } from '../store/indicator-sharing.reducers';
 import { IndicatorHeatMapComponent } from '../indicator-heat-map/indicator-heat-map.component';
 import { heightCollapse } from '../../global/animations/height-collapse';
+import { generateStixRelationship } from '../../global/static/stix-relationship';
+import { StixRelationshipTypes } from '../../global/enums/stix-relationship-types.enum';
+import { IndicatorSharingService } from '../indicator-sharing.service';
+import { downloadBundle } from '../../global/static/stix-bundle';
 
 @Component({
     selector: 'indicator-sharing-list',
@@ -42,6 +46,7 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
     constructor(
         public dialog: MatDialog,
         public store: Store<fromIndicatorSharing.IndicatorSharingFeatureState>,
+        private indicatorSharingService: IndicatorSharingService,
         // Used for SERVER_CALL_COMPLETE, this should be moved to ngrx
         protected changeDetectorRef: ChangeDetectorRef
     ) { 
@@ -215,6 +220,83 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
     public toggleShowStatistics() {
         this.showSummaryStats = !this.showSummaryStats;
         this.changeDetectorRef.markForCheck();
+    }
+
+    public downloadResults() {
+        const sensorRelationships: any[] = [];
+        const attackPatternIdSet = new Set();
+        const sensorIdSet = new Set();
+
+        const indicatorsCopy = this.filteredIndicators
+            .map((indicator) => {
+                const indicatorCopy = { ...indicator };
+                const enhancements: any = {};
+                const sensorIds: string[] = this.getSensorsByIndicatorId(indicator.id) ? this.getSensorsByIndicatorId(indicator.id)
+                    .map((sensor) => sensor.id) : [];
+                const attackPatternIds: string[] = this.getAttackPatternsByIndicatorId(indicator.id)
+                    .map((ap) => ap.id);                
+
+                if (indicatorCopy.metaProperties) {
+                    delete indicatorCopy.metaProperties;
+                }
+
+                if (indicator.metaProperties && indicator.metaProperties.queries) {
+                    const generatedQueries = { ...indicator.metaProperties.queries };
+                    const queryArr = [];
+                    for (let name in generatedQueries) {
+                        queryArr.push({ name, query: generatedQueries[name].query });
+                    }
+
+                    enhancements.x_unfetter_generated_queries = queryArr;
+                }
+
+                if (indicator.metaProperties && indicator.metaProperties.additional_queries) {
+                    enhancements.x_unfetter_user_queries = [...indicator.metaProperties.additional_queries];
+                }
+
+                if (sensorIds && sensorIds.length) {
+                    sensorIds.forEach((sensorId) => {
+                        sensorIdSet.add(sensorId)
+                        sensorRelationships.push(generateStixRelationship(sensorId, indicator.id, StixRelationshipTypes.X_UNFETTER_CAN_RUN));
+                    });
+                }
+
+                if (attackPatternIds && attackPatternIds.length) {
+                    attackPatternIds.forEach((attackPatternId) => attackPatternIdSet.add(attackPatternId));
+                }
+
+                return {
+                    ...indicatorCopy,
+                    ...enhancements
+                };
+            });
+            
+        indicatorsCopy
+            .forEach((indicator) => {
+                if (indicator.metaProperties) {
+                    delete indicator.metaProperties;
+                }
+            });
+        
+        const downloadData$ = this.indicatorSharingService.getDownloadData(indicatorsCopy.map((ind) => ind.id), Array.from(attackPatternIdSet), Array.from(sensorIdSet))
+            .subscribe(
+                (downloadData) => {
+                    console.log(downloadData);
+                    downloadBundle([indicatorsCopy, ...sensorRelationships, ...downloadData], `analytic-exchange-enhanced-bundle`);
+                },
+                (err) => {
+                    console.log(err);
+                },
+                () => {
+                    downloadData$.unsubscribe();
+                }
+            );
+
+        
+        // console.log(this.filteredIndicators);
+        // console.log(indicatorsCopy);         
+        // console.log('####', Array.from(sensorIdSet));  
+        // console.log('$$$$', Array.from(attackPatternIdSet));  
     }
 
 }

--- a/src/app/indicator-sharing/indicator-sharing.service.ts
+++ b/src/app/indicator-sharing/indicator-sharing.service.ts
@@ -149,13 +149,13 @@ export class IndicatorSharingService {
             .map(RxjsHelpers.mapArrayAttributes);
     }
 
-    public getDownloadData(indicatorId: string, attackPatternIds: string[], sensorIds: string[]): Observable<any[]> {
+    public getDownloadData(indicatorIds: string[], attackPatternIds: string[], sensorIds: string[]): Observable<any[]> {
         const relFilterObj = {
             $and: [
                 {
                     $or: [
-                        { 'stix.source_ref': indicatorId },
-                        { 'stix.target_ref': indicatorId }
+                        { 'stix.source_ref': { $in: indicatorIds } },
+                        { 'stix.target_ref': { $in: indicatorIds } }
                     ]
                 },
                 {


### PR DESCRIPTION
Sightings are now sorted by default starting with latest sighting. Users can toggle sorting to start with earliest sighting (or have no sort).
Any sightings created on stix pages in other tabs should appear without page refresh in the appropriate spot in the list of sighting events and Daily Totals chart should update.