### PR TITLE
Adds columns to master list dialog for assessments 3.0 baselines

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from './core/services/auth.service';
 import * as fromApp from './root-store/app.reducers';
 import * as userActions from './root-store/users/user.actions';
 import * as configActions from './root-store/config/config.actions';
+import * as identityActions from './root-store/identities/identity.actions';
 import { WSMessageTypes } from './global/enums/ws-message-types.enum';
 import { environment } from '../environments/environment';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
@@ -55,6 +56,7 @@ export class AppComponent implements OnInit {
         }));
       }
       this.store.dispatch(new configActions.FetchConfig(false));
+      this.store.dispatch(new identityActions.FetchIdentities());
     }
 
     const bodyElement: HTMLElement = document.getElementsByTagName('body')[0];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { ConfigEffects } from './root-store/config/config.effects';
 import { NotificationEffects } from './root-store/notification/notification.effects';
 import { UserEffects } from './root-store/users/user.effects';
 import { UtilityEffects } from './root-store/utility/utility.effects';
+import { IdentityEffects } from './root-store/identities/identity.effects';
 
 // make sure you export for AoT
 // export function stateSetter(reducer: ActionReducer<any>): ActionReducer<any> {
@@ -72,6 +73,7 @@ import { UtilityEffects } from './root-store/utility/utility.effects';
       ConfigEffects,
       UtilityEffects,
       NotificationEffects,
+      IdentityEffects,
     ]),
     (!environment.production && environment.runMode !== 'DEMO') ? StoreDevtoolsModule.instrument() : [],
     AppRoutingModule,

--- a/src/app/assess3/result/full/full.component.html
+++ b/src/app/assess3/result/full/full.component.html
@@ -1,15 +1,17 @@
 <div *ngIf="(finishedLoading|async) === true; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="(assessment|async) !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
-      <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
+      <unfetter-side-panel [item]="{ name: assessmentName | async | capitalize }"
+          class="side-panel" collapsible="false" width="350">
 
         <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
         <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>
         <sidepanel-option-item label="Delete" icon="delete" (click)="onDeleteCurrent($event)"></sidepanel-option-item>
 
-        <master-list-dialog-trigger title="Assessments" width="750px" height="400px" [dataSource]="masterListOptions.dataSource"
-          [columns]="masterListOptions.columns" (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
-          (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
+        <master-list-dialog-trigger title="Assessments" width="1200px" height="400px"
+            [dataSource]="masterListOptions.dataSource" [columns]="masterListOptions.columns"
+            (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
+            (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
       </unfetter-side-panel>
       <div *ngIf="assessGroupMain.riskByAttackPattern" class="side-panel-risks">
         <div class="risk-header-wrapper">

--- a/src/app/assess3/result/full/full.component.scss
+++ b/src/app/assess3/result/full/full.component.scss
@@ -79,3 +79,24 @@
     min-height: calc(100vh - #{$navbar-height}px);
 }
 
+::ng-deep .uf-master-list-dialog .mat-dialog-container {
+    mat-dialog-content {
+        div.master-list-table {
+            .master-list-capabilities, .master-list-capabilities-header {
+                flex: 1;
+                align-items: center;
+                text-align: center;
+            }
+            .master-list-extra, .master-list-extra-header {
+                flex: 1;
+                align-items: center;
+            }
+        }
+    }
+
+    mat-dialog-actions {
+        justify-content: flex-end;
+        padding: 6px 0;
+        padding-right: 6px;
+    }
+}

--- a/src/app/assess3/result/full/full.component.ts
+++ b/src/app/assess3/result/full/full.component.ts
@@ -42,7 +42,13 @@ export class FullComponent implements OnInit, OnDestroy {
   finishedLoading: Observable<boolean>;
   masterListOptions = {
     dataSource: null,
-    columns: new MasterListDialogTableHeaders('modified', 'Modified'),
+    columns: new MasterListDialogTableHeaders('modified', 'Date Modified')
+        .addColumn('capabilities', '# of Capabilities', 'master-list-capabilities', false, (value) => value || '0')
+        .addColumn('creator', 'Author', 'master-list-extra', false, (value) => value || 'Unknown')
+        .addColumn('framework', 'Type', 'master-list-extra', false, (value) => value || 'ATT&CK')
+        .addColumn('industry', 'Industry', 'master-list-extra', false, (value) => value || 'Local')
+        .addColumn('published', 'Status', 'master-list-extra', false, (published) => published ? 'Public' : 'Draft')
+        ,
     displayRoute: this.baseAssessUrl + '/result/full',
     modifyRoute: this.baseAssessUrl + '/wizard/edit',
     createRoute: this.baseAssessUrl + '/create',

--- a/src/app/assess3/result/result-header/result-header.component.html
+++ b/src/app/assess3/result/result-header/result-header.component.html
@@ -1,10 +1,10 @@
-<div id="tabWrapper">
+<div id="tabWrapper" class="flex flexColumn">
   <div class="banner-wrapper">
       <div class="flex">
         <div class="banner">ASSESSMENTS 3.0 is currently a beta. Some functionality does not work.</div>
       </div>
   </div>
-  <div class="height-100-percent">
+  <div class="flex1">
     <div class="height-100-percent flex flexRow">
       <div class="height-100-percent flex flexColumn">
         <div class="flex1"></div>

--- a/src/app/assess3/result/result-header/result-header.component.scss
+++ b/src/app/assess3/result/result-header/result-header.component.scss
@@ -8,7 +8,7 @@
 #tabWrapper {
     background-color: $assessments-nav-background;
     height: 128px;
-    padding-right: 16px;
+    // padding-right: 16px;
     // padding-left: 16px;
   }
 

--- a/src/app/assess3/result/summary/summary.component.html
+++ b/src/app/assess3/result/summary/summary.component.html
@@ -1,15 +1,17 @@
 <div id="newAssessmentsSummary" *ngIf="finishedLoading; else loadingBlock" class="fadeIn">
   <mat-sidenav-container *ngIf="summary !== undefined; else notFound">
     <mat-sidenav class="side-panel" mode="side" opened="true">
-      <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
+      <unfetter-side-panel [item]="{ name: assessmentName | async | capitalize }"
+          class="side-panel" collapsible="false" width="350">
 
         <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
         <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>
         <sidepanel-option-item label="Delete" icon="delete" (click)="onDeleteCurrent($event)"></sidepanel-option-item>
 
-        <master-list-dialog-trigger title="Assessments" width="750px" height="400px" [dataSource]="masterListOptions.dataSource"
-          [columns]="masterListOptions.columns" (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
-          (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
+        <master-list-dialog-trigger title="Assessments" width="1200px" height="400px"
+            [dataSource]="masterListOptions.dataSource" [columns]="masterListOptions.columns"
+            (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
+            (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
 
         <sidepanel-list-item label="{{summaries[0].name}}" [items]="summaries" expandable="true">
           <mat-list-item *ngFor="let summary of summaries; trackBy:trackByFn" class="list-divider" [@slideInOutAnimation]>

--- a/src/app/assess3/result/summary/summary.component.scss
+++ b/src/app/assess3/result/summary/summary.component.scss
@@ -9,3 +9,25 @@
     min-height: calc(100vh - #{$navbar-height}px);
     background-color: #F1F1F1;
 }
+
+::ng-deep .uf-master-list-dialog .mat-dialog-container {
+    mat-dialog-content {
+        div.master-list-table {
+            .master-list-capabilities, .master-list-capabilities-header {
+                flex: 1;
+                align-items: center;
+                text-align: center;
+            }
+            .master-list-extra, .master-list-extra-header {
+                flex: 1;
+                align-items: center;
+            }
+        }
+    }
+
+    mat-dialog-actions {
+        justify-content: flex-end;
+        padding: 6px 0;
+        padding-right: 6px;
+    }
+}

--- a/src/app/assess3/result/summary/summary.component.scss
+++ b/src/app/assess3/result/summary/summary.component.scss
@@ -13,10 +13,17 @@
 ::ng-deep .uf-master-list-dialog .mat-dialog-container {
     mat-dialog-content {
         div.master-list-table {
+            .master-list-item, .master-list-item-header {
+                flex: 3 !important;
+            }
             .master-list-capabilities, .master-list-capabilities-header {
                 flex: 1;
                 align-items: center;
                 text-align: center;
+            }
+            .master-list-organization, .mat-column-created_by_ref {
+                flex: 2;
+                align-items: center;
             }
             .master-list-extra, .master-list-extra-header {
                 flex: 1;

--- a/src/app/assess3/result/summary/summary.component.ts
+++ b/src/app/assess3/result/summary/summary.component.ts
@@ -23,6 +23,7 @@ import { Assessment3Object } from '../../../models/assess/assessment3-object';
 import { CleanAssessmentResultData } from '../store/summary.actions';
 import { Capability } from '../../../models/unfetter/capability';
 import { Identity } from 'stix';
+import { UsersService } from '../../../core/services/users.service';
 
 @Component({
   selector: 'summary',
@@ -45,7 +46,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
     columns: new MasterListDialogTableHeaders('modified', 'Date Modified')
         .addColumn('capabilities', '# of Capabilities', 'master-list-capabilities', false, (value) => value || '0')
         .addColumn('created_by_ref', 'Organization', 'master-list-organization', false, (value) => {
-          console.log('looking up identity', value, this.identities);
           let author: Identity = null;
           if (value) {
             author = this.identities.find(id => id.id === value)
@@ -70,6 +70,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
     private store: Store<SummaryState>,
     private userStore: Store<AppState>,
     private assessService: AssessService,
+    private usersService: UsersService,
   ) { }
 
   public getDialog(): MatDialog {
@@ -106,16 +107,15 @@ export class SummaryComponent implements OnInit, OnDestroy {
     const subIdentitie$ = this.userStore
       .select('identities')
       .pluck('identities')
-      .finally(() => console.log('identity retrieval done'))
+      .finally(() => subIdentitie$ && subIdentitie$.unsubscribe())
       .subscribe(
-        (identities: Identity[]) => { console.log('orgs found', identities); this.identities = identities; },
+        (identities: Identity[]) => this.identities = identities,
         (error) => console.log(`(${new Date().toISOString()}) error retrieving identities from app store`, error)
       );
 
     this.listenForDataChanges();
 
     this.subscriptions.push(idParamSub$);
-    this.subscriptions.push(subIdentitie$);
   }
 
   /**

--- a/src/app/assess3/result/summary/summary.component.ts
+++ b/src/app/assess3/result/summary/summary.component.ts
@@ -39,7 +39,13 @@ export class SummaryComponent implements OnInit, OnDestroy {
   finishedLoading = false;
   masterListOptions = {
     dataSource: null,
-    columns: new MasterListDialogTableHeaders('modified', 'Modified'),
+    columns: new MasterListDialogTableHeaders('modified', 'Date Modified')
+        .addColumn('capabilities', '# of Capabilities', 'master-list-capabilities', false, (value) => value || '0')
+        .addColumn('creator', 'Author', 'master-list-extra', false, (value) => value || 'Unknown')
+        .addColumn('framework', 'Type', 'master-list-extra', false, (value) => value || 'ATT&CK')
+        .addColumn('industry', 'Industry', 'master-list-extra', false, (value) => value || 'Local')
+        .addColumn('published', 'Status', 'master-list-extra', false, (published) => published ? 'Public' : 'Draft')
+        ,
     displayRoute: this.baseAssessUrl + '/result/summary',
     modifyRoute: this.baseAssessUrl + '/wizard/edit',
     createRoute: this.baseAssessUrl + '/create',
@@ -141,30 +147,18 @@ export class SummaryComponent implements OnInit, OnDestroy {
           return '';
         }
         if (summaries[0].object_ref) {
-          let retVal = summaries[0].name + ' - ';
-          
           // Get object reference to determine type
-          let o$;
-          o$ = this.assessService.getCapabilityById(summaries[0].object_ref);
-          const capName = o$.map((data) => {
-              if (data === undefined || data.length === 0) {
-                  return 'undefined';
-              } else {
-                  const capability = data[0] as Capability;
-                  return capability.name;
-              }
-          })
-          .catch((err) => {
-              console.log('error getting capability reference from object assessment', err);
-              return 'error';
-          });
-          
-          retVal += capName;
-
-          return retVal;
-        } else {
-          return summaries[0].name;
+          let o$ = this.assessService.getCapabilityById(summaries[0].object_ref)
+            .subscribe(
+              (capability) => {
+                if (capability !== undefined) {
+                    this.assessmentName = Observable.of(summaries[0].name + ' - ' + capability.name);
+                }
+              },
+              (err) => console.log('error getting capability reference from object assessment', err)
+            );
         }
+        return summaries[0].name;
       });
 
     this.subscriptions.push(sub1$, sub2$, sub8$);

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.html
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.html
@@ -47,6 +47,14 @@
                         </mat-cell>
                     </ng-container>
 
+                    <ng-container *ngFor="let extra of data.columns.extra" matColumnDef='{{extra.ref}}'>
+                        <mat-header-cell *matHeaderCellDef> {{extra.header}} </mat-header-cell>
+                        <mat-cell *matCellDef="let row" class="{{cdefs.rowClass(row, extra)}}"
+                                (click)="cdefs.canSelect(row, extra) && onSelect(row, extra.ref, $event)">
+                            <span> {{ $any(extra).format(row[extra.ref]) }} </span>
+                        </mat-cell>
+                    </ng-container>
+
                     <ng-container *ngIf="cdefs.actions as acts" matColumnDef='{{acts.ref}}'>
                         <mat-header-cell *matHeaderCellDef
                                 class="master-list-actions-header"> {{acts.header}} </mat-header-cell>

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
@@ -23,6 +23,7 @@
         }
 
         .mat-form-field {
+            width: 100%;
             margin: 10px 4px 4px 4px;
             padding: 2px 8px;
             background: rgba(1, 1, 1, .12);
@@ -99,11 +100,12 @@
                 align-items: center;
             }
 
-            .mat-column-actions {
+            .master-list-actions {
+                flex: 1;
                 text-align: right !important;
-
                 .mat-button {
                     min-width: 0;
+                    padding: 0 8px;
                 }
             }
 

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.ts
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.ts
@@ -16,24 +16,22 @@ import { Constance } from '../../../utils/constance';
  * throughout the UI, however, so it really shouldn't be necessary.
  */
 type ClassSelector = (row: any) => string;
+type Formatter = (value: string) => string;
 type Selectable = (row: any) => boolean;
 
 interface MasterListColumn {
     readonly ref: string;
-
     readonly header: string;
-
     classes?: string | ClassSelector;
-
     selectable?: boolean | Selectable;
-
-    format?(value: string): string;
+    format?: Formatter;
 }
 
 export class MasterListDialogTableHeaders {
 
     id: MasterListColumn = {ref: 'name', header: 'Name', selectable: true};
     edition: MasterListColumn;
+    extra: MasterListColumn[] = [];
     actions: MasterListColumn = {ref: 'actions', header: ''};
 
     private dateFormat = new DatePipe('en-US');
@@ -49,8 +47,16 @@ export class MasterListDialogTableHeaders {
         this.edition = {ref: editionColumn, header: editionHeader, selectable: selectable, format: editionFormat};
     }
 
+    public addColumn(column: string, header: string,
+        classes: string | ClassSelector = null,
+        selectable: boolean | Selectable = false,
+        format: Formatter = null): MasterListDialogTableHeaders {
+        this.extra.push({ref: column, header: header, classes: classes, selectable: selectable, format: format});
+        return this;
+    }
+
     public getColumns(): string[] {
-        return [this.id.ref, this.edition.ref, this.actions.ref];
+        return [this.id.ref, this.edition.ref, ...this.extra.map(col => col.ref), this.actions.ref];
     }
 
     public rowClass(row: any, column: MasterListColumn, ): string {

--- a/src/app/root-store/app.reducers.ts
+++ b/src/app/root-store/app.reducers.ts
@@ -3,18 +3,21 @@ import { ActionReducerMap } from '@ngrx/store';
 import * as fromUsers from './users/users.reducers';
 import * as fromConfig from './config/config.reducers';
 import * as fromUtility from './utility/utility.reducers';
+import * as fromIdentities from './identities/identity.reducers';
 import * as fromNotification from './notification/notification.reducers';
 
 export interface AppState {
     users: fromUsers.UserState,
     config: fromConfig.ConfigState,
     utility: any, // TODO update type if an interface is added
-    notifications: fromNotification.NotificationState
+    identities: fromIdentities.IdentityState,
+    notifications: fromNotification.NotificationState,
 }
 
 export const reducers: ActionReducerMap<AppState> = {
     users: fromUsers.usersReducer,
     config: fromConfig.configReducer,
     utility: fromUtility.utilityReducer,
-    notifications: fromNotification.notificationReducer
+    identities: fromIdentities.identitiesReducer,
+    notifications: fromNotification.notificationReducer,
 }

--- a/src/app/root-store/identities/identity.actions.ts
+++ b/src/app/root-store/identities/identity.actions.ts
@@ -1,0 +1,13 @@
+import { Action } from '@ngrx/store';
+import { Identity } from 'stix';
+
+export const FETCH_IDENTITIES = '[Identities] Fetch Identities';
+
+export class FetchIdentities implements Action {
+    public readonly type = FETCH_IDENTITIES;
+    constructor(public payload: Identity[]) {}
+}
+
+export type IdentityActions = 
+    FetchIdentities
+    ;

--- a/src/app/root-store/identities/identity.actions.ts
+++ b/src/app/root-store/identities/identity.actions.ts
@@ -2,12 +2,19 @@ import { Action } from '@ngrx/store';
 import { Identity } from 'stix';
 
 export const FETCH_IDENTITIES = '[Identities] Fetch Identities';
+export const SET_IDENTITIES = '[Identities] Set Identities';
 
 export class FetchIdentities implements Action {
     public readonly type = FETCH_IDENTITIES;
+}
+
+export class SetIdentities implements Action {
+    public readonly type = SET_IDENTITIES;
+
     constructor(public payload: Identity[]) {}
 }
 
 export type IdentityActions = 
-    FetchIdentities
+    FetchIdentities |
+    SetIdentities
     ;

--- a/src/app/root-store/identities/identity.effects.ts
+++ b/src/app/root-store/identities/identity.effects.ts
@@ -7,22 +7,12 @@ import * as identityActions from './identity.actions';
 @Injectable()
 export class IdentityEffects {
 
-    // Initial token refresh delay until configuration is loaded
-    private refreshTokenDelayMS: number = 10000;
-
-    // The buffer between a token expiring and refresh attempts being made
-    private refreshBufferPercent: number = 0.3;
-
-    private tokenInitialized: boolean = false;
-
-    private doRefreshToken: boolean = false;
-
     @Effect()
     public fetchIdentities = this.actions$
         .ofType(identityActions.FETCH_IDENTITIES)
         .switchMap(() => this.usersService.getOrganizations())
         .mergeMap(identities => [
-            new identityActions.FetchIdentities(identities.map(x => x.attributes))
+            new identityActions.SetIdentities(identities.map(x => x.attributes))
         ]);
 
     constructor(

--- a/src/app/root-store/identities/identity.effects.ts
+++ b/src/app/root-store/identities/identity.effects.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { Actions, Effect } from '@ngrx/effects';
+import { Observable } from 'rxjs/Observable';
+import { UsersService } from '../../core/services/users.service';
+import * as identityActions from './identity.actions';
+
+@Injectable()
+export class IdentityEffects {
+
+    // Initial token refresh delay until configuration is loaded
+    private refreshTokenDelayMS: number = 10000;
+
+    // The buffer between a token expiring and refresh attempts being made
+    private refreshBufferPercent: number = 0.3;
+
+    private tokenInitialized: boolean = false;
+
+    private doRefreshToken: boolean = false;
+
+    @Effect()
+    public fetchIdentities = this.actions$
+        .ofType(identityActions.FETCH_IDENTITIES)
+        .switchMap(() => this.usersService.getOrganizations())
+        .mergeMap(identities => [
+            new identityActions.FetchIdentities(identities.map(x => x.attributes))
+        ]);
+
+    constructor(
+        private actions$: Actions,
+        private usersService: UsersService,
+    ) {
+    }
+
+}

--- a/src/app/root-store/identities/identity.reducers.ts
+++ b/src/app/root-store/identities/identity.reducers.ts
@@ -11,7 +11,7 @@ const initialState: IdentityState = {
 
 export function identitiesReducer(state = initialState, action: identityActions.IdentityActions): IdentityState {
     switch (action.type) {
-        case identityActions.FETCH_IDENTITIES:
+        case identityActions.SET_IDENTITIES:
             return {
                 ...state,
                 identities: action.payload,

--- a/src/app/root-store/identities/identity.reducers.ts
+++ b/src/app/root-store/identities/identity.reducers.ts
@@ -1,0 +1,22 @@
+import * as identityActions from './identity.actions';
+import { Identity } from 'stix';
+
+export interface IdentityState {
+    identities: Identity[],
+}
+
+const initialState: IdentityState = {
+    identities: [],
+}
+
+export function identitiesReducer(state = initialState, action: identityActions.IdentityActions): IdentityState {
+    switch (action.type) {
+        case identityActions.FETCH_IDENTITIES:
+            return {
+                ...state,
+                identities: action.payload,
+            };
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#978.

New columns are visible on Assessments 3.0 master list dialog (even though the wireframes show them for baselines).

Adds an identities store for pulling organization names for display on the dialog (since what the assessment object contains is an id instead of a name).

Fixed some UI artifacts in the summary page.