### PR TITLE
Creates the heatmap dialog for choosing attack patterns

### DIFF
--- a/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
+++ b/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title>
+    <div class="flex">
+        <span>Choose VPN Related Attack Patterns</span>
+        <span class="flex1"></span>
+        <button mat-button (click)="clearSelections()">CLEAR</button>
+        <button mat-button [mat-dialog-close]="false">CANCEL</button>
+        <button mat-raised-button color="primary" [mat-dialog-close]="onClose()">SUBMIT</button>
+    </div>
+</h2>
+<mat-dialog-content>
+    <div id="attack-pattern-filter">
+        <attack-patterns-heatmap #heatmapView [attackPatterns]="attackPatterns" [heatMapOptions]="heatmapOptions"
+                (click)="toggleAttackPattern($event)"></attack-patterns-heatmap>
+    </div>
+</mat-dialog-content>

--- a/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.scss
+++ b/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.scss
@@ -1,0 +1,40 @@
+@import '../../../../styles/_variables.scss';
+
+$white: #FFFFFF;
+
+#attack-pattern-filter {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+}
+
+:host ::ng-deep {
+    background-color: $white;
+    .mat-dialog-container {
+        transition: none;
+    }
+    .mat-dialog-content {
+        height: 100%;
+    }
+    #attack-pattern-filter unf-heatmap {
+        div.heatmap-with-minimap {
+            height: 100%;
+        }
+        div.heat-map {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            background: white;
+        }
+        .heat-map-canvas {
+            cursor: pointer;
+        }
+        .heat-map-header rect.active, .heat-map-batch rect.active {
+            fill: $assessments-primary-lightest;
+        }
+        .heat-map-cell rect.selected {
+            fill: $assessments-primary;
+        }
+    }
+}

--- a/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
+++ b/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
@@ -1,0 +1,27 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AttackPatternChooserComponent } from './attack-pattern-chooser.component';
+
+describe('AttackPatternChooserComponent', () => {
+
+    let component: AttackPatternChooserComponent;
+    let fixture: ComponentFixture<AttackPatternChooserComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [ AttackPatternChooserComponent ]
+        })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AttackPatternChooserComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+});

--- a/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
+++ b/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
@@ -1,15 +1,76 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StoreModule } from '@ngrx/store';
+
+import { OverlayModule } from '@angular/cdk/overlay';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef, MatCardModule } from '@angular/material';
 
 import { AttackPatternChooserComponent } from './attack-pattern-chooser.component';
+import { AttackPatternsHeatmapComponent } from '../../../global/components/heatmap/attack-patterns-heatmap.component';
+import { HeatmapComponent } from '../../../global/components/heatmap/heatmap.component';
+import { CapitalizePipe } from '../../../global/pipes/capitalize.pipe';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { AuthService } from '../../../core/services/auth.service';
+import { mockAttackPatterns } from '../../../testing/mock-store';
+import { reducers } from '../../../root-store/app.reducers';
 
 describe('AttackPatternChooserComponent', () => {
 
     let component: AttackPatternChooserComponent;
     let fixture: ComponentFixture<AttackPatternChooserComponent>;
 
+    const mockAttackPatternData = [
+        {
+            type: 'attack-pattern',
+            id: mockAttackPatterns[0].id,
+            name: mockAttackPatterns[0].name,
+            description: 'Attack Pattern #1',
+            kill_chain_phases: [{phase_name: 'Something'}],
+            x_mitre_data_sources: ['The Source'],
+            x_mitre_platforms: ['iOS', 'Android'],
+        },
+        {
+            type: 'attack-pattern',
+            id: mockAttackPatterns[1].id,
+            name: mockAttackPatterns[1].name,
+            description: 'Attack Pattern #2',
+            kill_chain_phases: [{phase_name: 'Something Else'}],
+            x_mitre_data_sources: ['Another Source'],
+            x_mitre_platforms: ['AppleDOS', 'MS-DOS'],
+        },
+    ];
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
-            declarations: [ AttackPatternChooserComponent ]
+            imports: [
+                MatCardModule,
+                OverlayModule,
+                MatDialogModule,
+                RouterTestingModule,
+                HttpClientTestingModule,
+                StoreModule.forRoot(reducers),
+            ],
+            declarations: [
+                AttackPatternChooserComponent,
+                AttackPatternsHeatmapComponent,
+                HeatmapComponent,
+                CapitalizePipe,
+            ],
+            providers: [
+                GenericApi,
+                AuthService,
+                {
+                    provide: MAT_DIALOG_DATA,
+                    useValue: {active: [mockAttackPatterns[1].id]}
+                },
+                {
+                    provide: MatDialogRef,
+                    useValue: {
+                        close: function() {}
+                    }
+                },
+            ],
         })
         .compileComponents();
     }));

--- a/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.ts
+++ b/src/app/assess3/wizard/attack-pattern-chooser/attack-pattern-chooser.component.ts
@@ -1,0 +1,175 @@
+import {
+        Component,
+        Inject,
+        OnInit,
+        Input,
+        ViewChild,
+        ElementRef,
+        TemplateRef,
+        ViewContainerRef,
+        ChangeDetectorRef,
+        AfterViewInit,
+    } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { Overlay, OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { Store } from '@ngrx/store';
+
+import { AttackPatternsHeatmapComponent } from '../../../global/components/heatmap/attack-patterns-heatmap.component';
+import { HeatMapOptions } from '../../../global/components/heatmap/heatmap.data';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { Constance } from '../../../utils/constance';
+
+@Component({
+    selector: 'attack-pattern-chooser',
+    templateUrl: './attack-pattern-chooser.component.html',
+    styleUrls: ['./attack-pattern-chooser.component.scss'],
+})
+export class AttackPatternChooserComponent implements OnInit, AfterViewInit {
+
+    public attackPatterns = {};
+    @Input() public selectedPatterns = [];
+
+    @ViewChild('heatmapView') private view: AttackPatternsHeatmapComponent;
+    @Input() heatmapOptions: HeatMapOptions = {
+        view: {
+            component: '#attack-pattern-filter',
+        },
+        color: {
+            batchColors: [
+                {header: {bg: 'white', fg: '#333'}, body: {bg: 'white', fg: 'black'}},
+            ],
+            heatColors: {
+                'inactive': {bg: '#fcfcfc', fg: 'black'},
+                'selected': {bg: '.selected', fg: 'black'},
+                'active': {bg: '.active', fg: 'black'},
+            },
+        },
+        text: {
+            showCellText: true,
+        },
+        zoom: {
+            hasMinimap: false,
+            cellTitleExtent: 1,
+        },
+    }
+
+    @ViewChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
+    private overlayRef: OverlayRef;
+    private portal: TemplatePortal<any>;
+
+    constructor(
+        private dialogRef: MatDialogRef<AttackPatternsHeatmapComponent>,
+        @Inject(MAT_DIALOG_DATA) private data: any,
+        private genericApi: GenericApi,
+        private overlay: Overlay,
+        private vcr: ViewContainerRef,
+        private changeDetector: ChangeDetectorRef,
+    ) { }
+
+    ngOnInit() {
+        this.selectedPatterns = this.data.active || [];
+    }
+    
+    ngAfterViewInit() {
+        this.loadAttackPatterns();
+    }
+
+    /**
+     * @description retrieve the attack patterns and their tactics phases from the backend database
+     */
+    private loadAttackPatterns() {
+        const sort = { 'stix.name': '1' };
+        const project = {
+            'stix.id': 1,
+            'stix.name': 1,
+            'stix.description': 1,
+            'stix.kill_chain_phases': 1,
+            'extendedProperties.x_mitre_data_sources': 1,
+            'extendedProperties.x_mitre_platforms': 1,
+        };
+        const filter = encodeURI(`sort=${JSON.stringify(sort)}&project=${JSON.stringify(project)}`);
+        const initData$ = this.genericApi.get(`${Constance.ATTACK_PATTERN_URL}?${filter}`)
+            .finally(() => initData$ && initData$.unsubscribe())
+            .subscribe(
+                (patterns: any[]) => {
+                    this.attackPatterns = this.collectAttackPatterns(patterns);
+                    this.view['heatMapView'].forceUpdate();
+                    setTimeout(() => {
+                        this.view['heatMapView'].ngDoCheck();
+                        const selects = this.selectedPatterns
+                            .map(pattern => Object.values(this.attackPatterns).find((ap: any) => ap.id === pattern));
+                        this.selectedPatterns = [];
+                        selects.forEach(pattern => this.toggleAttackPattern({row: pattern}));
+                    }, 350);
+                },
+                (err) => console.log(new Date().toISOString(), err),
+            );
+    }
+
+    /**
+     * @description Build a list of all the attack patterns.
+     */
+    private collectAttackPatterns(patterns: any[]): any {
+        const attackPatterns = {};
+        patterns.forEach((pattern) => {
+            const name = pattern.attributes.name;
+            if (name) {
+                attackPatterns[name] = Object.assign({}, {
+                    id: pattern.attributes.id,
+                    name: name,
+                    title: name,
+                    description: pattern.attributes.description,
+                    phases: (pattern.attributes.kill_chain_phases || []).map(p => p.phase_name),
+                    sources: pattern.attributes.x_mitre_data_sources,
+                    platforms: pattern.attributes.x_mitre_platforms,
+                    value: 'inactive',
+                });
+            }
+        });
+        return attackPatterns;
+    }
+
+    /**
+     * @description for selecting and deselecting attack patterns
+     */
+    public toggleAttackPattern(clicked?: any) {
+        if (clicked && clicked.row) {
+            const index = this.selectedPatterns.findIndex(pattern => pattern.id === clicked.row.id);
+            let newValue = 'selected';
+            if (index < 0) {
+                // pattern was not previously selected; select it
+                this.selectedPatterns.push(clicked.row);
+            } else {
+                // remove the pattern from our selection list
+                newValue = 'inactive';
+                this.selectedPatterns.splice(index, 1);
+            }
+            const ap = this.attackPatterns[clicked.row.title];
+            if (ap) {
+                ap.value = newValue;
+                this.view['heatMapView'].heatmap.workspace.data.forEach(batch => {
+                    batch.value = batch.cells.some(cell => cell.value === 'selected') ? 'active' : null;
+                });
+                this.view['heatMapView'].updateCells();
+            }
+        }
+    }
+
+    /**
+     * @description Remove all selections
+     */
+    public clearSelections() {
+        this.selectedPatterns.slice(0).forEach(pattern => this.toggleAttackPattern({row: pattern}));
+    }
+
+    /**
+     * @description retrieve the list of selected attack pattern names
+     */
+    public onClose(): string[] {
+        return Array.from(new Set(this.selectedPatterns.map(pattern => pattern.id)));
+    }
+  
+}

--- a/src/app/assess3/wizard/capability/capability.component.html
+++ b/src/app/assess3/wizard/capability/capability.component.html
@@ -26,7 +26,7 @@
         </div>
         <div class="row margin-bottom">
           <div class="col-sm-12">
-              <button mat-raised-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
+              <button mat-raised-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(true)">
                 {{ openAttackMatrix }}
               </button>
           </div>

--- a/src/app/assess3/wizard/capability/capability.component.html
+++ b/src/app/assess3/wizard/capability/capability.component.html
@@ -6,7 +6,7 @@
           </mat-card-title>
         </div>
         <div class="col-lg-1">
-          <button mat-icon-button matTooltip="HeatMap Chart View" (click)="showHeatMap = true">
+          <button mat-icon-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(true)">
             <mat-icon class="mat-24" aria-hidden="true" aria-label="view heat map">view_comfy</mat-icon>
             {{ attackMatrix }}
           </button>

--- a/src/app/assess3/wizard/capability/capability.component.ts
+++ b/src/app/assess3/wizard/capability/capability.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 
 @Component({
   selector: 'unf-assess3-wizard-capability',
@@ -12,7 +12,8 @@ export class CapabilityComponent implements OnInit {
   public noAttackPatterns: string = 'You have no Attack Patterns yet';
   public addAttackPatterns: string = 'Add a Kill Chain Phase and Attack Patterns and they will show up here';
   public openAttackMatrix: string = 'Open Att&ck Matrix';
-  public showHeatMap = false;
+  @Output()
+  public onToggleHeatMap = new EventEmitter<boolean>();
 
   constructor() { }
 

--- a/src/app/assess3/wizard/category/category.component.ts
+++ b/src/app/assess3/wizard/category/category.component.ts
@@ -23,13 +23,14 @@ export class CategoryComponent implements OnInit {
   }
 
   /**
-   * @description
-   * @param index
-   * @param item
-   * @returns {number}
+   * @description angular track by list function, uses the items id if
+   *  it exists, otherwise uses the index
+   * @param {number} index
+   * @param {item}
+   * @return {number}
    */
-  public trackByFn(index, item) {
-    return index;
+  public trackByFn(index: number, item: any): number {
+    return item.id || index;
   }
 
   /*

--- a/src/app/assess3/wizard/wizard.component.html
+++ b/src/app/assess3/wizard/wizard.component.html
@@ -48,7 +48,7 @@
     <!-- List of cards containing each panel in the baselines wizard -->
     <div [ngSwitch]="openedSidePanel">
       <unf-assess3-wizard-category *ngSwitchCase="'categories'" #categories></unf-assess3-wizard-category>
-      <unf-assess3-wizard-capability *ngSwitchCase="'capabilities'"></unf-assess3-wizard-capability>
+      <unf-assess3-wizard-capability *ngSwitchCase="'capabilities'" (onToggleHeatMap)="toggleHeatMap()"></unf-assess3-wizard-capability>
       <div *ngSwitchCase="'capability'">
         <p>This is the attack pattern selection and capability scoring panel.</p>
       </div>

--- a/src/app/assess3/wizard/wizard.component.ts
+++ b/src/app/assess3/wizard/wizard.component.ts
@@ -826,13 +826,14 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   }
 
   /**
-   * @description
-   * @param index
-   * @param item
-   * @returns {number}
+   * @description angular track by list function, uses the items id if
+   *  it exists, otherwise uses the index
+   * @param {number} index
+   * @param {item}
+   * @return {number}
    */
-  public trackByFn(index, item) {
-    return index;
+  public trackByFn(index: number, item: any): number {
+    return item.id || index;
   }
 
   /*

--- a/src/app/assess3/wizard/wizard.component.ts
+++ b/src/app/assess3/wizard/wizard.component.ts
@@ -2,7 +2,7 @@ import { Component, ChangeDetectorRef, ElementRef, Input, OnInit, SimpleChanges,
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
 import { Location } from '@angular/common';
 
-import { MatSnackBar, MatSelect } from '@angular/material';
+import { MatSnackBar, MatSelect, MatDialog } from '@angular/material';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { Store } from '@ngrx/store';
@@ -34,6 +34,7 @@ import { heightCollapse } from '../../global/animations/height-collapse';
 import { WizardAssessment } from './models/wizard-assessment';
 import { ScoresModel } from './models/scores-model';
 import { Capability } from '../../models/unfetter/capability';
+import { AttackPatternChooserComponent } from './attack-pattern-chooser/attack-pattern-chooser.component';
 
 type ButtonLabel = 'SAVE' | 'CONTINUE';
 
@@ -92,6 +93,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
       }
     }
   };
+
   // public description = `An Assessment is your evaluation of the implementations of your network.  You will rate your environment
   // ' to the best of your ability. On the final page of the survey, you will be asked to enter a name for the report and a description.
   // Unfetter Discover will use the survey to help you understand your gaps, how important they are and which should be addressed.
@@ -112,7 +114,10 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   public categories: Dictionary<{ name: string, scoresModel: ScoresModel, capabilities: any[] }>[] = [];
   private currentCapabilities: Capability[];
   private currentCapability = {} as Capability;
-  
+
+  public showHeatmap = false;
+  public attackPatterns: any[] = [];
+
   private readonly subscriptions: Subscription[] = [];
   private readonly sidePanelNames: string[] = ['categories', 'capabilities', 'capability', 'summary'];
 
@@ -128,7 +133,8 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
     private userStore: Store<AppState>,
     private assessStore: Store<FullAssessmentResultState>,
     private wizardStore: Store<assessReducers.AssessState>,
-    private changeDetection: ChangeDetectorRef
+    private changeDetection: ChangeDetectorRef,
+    private dialog: MatDialog,
   ) {
     super();
     this.CHART_TYPE = 'doughnut';
@@ -1028,6 +1034,36 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
     return groupRisk;
   }
 
+  /**
+   * @description Displays a slide-out that shows the user a heat map of all attack patterns for filtering
+   */
+  public toggleHeatMap() {
+    if (this.showHeatmap) {
+      this.showHeatmap = false;
+      this.dialog.closeAll();
+    } else {
+      this.showHeatmap = true;
+      const dialog = this.dialog.open(AttackPatternChooserComponent, {
+        width: '80vw',
+        height: '80vh',
+        hasBackdrop: true,
+        disableClose: false,
+        closeOnNavigation: true,
+        data: {
+          active: this.attackPatterns,
+        },
+      });
+      dialog.afterClosed().subscribe(
+        result => {
+          if (result) {
+            this.attackPatterns = result;
+          }
+          this.showHeatmap = false;
+        },
+        (err) => console.log(err),
+      );
+    }
+  }
   /*
    * @description update the chart data
    * @return {void}

--- a/src/app/assess3/wizard/wizard.module.ts
+++ b/src/app/assess3/wizard/wizard.module.ts
@@ -19,11 +19,13 @@ import { CapabilityComponent } from './capability/capability.component';
 import { CategoryComponent } from './category/category.component';
 import { WizardComponent } from './wizard.component';
 import { routing } from './wizard.routing';
+import { AttackPatternChooserComponent } from './attack-pattern-chooser/attack-pattern-chooser.component';
 
 const moduleComponents = [
   WizardComponent,
   CategoryComponent,
   CapabilityComponent,
+  AttackPatternChooserComponent,
 ];
 
 const matModules = [
@@ -56,10 +58,9 @@ const primengModules = [
   ],
   declarations: [
     ...moduleComponents,
-    CapabilityComponent,
   ],
-  exports: [
-    ...moduleComponents,
-  ],
+  entryComponents: [
+    AttackPatternChooserComponent,
+  ]
 })
 export class WizardModule { }

--- a/src/app/indicator-sharing/indicator-sharing.module.ts
+++ b/src/app/indicator-sharing/indicator-sharing.module.ts
@@ -48,7 +48,6 @@ import { AddAttackPatternComponent } from './add-attack-pattern/add-attack-patte
 import { IndicatorHeatMapComponent } from './indicator-heat-map/indicator-heat-map.component';
 import { IndicatorHeatMapFilterComponent } from './indicator-heat-map/indicator-heatmap-filter.component';
 import { SummaryStatisticsComponent } from './summary-statistics/summary-statistics.component';
-import { AttackPatternsHeatmapComponent } from '../global/components/heatmap/attack-patterns-heatmap.component';
 
 const matModules = [
     MatButtonModule,


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#975.

This version is without a minimap, like in the wireframes. Will be adding hot-corners to the minimap so it can overlay the heatmap, but be moved out of the way, in a separate issue. Unless you have a massive monitor, this heatmap is harder on the eyes. Perhaps for this one, we'd prefer more of the table view on the Mitre ATT&CK page, to prevent eye strain.