### PR TITLE
fix routing and pull less data

### DIFF
--- a/src/app/assess/result/store/full-result.actions.ts
+++ b/src/app/assess/result/store/full-result.actions.ts
@@ -7,7 +7,8 @@ import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 import { Relationship } from '../../../models';
 
 // For effects
-export const LOAD_ASSESSMENT_RESULT_DATA = '[Assess Result] LOAD_ASSESSMENT_RESULT_DATA';
+export const LOAD_ASSESSMENTS_BY_ROLLUP_ID = '[Assess Result] LOAD_ASSESSMENTS_BY_ROLLUP_ID';
+export const LOAD_ASSESSMENT_BY_ID = '[Assess Result] LOAD_ASSESSMENT_BY_ID';
 export const LOAD_GROUP_DATA = '[Assess Result Group] LOAD_GROUP_DATA';
 export const LOAD_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] LOAD_GROUP_CURRENT_ATTACK_PATTERN';
 export const LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] LOAD_ATTACK_PATTERN_RELATIONSHIPS';
@@ -17,6 +18,7 @@ export const UPDATE_ASSESSMENT_OBJECT = '[Assess Result Group] UPDATE_ASSESSMENT
 
 // For reducers
 export const SET_ASSESSMENTS = '[Assess Result] SET_ASSESSMENTS';
+export const SET_ASSESSMENT = '[Assess Result] SET_ASSESSMENT';
 export const SET_GROUP_DATA = '[Assess Result Group] SET_GROUP_DATA';
 export const SET_GROUP_ASSESSMENT_OBJECTS = '[Assess Result Group] SET_GROUP_ASSESSMENT_OBJECTS_DATA';
 export const SET_GROUP_RISK_BY_ATTACK_PATTERN = '[Assess Result Group] SET_RISK_BY_ATTACK_PATTERN';
@@ -34,14 +36,26 @@ export class SetAssessments implements Action {
     constructor(public payload: Assessment[]) { }
 }
 
+export class SetAssessment implements Action {
+    public readonly type = SET_ASSESSMENT;
+    constructor(public payload: Assessment) { }
+}
+
 export class FinishedLoading implements Action {
     public readonly type = FINISHED_LOADING;
 
     constructor(public payload: boolean) { }
 }
 
-export class LoadAssessmentResultData implements Action {
-    public readonly type = LOAD_ASSESSMENT_RESULT_DATA;
+export class LoadAssessmentsByRollupId implements Action {
+    public readonly type = LOAD_ASSESSMENTS_BY_ROLLUP_ID;
+
+    // assessment rollup id
+    constructor(public payload: string) { }
+}
+
+export class LoadAssessmentById implements Action {
+    public readonly type = LOAD_ASSESSMENT_BY_ID;
 
     // assessment rollup id
     constructor(public payload: string) { }
@@ -126,13 +140,15 @@ export type FullAssessmentResultActions =
     CleanAssessmentResultData |
     DonePushUrl |
     FinishedLoading |
-    LoadAssessmentResultData |
+    LoadAssessmentsByRollupId |
+    LoadAssessmentById |
     LoadGroupData |
     LoadGroupCurrentAttackPattern |
     LoadGroupAttackPatternRelationships |
     PushUrl |
     ReloadAfterAssessmentObjectUpdate |
     SetAssessments |
+    SetAssessment |
     SetGroupData |
     SetGroupAssessedObjects |
     SetGroupAttackPatternRelationships |

--- a/src/app/assess/result/store/full-result.effects.ts
+++ b/src/app/assess/result/store/full-result.effects.ts
@@ -9,12 +9,7 @@ import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 import { Stix } from '../../../models/stix/stix';
 import { Constance } from '../../../utils/constance';
 import { AssessService } from '../../services/assess.service';
-import { DonePushUrl, FinishedLoading, LOAD_ASSESSMENT_RESULT_DATA, LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS, 
-    LOAD_GROUP_CURRENT_ATTACK_PATTERN, LOAD_GROUP_DATA, LoadGroupData, PUSH_URL, SetAssessments, SetGroupAttackPatternRelationships, 
-    SetGroupCurrentAttackPattern, SetGroupData, UPDATE_ASSESSMENT_OBJECT } from './full-result.actions';
-
-
-
+import { DonePushUrl, FinishedLoading, LOAD_ASSESSMENTS_BY_ROLLUP_ID, LOAD_ASSESSMENT_BY_ID, LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS, LOAD_GROUP_CURRENT_ATTACK_PATTERN, LOAD_GROUP_DATA, LoadGroupData, PUSH_URL, SetAssessments, SetGroupAttackPatternRelationships, SetGroupCurrentAttackPattern, SetGroupData, UPDATE_ASSESSMENT_OBJECT, SetAssessment } from './full-result.actions';
 
 @Injectable()
 export class FullResultEffects {
@@ -27,8 +22,8 @@ export class FullResultEffects {
     ) { }
 
     @Effect()
-    public fetchAssessmentResultData = this.actions$
-        .ofType(LOAD_ASSESSMENT_RESULT_DATA)
+    public fetchAssessmentsByRollupId = this.actions$
+        .ofType(LOAD_ASSESSMENTS_BY_ROLLUP_ID)
         .pluck('payload')
         .switchMap((rollupId: string) => {
             return this.assessService
@@ -36,6 +31,17 @@ export class FullResultEffects {
                 .catch((ex) => Observable.empty());
         })
         .mergeMap((data: Assessment[]) => [new SetAssessments(data), new FinishedLoading(true)]);
+
+    @Effect()
+    public fetchAssessmentById = this.actions$
+        .ofType(LOAD_ASSESSMENT_BY_ID)
+        .pluck('payload')
+        .switchMap((id: string) => {
+            return this.assessService
+                .getById(id)
+                .catch((ex) => Observable.empty());
+        })
+        .mergeMap((data: Assessment) => [new SetAssessment(data), new FinishedLoading(true)]);
 
     @Effect()
     public fetchAssessmentGroupData = this.actions$

--- a/src/app/assess/result/store/full-result.reducers.ts
+++ b/src/app/assess/result/store/full-result.reducers.ts
@@ -3,7 +3,7 @@ import { Assessment } from '../../../models/assess/assessment';
 import { AssessmentObject } from '../../../models/assess/assessment-object';
 import { AssessedByAttackPattern } from '../full/group/models/assessed-by-attack-pattern';
 import { DisplayedAssessmentObject } from '../full/group/models/displayed-assessment-object';
-import { FullAssessmentResultActions, LOAD_ASSESSMENT_RESULT_DATA } from './full-result.actions';
+import { FullAssessmentResultActions, LOAD_ASSESSMENTS_BY_ROLLUP_ID } from './full-result.actions';
 import { Stix } from '../../../models/stix/stix';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
 import { Relationship } from '../../../models';
@@ -60,7 +60,11 @@ export function fullAssessmentResultReducer(state = initialState, action: FullAs
     switch (action.type) {
         case fullAssessmentResultActions.CLEAN_ASSESSMENT_RESULT_DATA:
             return genState();
-        case LOAD_ASSESSMENT_RESULT_DATA:
+        case LOAD_ASSESSMENTS_BY_ROLLUP_ID:
+            return {
+                ...state,
+            };
+        case fullAssessmentResultActions.LOAD_ASSESSMENT_BY_ID:
             return {
                 ...state,
             };
@@ -68,6 +72,11 @@ export function fullAssessmentResultReducer(state = initialState, action: FullAs
             return {
                 ...state,
                 assessmentTypes: [...action.payload],
+            };
+        case fullAssessmentResultActions.SET_ASSESSMENT:
+            return {
+                ...state,
+                fullAssessment: { ...action.payload },
             };
         case fullAssessmentResultActions.FINISHED_LOADING:
             return {

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -19,7 +19,7 @@ import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { AppState } from '../../root-store/app.reducers';
 import { Constance } from '../../utils/constance';
-import { LoadAssessmentResultData } from '../result/store/full-result.actions';
+import { LoadAssessmentsByRollupId } from '../result/store/full-result.actions';
 import { FullAssessmentResultState } from '../result/store/full-result.reducers';
 import { CleanAssessmentWizardData, LoadAssessmentWizardData, SaveAssessment, UpdatePageTitle } from '../store/assess.actions';
 import * as assessReducers from '../store/assess.reducers';
@@ -288,7 +288,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
         },
         (err) => console.log(err));
     this.subscriptions.push(sub$);
-    this.assessStore.dispatch(new LoadAssessmentResultData(rollupId));
+    this.assessStore.dispatch(new LoadAssessmentsByRollupId(rollupId));
   }
 
   public loadAssessments(rollupId: string, arr: Array<Assessment>, meta: Partial<AssessmentMeta>) {


### PR DESCRIPTION
## problem
assessment 2.0 routing in the result tab, failed on the same rollup id.  This was left over from a different approach
also the result tab queries more data then necessary

## solution
create a ngrx effect to pull less data
tell the master list to query across rollup ids

## test
* bring up assessments 2.0 result tab master list
* verify you can click across assessments
* watch network console pull only 1 assessments vs potentially 3