### PR TITLE
Issue 841

### DIFF
--- a/src/app/assess/result/full/full.component.html
+++ b/src/app/assess/result/full/full.component.html
@@ -60,7 +60,7 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="(assessment|async)?.created"></result-header>
+        <result-header [assessment]="(assessment|async)" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="(assessment|async)?.created"></result-header>
         <unf-assess-group #assessGroupMain [assessmentGroup]="assessmentGroup" [activePhase]="phase" [rollupId]="rollupId" [assessment]="(assessment|async)" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)"></unf-assess-group>
       </div>
     </mat-sidenav-content>

--- a/src/app/assess/result/full/full.component.ts
+++ b/src/app/assess/result/full/full.component.ts
@@ -13,7 +13,7 @@ import { AppState } from '../../../root-store/app.reducers';
 import { Constance } from '../../../utils/constance';
 import { LastModifiedAssessment } from '../../models/last-modified-assessment';
 import { AssessService } from '../../services/assess.service';
-import { CleanAssessmentResultData, LoadAssessmentsByRollupId, LoadAssessmentById } from '../store/full-result.actions';
+import { CleanAssessmentResultData, LoadAssessmentById } from '../store/full-result.actions';
 import { FullAssessmentResultState } from '../store/full-result.reducers';
 import { SummaryDataSource } from '../summary/summary.datasource';
 import { FullAssessmentGroup } from './group/models/full-assessment-group';

--- a/src/app/assess/result/result-header/result-header.component.html
+++ b/src/app/assess/result/result-header/result-header.component.html
@@ -1,4 +1,5 @@
 <div id="tabWrapper">
+  <uf-info-bar *ngIf="percentCompleted < 100" [message]="percentCompletedMsg"></uf-info-bar>
   <div class="height-100-percent">
     <div class="height-100-percent flex flexRow">
       <div class="height-100-percent flex flexColumn">

--- a/src/app/assess/result/result-header/result-header.component.html
+++ b/src/app/assess/result/result-header/result-header.component.html
@@ -1,5 +1,5 @@
 <div id="tabWrapper">
-  <uf-info-bar *ngIf="percentCompleted < 100" [message]="percentCompletedMsg"></uf-info-bar>
+  <uf-info-bar *ngIf="percentCompleted < 100" [message]="percentCompletedMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
   <div class="height-100-percent">
     <div class="height-100-percent flex flexRow">
       <div class="height-100-percent flex flexColumn">

--- a/src/app/assess/result/result-header/result-header.component.ts
+++ b/src/app/assess/result/result-header/result-header.component.ts
@@ -12,17 +12,18 @@ export class ResultHeaderComponent implements OnInit {
   rollupId: string;
   @Input()
   assessmentId: string;
-
   @Input()
   public created: Date;
   @Input()
   public assessment: Assessment;
-
   public summaryLink: string;
   public resultsLink: string;
-
   public percentCompletedMsg: string;
   public percentCompleted = 0;
+  protected totalIndicators = 45;
+  protected totalCoas = 249;
+  protected totalSensors = 7;
+  protected editUrl: string;
 
   constructor() { }
 
@@ -34,8 +35,11 @@ export class ResultHeaderComponent implements OnInit {
     const base = '/assess/result/';
     this.summaryLink = `${base}/summary/${this.rollupId}/${this.assessmentId}`;
     this.resultsLink = `${base}/full/${this.rollupId}/${this.assessmentId}`;
+    const editBase = '/assess/wizard/edit/';
+    this.editUrl = `${editBase}/${this.rollupId}`; 
+    // TODO: initialize the correct total questions, by calling the server, may need a count endpoint
     this.percentCompleted = this.calcPercentCompleted(this.assessment);
-    this.percentCompletedMsg = `${this.percentCompleted} of your assessment is complete.`;
+    this.percentCompletedMsg = `${this.percentCompleted}% of your assessment is complete.`;
   }
 
   /**
@@ -43,12 +47,46 @@ export class ResultHeaderComponent implements OnInit {
    * @returns number
    */
   public calcPercentCompleted(assessment: Assessment): number {
+    const defaultPercent = 0;
     if (!assessment) {
-      return 0;
+      return defaultPercent;
     }
 
-    // assessment.assessment_objects;
-    console.log('calc % completed', assessment);
+    const assessmentObjects = assessment.assessment_objects || [];
+    if (assessmentObjects.length < 1) {
+      return defaultPercent;
+    }
+
+    const assessmentType = assessmentObjects[0].stix.type || '';
+    let totalQuestions;
+    switch (assessmentType) {
+      case 'indicator': {
+        totalQuestions = this.totalIndicators;
+        break;
+      }
+      case 'course-of-action': {
+        totalQuestions = this.totalCoas;
+        break;
+      }
+      case 'x-unfetter-sensor': {
+        totalQuestions = this.totalSensors;
+        break;
+      }
+      case 'x-unfetter-capability': {
+        totalQuestions = this.totalSensors;
+        break;
+      }
+      default: {
+        const msg = `cannot cacluate percent complete. cannot determine the assessment type of ${assessmentObjects[0]}.  moving on...`;
+        console.log(msg);
+        return defaultPercent;
+      }
+    }
+
+    const numAssessed = assessmentObjects.length;
+    const percent = Math.round((numAssessed / totalQuestions) * 100);
+    // console.log('calc % completed', percent);
+    return percent;
   }
 
 }

--- a/src/app/assess/result/result-header/result-header.component.ts
+++ b/src/app/assess/result/result-header/result-header.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { Assessment } from '../../../models/assess/assessment';
 
 @Component({
   selector: 'result-header',
@@ -14,9 +15,14 @@ export class ResultHeaderComponent implements OnInit {
 
   @Input()
   public created: Date;
+  @Input()
+  public assessment: Assessment;
 
   public summaryLink: string;
   public resultsLink: string;
+
+  public percentCompletedMsg: string;
+  public percentCompleted = 0;
 
   constructor() { }
 
@@ -28,6 +34,21 @@ export class ResultHeaderComponent implements OnInit {
     const base = '/assess/result/';
     this.summaryLink = `${base}/summary/${this.rollupId}/${this.assessmentId}`;
     this.resultsLink = `${base}/full/${this.rollupId}/${this.assessmentId}`;
+    this.percentCompleted = this.calcPercentCompleted(this.assessment);
+    this.percentCompletedMsg = `${this.percentCompleted} of your assessment is complete.`;
+  }
+
+  /**
+   * @param  {Assessment} assessment
+   * @returns number
+   */
+  public calcPercentCompleted(assessment: Assessment): number {
+    if (!assessment) {
+      return 0;
+    }
+
+    // assessment.assessment_objects;
+    console.log('calc % completed', assessment);
   }
 
 }

--- a/src/app/assess/result/result.module.ts
+++ b/src/app/assess/result/result.module.ts
@@ -1,50 +1,45 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatCardModule, MatProgressSpinnerModule, MatSelectModule, MatSliderModule, MatTableModule, MatTabsModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
-import { MatProgressSpinnerModule, MatTabsModule, MatCardModule, MatSliderModule, MatTableModule, MatSelectModule } from '@angular/material';
-
-import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
-
+import { StoreModule } from '@ngrx/store';
 import { ChartsModule } from 'ng2-charts';
-
 import { GlobalModule } from '../../global/global.module';
-
-import { SummaryEffects } from './store/summary.effects';
-import { summaryReducer } from './store/summary.reducers';
-import { RiskByAttackPatternEffects } from './store/riskbyattackpattern.effects';
-import { riskByAttackPatternReducer } from './store/riskbyattackpattern.reducers';
-import { SummaryComponent } from './summary/summary.component';
 import { FullComponent } from './full/full.component';
+import { AddAssessedObjectComponent } from './full/group/add-assessed-object/add-assessed-object.component';
+import { AssessGroupComponent } from './full/group/assessments-group.component';
 import { ResultHeaderComponent } from './result-header/result-header.component';
-import { SummaryHeaderComponent } from './summary/summary-header/summary-header.component';
-import { SummaryReportComponent } from './summary/summary-report/summary-report.component';
-import { AssessmentsSummaryComponent } from '../../assessments/assessments-summary/assessments-summary.component';
 import { FullResultEffects } from './store/full-result.effects';
 import { fullAssessmentResultReducer } from './store/full-result.reducers';
-import { AssessGroupComponent } from './full/group/assessments-group.component';
-import { AddAssessedObjectComponent } from './full/group/add-assessed-object/add-assessed-object.component';
+import { RiskByAttackPatternEffects } from './store/riskbyattackpattern.effects';
+import { riskByAttackPatternReducer } from './store/riskbyattackpattern.reducers';
+import { SummaryEffects } from './store/summary.effects';
+import { summaryReducer } from './store/summary.reducers';
 import { SummaryCalculationService } from './summary/summary-calculation.service';
-import { SophisticationBreakdownComponent } from './summary/summary-report/sophistication-breakdown/sophistication-breakdown.component';
-import { TechniquesChartComponent } from './summary/summary-report/techniques-chart/techniques-chart.component';
+import { SummaryHeaderComponent } from './summary/summary-header/summary-header.component';
 import { AssessmentChartComponent } from './summary/summary-report/assessment-chart/assessment-chart.component';
+import { SophisticationBreakdownComponent } from './summary/summary-report/sophistication-breakdown/sophistication-breakdown.component';
+import { SummaryReportComponent } from './summary/summary-report/summary-report.component';
+import { TechniquesChartComponent } from './summary/summary-report/techniques-chart/techniques-chart.component';
+import { SummaryComponent } from './summary/summary.component';
 
 const materialModules = [
   MatCardModule,
   MatProgressSpinnerModule,
-  MatSliderModule,
   MatSelectModule,
+  MatSliderModule,
   MatTableModule,
   MatTabsModule,
 ];
 
 const moduleComponents = [
-  AssessGroupComponent,
   AddAssessedObjectComponent,
-  SummaryComponent,
+  AssessGroupComponent,
   FullComponent,
   ResultHeaderComponent,
+  SummaryComponent,
   SummaryHeaderComponent,
   SummaryReportComponent,
 ];

--- a/src/app/assess/result/summary/summary-sort-helper.ts
+++ b/src/app/assess/result/summary/summary-sort-helper.ts
@@ -1,7 +1,7 @@
-import { Phase } from '../../../models/assess/phase';
+import { SortHelper } from '../../../global/static/sort-helper';
 import { AssessAttackPattern } from '../../../models/assess/assess-attack-pattern';
 import { AssessKillChainType } from '../../../models/assess/assess-kill-chain-type';
-import { SortHelper } from '../../../global/static/sort-helper';
+import { Phase } from '../../../models/assess/phase';
 
 export class SummarySortHelper extends SortHelper {
 

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -25,7 +25,7 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="summary?.created"></result-header>
+        <result-header [assessment]="(summary|async)" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="summary?.created"></result-header>
         <summary-report></summary-report>
       </div>
     </mat-sidenav-content>

--- a/src/app/assess/result/summary/summary.component.html
+++ b/src/app/assess/result/summary/summary.component.html
@@ -25,7 +25,7 @@
     </mat-sidenav>
     <mat-sidenav-content>
       <div class="main-panel">
-        <result-header [assessment]="(summary|async)" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="summary?.created"></result-header>
+        <result-header [assessment]="summary" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="summary?.created"></result-header>
         <summary-report></summary-report>
       </div>
     </mat-sidenav-content>

--- a/src/app/assess/result/summary/summary.component.ts
+++ b/src/app/assess/result/summary/summary.component.ts
@@ -1,34 +1,27 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
-
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
-
-import { Subscription } from 'rxjs/Subscription';
-import { Observable } from 'rxjs/Observable';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-
-import { SummaryState } from '../store/summary.reducers';
-import { RiskByAttackPatternState } from '../store/riskbyattackpattern.reducers';
-import { LoadAssessmentSummaryData, LoadSingleAssessmentSummaryData, LoadSingleRiskPerKillChainData, LoadSingleSummaryAggregationData } from '../store/summary.actions';
-
-import { AppState } from '../../../root-store/app.reducers';
-import { Assessment } from '../../../models/assess/assessment';
-import { AssessService } from '../../services/assess.service';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 import { ConfirmationDialogComponent } from '../../../components/dialogs/confirmation/confirmation-dialog.component';
-import { MasterListDialogTableHeaders } from '../../../global/components/master-list-dialog/master-list-dialog.component';
-import { LastModifiedAssessment } from '../../models/last-modified-assessment';
 import { slideInOutAnimation } from '../../../global/animations/animations';
-import { Constance } from '../../../utils/constance';
-import { UserProfile } from '../../../models/user/user-profile';
-import { SummaryDataSource } from './summary.datasource';
-import { SummaryCalculationService } from './summary-calculation.service';
-import { AssessmentObject } from '../../../models/assess/assessment-object';
-import { AssessmentsDashboardService } from '../../../assessments/assessments-dashboard/assessments-dashboard.service';
+import { MasterListDialogTableHeaders } from '../../../global/components/master-list-dialog/master-list-dialog.component';
+import { Assessment } from '../../../models/assess/assessment';
 import { RiskByAttack } from '../../../models/assess/risk-by-attack';
-import { LoadAssessmentRiskByAttackPatternData, LoadSingleAssessmentRiskByAttackPatternData, CleanAssessmentRiskByAttackPatternData } from '../store/riskbyattackpattern.actions';
 import { RiskByKillChain } from '../../../models/assess/risk-by-kill-chain';
 import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
-import { CleanAssessmentResultData } from '../store/summary.actions';
+import { UserProfile } from '../../../models/user/user-profile';
+import { AppState } from '../../../root-store/app.reducers';
+import { Constance } from '../../../utils/constance';
+import { LastModifiedAssessment } from '../../models/last-modified-assessment';
+import { AssessService } from '../../services/assess.service';
+import { CleanAssessmentRiskByAttackPatternData, LoadSingleAssessmentRiskByAttackPatternData } from '../store/riskbyattackpattern.actions';
+import { RiskByAttackPatternState } from '../store/riskbyattackpattern.reducers';
+import { CleanAssessmentResultData, LoadSingleAssessmentSummaryData, LoadSingleRiskPerKillChainData, LoadSingleSummaryAggregationData } from '../store/summary.actions';
+import { SummaryState } from '../store/summary.reducers';
+import { SummaryCalculationService } from './summary-calculation.service';
+import { SummaryDataSource } from './summary.datasource';
 
 @Component({
   selector: 'summary',

--- a/src/app/global/components/info-bar/info-bar.component.html
+++ b/src/app/global/components/info-bar/info-bar.component.html
@@ -1,0 +1,13 @@
+<div class="info-bar-wrapper" [style.display]="shouldShow === true ? 'block': 'none'">
+  <div class="flex">
+    <div class="info-bar">
+      {{message}}
+      <span *ngIf="completeBtnMsg && completeActionUrl">
+        <a mat-button (click)="onCompleteClick($event)">
+          {{completeBtnMsg}}
+        </a>
+      </span>
+      <a mat-button (click)="onDismissClick($event)">{{dismissBtnMsg}}</a>
+    </div>
+  </div>
+</div>

--- a/src/app/global/components/info-bar/info-bar.component.html
+++ b/src/app/global/components/info-bar/info-bar.component.html
@@ -3,7 +3,7 @@
     <div class="info-bar">
       {{message}}
       <span *ngIf="completeBtnMsg && completeActionUrl">
-        <a mat-button (click)="onCompleteClick($event)">
+        <a mat-button [routerLink]="completeActionUrl">
           {{completeBtnMsg}}
         </a>
       </span>

--- a/src/app/global/components/info-bar/info-bar.component.scss
+++ b/src/app/global/components/info-bar/info-bar.component.scss
@@ -1,0 +1,29 @@
+@import '../../../../styles/_variables.scss';
+
+.info-bar-wrapper {
+    position: absolute;
+    background-color: #4F5B62;
+    height: 48px;
+    width: 100%;
+    color: $dark-text-default;
+    font-size: 14px;
+
+    .flex {
+        height: 100%;
+        width: 100%;
+
+        .info-bar {
+            margin: auto 14px;
+        }
+    }
+
+    a:focus {
+        outline: none;
+        color: $light-text-slightly-dimmed;
+    }
+
+    a:hover {
+        color: $light-text-slightly-dimmed;
+    }
+
+}

--- a/src/app/global/components/info-bar/info-bar.component.spec.ts
+++ b/src/app/global/components/info-bar/info-bar.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material';
+import { InfoBarComponent } from './info-bar.component';
+
+describe('InfoBarComponent', () => {
+  let component: InfoBarComponent;
+  let fixture: ComponentFixture<InfoBarComponent>;
+
+  beforeEach(async(() => {
+
+    const materialModules = [
+      MatButtonModule,
+    ]
+    TestBed.configureTestingModule({
+      declarations: [InfoBarComponent],
+      imports: [
+        ...materialModules,
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InfoBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/global/components/info-bar/info-bar.component.spec.ts
+++ b/src/app/global/components/info-bar/info-bar.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material';
+import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 import { InfoBarComponent } from './info-bar.component';
 
 describe('InfoBarComponent', () => {
@@ -15,6 +17,7 @@ describe('InfoBarComponent', () => {
       declarations: [InfoBarComponent],
       imports: [
         ...materialModules,
+        RouterTestingModule,
       ]
     })
       .compileComponents();
@@ -23,10 +26,35 @@ describe('InfoBarComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InfoBarComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should have a close action', () => {
+    expect(component.shouldShow).toBeTruthy();
+    component.onDismissClick();
+    expect(component.shouldShow).toBeFalsy();
+  });
+
+  it('should dislay message', () => {
+    const customMsg = 'custom message';
+    component.message = customMsg;
+    fixture.detectChanges();
+    const infoBarElement = fixture.debugElement;
+    const msgElement = infoBarElement.query(By.css('.info-bar'));
+    expect(msgElement.nativeElement).toBeDefined();
+    expect(msgElement.nativeElement.textContent).toContain(customMsg);
+  });
+
+  it('should dislay complete action', () => {
+    component.completeActionUrl = 'https://127.0.0.1/test';
+    component.completeBtnMsg = 'click to complete';
+    fixture.detectChanges();
+    const infoBarElement = fixture.debugElement;
+    const msgElement = infoBarElement.query(By.css('.info-bar'));
+    expect(msgElement.nativeElement).toBeDefined();
+    expect(msgElement.nativeElement.textContent).toContain(component.completeBtnMsg);
   });
 });

--- a/src/app/global/components/info-bar/info-bar.component.ts
+++ b/src/app/global/components/info-bar/info-bar.component.ts
@@ -1,0 +1,44 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'uf-info-bar',
+  templateUrl: './info-bar.component.html',
+  styleUrls: ['./info-bar.component.scss']
+})
+export class InfoBarComponent implements OnInit {
+
+  @Input()
+  public shouldShow = true;
+  @Input()
+  public message = '';
+  @Input()
+  public dismissBtnMsg = 'DISMISS';
+  @Input()
+  public completeBtnMsg = 'COMPLETE';
+  @Input()
+  public completeActionUrl = '';
+  constructor() { }
+  
+  /**
+   * @returns void
+   */
+  public ngOnInit(): void {
+  }
+
+  /**
+   * @param  {UIEvent} event?
+   * @returns void
+   */
+  public onDismissClick(event?: UIEvent): void {
+    this.shouldShow = false;
+  }
+
+  /**
+   * @param  {UIEvent} event?
+   * @returns void
+   */
+  public onCompleteClick(event?: UIEvent): void {
+    console.log('on complete');
+  }
+
+}

--- a/src/app/global/components/info-bar/info-bar.component.ts
+++ b/src/app/global/components/info-bar/info-bar.component.ts
@@ -38,15 +38,4 @@ export class InfoBarComponent implements OnInit {
     this.shouldShow = false;
   }
 
-  /**
-   * @param  {UIEvent} event?
-   * @returns Promise
-   */
-  public onCompleteClick(event?: UIEvent): Promise<boolean> {
-    if (!this.completeActionUrl) {
-      return Promise.resolve(false);
-    }
-    return this.router.navigateByUrl(this.completeActionUrl);
-  }
-
 }

--- a/src/app/global/components/info-bar/info-bar.component.ts
+++ b/src/app/global/components/info-bar/info-bar.component.ts
@@ -1,9 +1,11 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'uf-info-bar',
   templateUrl: './info-bar.component.html',
-  styleUrls: ['./info-bar.component.scss']
+  styleUrls: ['./info-bar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InfoBarComponent implements OnInit {
 
@@ -17,8 +19,11 @@ export class InfoBarComponent implements OnInit {
   public completeBtnMsg = 'COMPLETE';
   @Input()
   public completeActionUrl = '';
-  constructor() { }
-  
+
+  constructor(
+    protected router: Router,
+  ) { }
+
   /**
    * @returns void
    */
@@ -35,10 +40,13 @@ export class InfoBarComponent implements OnInit {
 
   /**
    * @param  {UIEvent} event?
-   * @returns void
+   * @returns Promise
    */
-  public onCompleteClick(event?: UIEvent): void {
-    console.log('on complete');
+  public onCompleteClick(event?: UIEvent): Promise<boolean> {
+    if (!this.completeActionUrl) {
+      return Promise.resolve(false);
+    }
+    return this.router.navigateByUrl(this.completeActionUrl);
   }
 
 }

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -70,7 +70,7 @@ const matModules = [
     MatMenuModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
-    MatSelectModule
+    MatSelectModule,
     MatSidenavModule,
     MatTableModule,
     MatTabsModule,

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -1,130 +1,122 @@
-// ~~~ Vendor ~~~
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule, MatExpansionModule, MatListModule, MatSelectModule } from '@angular/material';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
-import { MatInputModule } from '@angular/material/input';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatListModule, MatDialog, MatCardModule, MatSelectModule } from '@angular/material';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatExpansionModule } from '@angular/material';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
-
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-
-// ~~~ Local ~~~
-
-// Pipes
-import { CapitalizePipe } from './pipes/capitalize.pipe';
-import { SophisticationPipe } from './pipes/sophistication.pipe';
-import { FieldSortPipe } from './pipes/field-sort.pipe';
-import { TimeAgoPipe } from './pipes/time-ago.pipe';
-
-// Components and directives
-import { RiskIconComponent } from './components/risk-icon/risk-icon.component';
-import { StixTableComponent } from './components/stix-table/stix-table.component';
-import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
-import { KillChainPhasesReactiveComponent } from './components/kill-chain-phases/kill-chain-phases.component';
-import { ExternalReferencesReactiveComponent } from './components/external-references/external-references.component';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterModule } from '@angular/router';
 import { AddLabelReactiveComponent } from './components/add-label/add-label.component';
-import { ObservableDataTreeComponent } from './components/observable-data-tree/observable-data-tree.component';
-import { ChipLinksComponent } from './components/chip-links/chip-links.component';
-import { ObservableDataSummaryComponent } from './components/observable-data-summary/observable-data-summary.component';
-import { HeaderNavigationComponent } from './components/header-navigation/header-navigation.component';
-import { NotificationWindowComponent } from './components/notification-window/notification-window.component';
-import { SpeedDialComponent } from './components/speed-dial/speed-dial.component';
-import { FooterComponent } from './components/footer/footer.component';
-import { LandingPageComponent } from './components/landing-page/landing-page.component';
-import { SidepanelComponent } from './components/sidepanel/sidepanel.component';
-import { SidepanelListItemComponent } from './components/sidepanel/sidepanel-list-item.component';
-import { SidepanelOptionItemComponent } from './components/sidepanel/sidepanel-option-item.component';
-import { SidepanelMiniItemComponent } from './components/sidepanel/sidepanel-mini-item.component';
-import { HelpWindowComponent } from './components/help-window/help-window.component';
 import { AdditionalQueriesComponent } from './components/additional-queries/additional-queries.component';
-import { MasterListDialogComponent, MasterListDialogTriggerComponent } from './components/master-list-dialog/master-list-dialog.component';
-import { ErrorCardComponent } from './components/error-card/error-card.component';
-import { RiskBreakdownComponent } from './components/risk-breakdown/risk-breakdown.component';
-import { TreemapComponent } from './components/treemap/treemap.component';
-import { HeatmapComponent } from './components/heatmap/heatmap.component';
+import { ChipLinksComponent } from './components/chip-links/chip-links.component';
 import { CreatedByRefComponent } from './components/created-by-ref/created-by-ref.component';
-import { RelatationshipGeneratorComponent } from './components/relatationship-generator/relatationship-generator.component';
-import { InfiniteScrollDirective } from './directives/infinite-scroll.directive';
-import { PublishedCheckboxComponent } from './components/published-checkbox/published-checkbox.component';
+import { ErrorCardComponent } from './components/error-card/error-card.component';
+import { ExternalReferencesReactiveComponent } from './components/external-references/external-references.component';
+import { FooterComponent } from './components/footer/footer.component';
 import { HeaderLogoComponent } from './components/header-logo/header-logo.component';
+import { HeaderNavigationComponent } from './components/header-navigation/header-navigation.component';
 import { AttackPatternsHeatmapComponent } from './components/heatmap/attack-patterns-heatmap.component';
+import { HeatmapComponent } from './components/heatmap/heatmap.component';
+import { HelpWindowComponent } from './components/help-window/help-window.component';
+import { InfoBarComponent } from './components/info-bar/info-bar.component';
+import { KillChainPhasesReactiveComponent } from './components/kill-chain-phases/kill-chain-phases.component';
+import { LandingPageComponent } from './components/landing-page/landing-page.component';
+import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
+import { MasterListDialogComponent, MasterListDialogTriggerComponent } from './components/master-list-dialog/master-list-dialog.component';
+import { NotificationWindowComponent } from './components/notification-window/notification-window.component';
+import { ObservableDataSummaryComponent } from './components/observable-data-summary/observable-data-summary.component';
+import { ObservableDataTreeComponent } from './components/observable-data-tree/observable-data-tree.component';
 import { PiiCheckMessageComponent } from './components/pii-check-message/pii-check-message.component';
+import { PublishedCheckboxComponent } from './components/published-checkbox/published-checkbox.component';
+import { RelatationshipGeneratorComponent } from './components/relatationship-generator/relatationship-generator.component';
+import { RiskBreakdownComponent } from './components/risk-breakdown/risk-breakdown.component';
+import { RiskIconComponent } from './components/risk-icon/risk-icon.component';
+import { SidepanelListItemComponent } from './components/sidepanel/sidepanel-list-item.component';
+import { SidepanelMiniItemComponent } from './components/sidepanel/sidepanel-mini-item.component';
+import { SidepanelOptionItemComponent } from './components/sidepanel/sidepanel-option-item.component';
+import { SidepanelComponent } from './components/sidepanel/sidepanel.component';
+import { SpeedDialComponent } from './components/speed-dial/speed-dial.component';
+import { StixTableComponent } from './components/stix-table/stix-table.component';
+import { TreemapComponent } from './components/treemap/treemap.component';
+import { InfiniteScrollDirective } from './directives/infinite-scroll.directive';
+import { CapitalizePipe } from './pipes/capitalize.pipe';
+import { FieldSortPipe } from './pipes/field-sort.pipe';
+import { SophisticationPipe } from './pipes/sophistication.pipe';
+import { TimeAgoPipe } from './pipes/time-ago.pipe';
 
 const matModules = [
     MatAutocompleteModule,
     MatButtonModule,
+    MatCardModule,
     MatCheckboxModule,
     MatChipsModule,
-    MatPaginatorModule,
-    MatInputModule,
+    MatDialogModule,
+    MatExpansionModule,
     MatIconModule,
-    MatTooltipModule,
-    MatTableModule,
-    MatProgressSpinnerModule,
-    MatToolbarModule,
+    MatInputModule,
     MatListModule,
     MatMenuModule,
-    MatSidenavModule,
-    MatExpansionModule,
-    MatDialogModule,
-    MatTabsModule,
-    MatCardModule,
+    MatPaginatorModule,
+    MatProgressSpinnerModule,
     MatSelectModule
+    MatSidenavModule,
+    MatTableModule,
+    MatTabsModule,
+    MatToolbarModule,
+    MatTooltipModule,
 ];
 
 const unfetterComponents = [
-    CapitalizePipe,
-    SophisticationPipe,
-    TimeAgoPipe,
-    RiskIconComponent,
-    StixTableComponent,
-    FieldSortPipe,
-    LoadingSpinnerComponent,
-    KillChainPhasesReactiveComponent,
-    ExternalReferencesReactiveComponent,
     AddLabelReactiveComponent,
-    ObservableDataTreeComponent,
+    AdditionalQueriesComponent,
+    AttackPatternsHeatmapComponent,
+    CapitalizePipe,
     ChipLinksComponent,
-    ObservableDataSummaryComponent,
-    HeaderNavigationComponent,
-    NotificationWindowComponent,
-    SpeedDialComponent,
+    CreatedByRefComponent,
+    ErrorCardComponent,
+    ExternalReferencesReactiveComponent,
+    FieldSortPipe,
     FooterComponent,
+    HeaderLogoComponent,
+    HeaderNavigationComponent,
+    HeatmapComponent,
+    HelpWindowComponent,
+    InfiniteScrollDirective,
+    InfoBarComponent,
+    KillChainPhasesReactiveComponent,
     LandingPageComponent,
+    LoadingSpinnerComponent,
+    MasterListDialogComponent,
+    MasterListDialogTriggerComponent,
+    NotificationWindowComponent,
+    ObservableDataSummaryComponent,
+    ObservableDataTreeComponent,
+    PiiCheckMessageComponent,
+    PublishedCheckboxComponent,
+    RelatationshipGeneratorComponent,
+    RiskBreakdownComponent,
+    RiskIconComponent,
     SidepanelComponent,
     SidepanelListItemComponent,
-    SidepanelOptionItemComponent,
     SidepanelMiniItemComponent,
-    HelpWindowComponent,
-    AdditionalQueriesComponent,
-    MasterListDialogTriggerComponent,
-    MasterListDialogComponent,
-    ErrorCardComponent,
-    RiskBreakdownComponent,
+    SidepanelOptionItemComponent,
+    SophisticationPipe,
+    SpeedDialComponent,
+    StixTableComponent,
+    TimeAgoPipe,
     TreemapComponent,
-    HeatmapComponent,
-    AttackPatternsHeatmapComponent,
-    CreatedByRefComponent,
-    RelatationshipGeneratorComponent,
-    InfiniteScrollDirective,
-    PublishedCheckboxComponent,
-    HeaderLogoComponent,
-    PiiCheckMessageComponent,
 ];
 
 @NgModule({
@@ -136,7 +128,8 @@ const unfetterComponents = [
         ...matModules
     ],
     declarations: [
-        ...unfetterComponents,        
+        ...unfetterComponents,
+
     ],
     exports: [
         ...unfetterComponents,


### PR DESCRIPTION
fixes unfetter-discover/unfetter#841

# problem
users do not know if there assessment is complete

# changes
an info bar per the mockup will show a % complete, dismiss and complete actions
should see on assessment 2.0 summary and result tags for all types
since assessments do not store the unanswered questions, I used hard coded total question count. 
will need an efficient query to grab just the counts, that endpoint does not exist

# test
pull this pr
visit all three demo assessments
verify they show % complete, also dismiss and complete actions
verify actions
verify both summary and result tabs
