### PR TITLE
Created initial capability definition panel for the baseline wizard

### DIFF
--- a/src/app/assess3/assess3.module.ts
+++ b/src/app/assess3/assess3.module.ts
@@ -1,29 +1,24 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-
-import { routing } from './assess3.routing';
-
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
-
-import { Create3Component } from './create/create3.component';
-
-import { Assess3Guard } from './assess3.guard';
-import { AssessService } from './services/assess.service';
-import { AssessStateService } from './services/assess-state.service';
-
-import { AssessEffects } from './store/assess.effects';
+import { MatInputModule } from '@angular/material/input';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
-import { assessmentReducer } from './store/assess.reducers';
+import { GlobalModule } from '../global/global.module';
+import { Assess3Guard } from './assess3.guard';
+import { routing } from './assess3.routing';
+import { Create3Component } from './create/create3.component';
 import { Assess3LayoutComponent } from './layout/assess3-layout.component';
 import { ResultModule } from './result/result.module';
+import { AssessStateService } from './services/assess-state.service';
 import { AssessSummaryService } from './services/assess-summary.service';
-import { GlobalModule } from '../global/global.module';
+import { AssessService } from './services/assess.service';
+import { AssessEffects } from './store/assess.effects';
+import { assessmentReducer } from './store/assess.reducers';
 
 const moduleComponents = [
   Assess3LayoutComponent,

--- a/src/app/assess3/wizard/capability/capability.component.html
+++ b/src/app/assess3/wizard/capability/capability.component.html
@@ -1,0 +1,36 @@
+    <mat-card-content>
+      <div class="row margin-bottom top-row flex-sm flexItemsCenter">
+        <div class="col-lg-9">
+          <mat-card-title>
+            {{ dummyCapabilityName }}
+          </mat-card-title>
+        </div>
+        <div class="col-lg-1">
+          <button mat-icon-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
+            <mat-icon class="mat-24" aria-hidden="true" aria-label="view heat map">view_comfy</mat-icon>
+            {{ attackMatrix }}
+          </button>
+        </div>
+      </div>
+
+      <div class="row margin-bottom main-row flex-col">
+        <div class="row margin-bottom">
+          <div class="col-sm-12">
+            {{ noAttackPatterns }}
+          </div>
+        </div>
+        <div class="row margin-bottom">
+          <div class="col-sm-12">
+            {{ addAttackPatterns }}
+          </div>
+        </div>
+        <div class="row margin-bottom">
+          <div class="col-sm-12">
+              <button mat-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
+                {{ openAttackMatrix }}
+              </button>
+          </div>
+        </div>
+      </div>
+    </mat-card-content>
+    

--- a/src/app/assess3/wizard/capability/capability.component.html
+++ b/src/app/assess3/wizard/capability/capability.component.html
@@ -26,7 +26,7 @@
         </div>
         <div class="row margin-bottom">
           <div class="col-sm-12">
-              <button mat-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
+              <button mat-raised-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
                 {{ openAttackMatrix }}
               </button>
           </div>

--- a/src/app/assess3/wizard/capability/capability.component.scss
+++ b/src/app/assess3/wizard/capability/capability.component.scss
@@ -1,0 +1,29 @@
+@import '../../../../styles/_variables.scss';
+
+:host {
+    display: flex;
+    flex-direction: row;
+    width: 1282px;
+}
+
+.top-row {
+    width: 900px;
+}
+
+.main-row {
+    width: 800px;
+}
+
+
+.flex-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.flex-row {
+    display: flex;
+    flex-direction: row;
+}
+

--- a/src/app/assess3/wizard/capability/capability.component.spec.ts
+++ b/src/app/assess3/wizard/capability/capability.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CapabilityComponent } from './capability.component';
+
+describe('CapabilityComponent', () => {
+  let component: CapabilityComponent;
+  let fixture: ComponentFixture<CapabilityComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CapabilityComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CapabilityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/assess3/wizard/capability/capability.component.spec.ts
+++ b/src/app/assess3/wizard/capability/capability.component.spec.ts
@@ -1,5 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MatButtonModule, MatCardModule, MatIconModule, MatTooltipModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { CapabilityComponent } from './capability.component';
 
 describe('CapabilityComponent', () => {
@@ -7,10 +8,21 @@ describe('CapabilityComponent', () => {
   let fixture: ComponentFixture<CapabilityComponent>;
 
   beforeEach(async(() => {
+    const matModules = [
+      MatButtonModule,
+      MatCardModule,
+      MatIconModule,
+      MatTooltipModule,
+    ];
+
     TestBed.configureTestingModule({
-      declarations: [ CapabilityComponent ]
+      declarations: [CapabilityComponent],
+      imports: [
+        NoopAnimationsModule,
+        ...matModules,
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/assess3/wizard/capability/capability.component.ts
+++ b/src/app/assess3/wizard/capability/capability.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'unf-assess3-wizard-capability',
+  templateUrl: './capability.component.html',
+  styleUrls: ['./capability.component.scss']
+})
+export class CapabilityComponent implements OnInit {
+
+  public dummyCapabilityName: string = 'Capability Name (VPN)';
+  public attackMatrix: string = 'Att&ck Matrix';
+  public noAttackPatterns: string = 'You have no Attack Patterns yet';
+  public addAttackPatterns: string = 'Add a Kill Chain Phase and Attack Patterns and they will show up here';
+  public openAttackMatrix: string = 'Open Att&ck Matrix';
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/assess3/wizard/capability/capability.component.ts
+++ b/src/app/assess3/wizard/capability/capability.component.ts
@@ -12,6 +12,7 @@ export class CapabilityComponent implements OnInit {
   public noAttackPatterns: string = 'You have no Attack Patterns yet';
   public addAttackPatterns: string = 'Add a Kill Chain Phase and Attack Patterns and they will show up here';
   public openAttackMatrix: string = 'Open Att&ck Matrix';
+  public showHeatMap = false;
 
   constructor() { }
 

--- a/src/app/assess3/wizard/category/category.component.html
+++ b/src/app/assess3/wizard/category/category.component.html
@@ -19,7 +19,7 @@
               </form>
             </div>
             <div class="col-xs-2">
-              <button mat-button (click)="onDeleteCategory(existingCategory)">
+              <button mat-icon-button (click)="onDeleteCategory(existingCategory)">
                 <mat-icon>highlight off</mat-icon>
               </button>
             </div>
@@ -41,7 +41,7 @@
                 </mat-form-field>
               </div>
               <div class="col-lg-1">
-                <button mat-button (click)="onAddCategory(newCategory)">
+                <button mat-icon-button (click)="onAddCategory(newCategory)">
                   <mat-icon>add circle outline</mat-icon>
                 </button>    
               </div>

--- a/src/app/assess3/wizard/category/category.component.spec.ts
+++ b/src/app/assess3/wizard/category/category.component.spec.ts
@@ -1,12 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import * as fromRoot from 'app/root-store/app.reducers';
-
-import { CategoryComponent } from './category.component';
-import { MatButtonModule, MatCardModule, MatDatepickerModule, MatDialogModule, MatExpansionModule, MatSnackBarModule, MatSelectModule, MatInputModule, MatProgressBarModule, MatIconModule } from '@angular/material';
-import { StoreModule, combineReducers } from '@ngrx/store';
-import { assessmentReducer } from '../../../assess/store/assess.reducers';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MatButtonModule, MatCardModule, MatIconModule, MatSelectModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { StoreModule, combineReducers } from '@ngrx/store';
+import * as fromRoot from 'app/root-store/app.reducers';
+import { assessmentReducer } from '../../../assess/store/assess.reducers';
+import { CategoryComponent } from './category.component';
 
 describe('CategoryComponent', () => {
   let component: CategoryComponent;
@@ -21,7 +19,7 @@ describe('CategoryComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CategoryComponent ],
+      declarations: [CategoryComponent],
       imports: [
         NoopAnimationsModule,
         ...matModules,
@@ -31,7 +29,7 @@ describe('CategoryComponent', () => {
         }),
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/assess3/wizard/wizard.component.html
+++ b/src/app/assess3/wizard/wizard.component.html
@@ -2,8 +2,7 @@
   <div @heightCollapse class="flex-col mt-18 mb-12">
   </div>
   <mat-accordion displayMode="flat" multi="false">
-    <mat-expansion-panel hideToggle="true" [expanded]="openedSidePanel === 'categories'"
-      (opened)="onOpenSidePanel('categories', $event)">
+    <mat-expansion-panel hideToggle="true" [expanded]="openedSidePanel === 'categories'" (opened)="onOpenSidePanel('categories', $event)">
       <mat-expansion-panel-header [expandedHeight]="sidePanelExpandedHeight" [collapsedHeight]="sidePanelCollapseHeight">
         <mat-panel-title>
           CATEGORIES
@@ -46,54 +45,43 @@
 
 <div class="card flex1">
   <mat-card>
-
     <!-- List of cards containing each panel in the baselines wizard -->
-    
-    <!-- CATEGORIES DEFINITION PANEL -->
-    <div *ngIf="openedSidePanel === 'categories'"> 
-      <unf-assess3-wizard-category #categories></unf-assess3-wizard-category>
-    </div>
-
-    <!-- CAPABILITIES SELECTION PANEL -->
-    <div *ngIf="openedSidePanel === 'capabilities'"> 
-      <p>This is the capabilities definition panel.</p> 
-      <!--<unf-assess3-wizard-capability></unf-assess3-wizard-capability>-->
-    </div>
-
-    <!-- KCP/AP SELECTION and SCORING PANEL -->
-    <div *ngIf="openedSidePanel === 'capability'"> 
-      <p>This is the attack pattern selection and capability scoring panel.</p>
-    </div>
-
-    <div *ngIf="openedSidePanel === 'summary'">
-      <mat-card-header>
-        <mat-card-title>Assessment Report</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="row mat-card-padding">
-          <div class="col-xs-8">
-            <mat-form-field class="full-width">
-              <input matInput placeholder="Assessment Name" name="assessment-name" [(ngModel)]="meta.title">
-              <mat-error *ngIf="isTitleEmpty()">
-                Title is
-                <strong>required</strong>
-              </mat-error>
-            </mat-form-field>
+    <div [ngSwitch]="openedSidePanel">
+      <unf-assess3-wizard-category *ngSwitchCase="'categories'" #categories></unf-assess3-wizard-category>
+      <unf-assess3-wizard-capability *ngSwitchCase="'capabilities'"></unf-assess3-wizard-capability>
+      <div *ngSwitchCase="'capability'">
+        <p>This is the attack pattern selection and capability scoring panel.</p>
+      </div>
+      <div *ngSwitchDefault>
+        <mat-card-header>
+          <mat-card-title>Assessment Report</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="row mat-card-padding">
+            <div class="col-xs-8">
+              <mat-form-field class="full-width">
+                <input matInput placeholder="Assessment Name" name="assessment-name" [(ngModel)]="meta.title">
+                <mat-error *ngIf="isTitleEmpty()">
+                  Title is
+                  <strong>required</strong>
+                </mat-error>
+              </mat-form-field>
+            </div>
           </div>
-        </div>
-        <div class="row mat-card-padding">
-          <div class="col-xs-12">
-            <mat-form-field class="full-width">
-              <textarea matInput placeholder="Assessment Description" [(ngModel)]="meta.description"></textarea>
-            </mat-form-field>
+          <div class="row mat-card-padding">
+            <div class="col-xs-12">
+              <mat-form-field class="full-width">
+                <textarea matInput placeholder="Assessment Description" [(ngModel)]="meta.description"></textarea>
+              </mat-form-field>
+            </div>
           </div>
-        </div>
-        <div class="row mat-card-padding">
-          <div class="col-xs-12">
-            <created-by-ref [assessmentMeta]="meta"></created-by-ref>
+          <div class="row mat-card-padding">
+            <div class="col-xs-12">
+              <created-by-ref [assessmentMeta]="meta"></created-by-ref>
+            </div>
           </div>
-        </div>
-      </mat-card-content>
+        </mat-card-content>
+      </div>
     </div>
 
     <mat-card-actions class="text-right">

--- a/src/app/assess3/wizard/wizard.component.html
+++ b/src/app/assess3/wizard/wizard.component.html
@@ -56,7 +56,8 @@
 
     <!-- CAPABILITIES SELECTION PANEL -->
     <div *ngIf="openedSidePanel === 'capabilities'"> 
-      <p>This is the capabilities definition panel.</p>>
+      <p>This is the capabilities definition panel.</p> 
+      <!--<unf-assess3-wizard-capability></unf-assess3-wizard-capability>-->
     </div>
 
     <!-- KCP/AP SELECTION and SCORING PANEL -->

--- a/src/app/assess3/wizard/wizard.component.spec.ts
+++ b/src/app/assess3/wizard/wizard.component.spec.ts
@@ -1,28 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
-import { MatButtonModule, MatCardModule, MatDatepickerModule, MatDialogModule, MatSnackBarModule, MatSelectModule, MatInputModule, MatExpansionModule, MatProgressBarModule, MatIcon } from '@angular/material';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { StoreModule, combineReducers } from '@ngrx/store';
-
-import * as fromRoot from 'app/root-store/app.reducers';
-import { assessmentReducer } from '../store/assess.reducers';
-
-import { WizardComponent } from './wizard.component';
-import { ComponentModule } from '../../components/component.module';
-import { ChartsModule } from 'ng2-charts';
-import { PipesModule } from '../../pipes/pipes.module';
-import { GlobalModule } from '../../global/global.module';
-import { GenericApi } from '../../core/services/genericapi.service';
+import { MatButtonModule, MatCardModule, MatDatepickerModule, MatDialogModule, MatExpansionModule, MatInputModule, MatProgressBarModule, MatSelectModule, MatSnackBarModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Observable } from 'rxjs/Observable';
-import { Assessment3Meta } from '../../models/assess/assessment3-meta';
-import { Assessment3 } from '../../models/assess/assessment3';
-import { Assessment3Object } from '../../models/assess/assessment3-object';
-import { Stix } from '../../models/stix/stix';
-import { StixLabelEnum } from '../../models/stix/stix-label.enum';
+import { StoreModule, combineReducers } from '@ngrx/store';
+import * as fromRoot from 'app/root-store/app.reducers';
+import { ChartsModule } from 'ng2-charts';
+import { ComponentModule } from '../../components/component.module';
+import { GenericApi } from '../../core/services/genericapi.service';
+import { GlobalModule } from '../../global/global.module';
+import { PipesModule } from '../../pipes/pipes.module';
+import { assessmentReducer } from '../store/assess.reducers';
+import { CapabilityComponent } from './capability/capability.component';
 import { CategoryComponent } from './category/category.component';
+import { WizardComponent } from './wizard.component';
 
 class MockModel {
   attributes: any;
@@ -40,7 +32,7 @@ class MockModel {
               type: null, valid_from: null, labels: null, modified: null, created: null,
               metaProperties: null, id: 'gogogadget'
             },
-          questions: [{ name: 'eringobragh', score: 'L' }, { name: 'gobragherin', score: 'M' }, { name: 'bragheringo', score: 'S' } ]
+          questions: [{ name: 'eringobragh', score: 'L' }, { name: 'gobragherin', score: 'M' }, { name: 'bragheringo', score: 'S' }]
         },
         {
           stix:
@@ -50,7 +42,7 @@ class MockModel {
               type: null, valid_from: null, labels: null, modified: null, created: null,
               metaProperties: null, id: 'gogadgetgo'
             },
-            questions: [{ name: 'eringobragh', score: 'N/A' }, { name: 'gobragherin', score: 'L' }, { name: 'bragheringo', score: 'M' } ]
+          questions: [{ name: 'eringobragh', score: 'N/A' }, { name: 'gobragherin', score: 'L' }, { name: 'bragheringo', score: 'M' }]
         },
         {
           stix:
@@ -60,7 +52,7 @@ class MockModel {
               type: null, valid_from: null, labels: null, modified: null, created: null,
               metaProperties: null, id: 'gadgetgogo'
             },
-            questions: [{ name: 'eringobragh', score: 'N/A' }, { name: 'gobragherin', score: 'N/A' }, { name: 'bragheringo', score: 'N/A' } ]
+          questions: [{ name: 'eringobragh', score: 'N/A' }, { name: 'gobragherin', score: 'N/A' }, { name: 'bragheringo', score: 'N/A' }]
         }],
       created: null,
       description: null, modified: null, name: null, type: null, version: null,
@@ -92,7 +84,8 @@ describe('WizardComponent', () => {
     TestBed.configureTestingModule({
       declarations: [
         WizardComponent,
-        CategoryComponent
+        CategoryComponent,
+        CapabilityComponent,
       ],
       imports: [
         NoopAnimationsModule,

--- a/src/app/assess3/wizard/wizard.module.ts
+++ b/src/app/assess3/wizard/wizard.module.ts
@@ -21,6 +21,7 @@ import { ChartsModule } from 'ng2-charts';
 import { PipesModule } from '../../pipes/pipes.module';
 import { GlobalModule } from '../../global/global.module';
 import { CategoryComponent } from './category/category.component';
+import { CapabilityComponent } from './capability/capability.component';
 
 const moduleComponents = [
   WizardComponent,
@@ -57,6 +58,7 @@ const primengModules = [
   ],
   declarations: [
     ...moduleComponents,
+    CapabilityComponent,
   ],
   exports: [
     ...moduleComponents,

--- a/src/app/assess3/wizard/wizard.module.ts
+++ b/src/app/assess3/wizard/wizard.module.ts
@@ -1,31 +1,29 @@
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-import { WizardComponent } from './wizard.component';
-
-import { routing } from './wizard.routing';
-
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatSelectModule } from '@angular/material/select';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { ComponentModule } from '../../components/component.module';
-import { FormsModule } from '@angular/forms';
-import { CalendarModule } from 'primeng/components/calendar/calendar';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ChartsModule } from 'ng2-charts';
-import { PipesModule } from '../../pipes/pipes.module';
+import { CalendarModule } from 'primeng/components/calendar/calendar';
+import { ComponentModule } from '../../components/component.module';
 import { GlobalModule } from '../../global/global.module';
-import { CategoryComponent } from './category/category.component';
+import { PipesModule } from '../../pipes/pipes.module';
 import { CapabilityComponent } from './capability/capability.component';
+import { CategoryComponent } from './category/category.component';
+import { WizardComponent } from './wizard.component';
+import { routing } from './wizard.routing';
 
 const moduleComponents = [
   WizardComponent,
   CategoryComponent,
+  CapabilityComponent,
 ];
 
 const matModules = [


### PR DESCRIPTION
This is the capability component the capability definition panel for the baseline wizard, it is a subcomponent of the assessment 3.0 wizard component.

For this PR the capability component just has the basic structure for the UI with some dummy data for the capability name. Need to add the functionality to retrieve the capability name from the wizard side panel and to display the heatmap when the Open Att&ck Matrix button is clicked.

To test:
1. Uncomment the selector for the unf-assess3-wizard-capability component within the wizard.component.html file.
2. Run/Debug Unfetter or unfetter-ui
3. Open Assessments 3.0
4. create an assessment, click continue
5. add two categories from the drop-down list, click continue
6. click on the first category In the side panel and the capability definition panel will be displayed
