### PR TITLE
quicker travis feedback, lighter vendor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,7 @@ addons:
 install:
   - npm install
 script:
-  - npm run clean
-  - npm run build:prod
   - npm run lint
-#  - npm run headless:test
   - npm run headless:coverage
+  - npm run build:prod
   - npm run doc
-  - npm run clean

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,23 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/build-optimizer": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.42.tgz",
-      "integrity": "sha512-BAYCVZ10ro6mgZQDZiNiVbX8ppygw4q7z/stpwG8WjMswgMRIcxsxYoC1VFuWcUPAf4UyfTIav6e8UZWA5+xnQ==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.5.8.tgz",
+      "integrity": "sha512-D5baiuYYhAgBpZp7QerAc8VQub9SqJlrscHEaI4ypWf5VXzWeEPYL2R5V5Zju9NTDqZQPos2vgju7KbKTRBPqg==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
         "source-map": "0.5.7",
-        "typescript": "2.6.2",
+        "typescript": "2.7.2",
         "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -118,6 +126,20 @@
         "webpack-sources": "1.1.0",
         "webpack-subresource-integrity": "1.0.4",
         "zone.js": "0.8.26"
+      },
+      "dependencies": {
+        "@angular-devkit/build-optimizer": {
+          "version": "0.0.42",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.42.tgz",
+          "integrity": "sha512-BAYCVZ10ro6mgZQDZiNiVbX8ppygw4q7z/stpwG8WjMswgMRIcxsxYoC1VFuWcUPAf4UyfTIav6e8UZWA5+xnQ==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "source-map": "0.5.7",
+            "typescript": "2.6.2",
+            "webpack-sources": "1.1.0"
+          }
+        }
       }
     },
     "@angular/common": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
+    "@angular-devkit/build-optimizer": "^0.5.8",
     "@angular-devkit/core": "0.0.29",
     "@angular/cli": "1.6.3",
     "@angular/compiler-cli": "^5.0.0",

--- a/src/app/assess/wizard/wizard.component.ts
+++ b/src/app/assess/wizard/wizard.component.ts
@@ -3,7 +3,7 @@ import { AfterViewInit, ChangeDetectorRef, Component, HostListener, OnDestroy, O
 import { MatSelect, MatSnackBar } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { MenuItem } from 'primeng/primeng';
+import { MenuItem } from 'primeng/components/common/menuitem';
 import { Subscription } from 'rxjs/Subscription';
 import { Key } from 'ts-keycode-enum';
 import { GenericApi } from '../../core/services/genericapi.service';
@@ -815,7 +815,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
     if (item && item.id) {
       return item.id;
     }
-  
+
     return index;
   }
 

--- a/src/app/components/component.module.ts
+++ b/src/app/components/component.module.ts
@@ -1,25 +1,26 @@
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NgModule,  ApplicationRef } from '@angular/core';
-import { RouterModule,  PreloadAllModules } from '@angular/router';
-import { CalendarModule, AccordionModule, DataListModule, CheckboxModule } from 'primeng/primeng';
-import { MatButtonModule, MatListModule, MatCardModule,
-  MatDialogModule, MatChipsModule, MatInputModule, MatSelectModule, MatAutocompleteModule, MatCheckboxModule, MatIconModule } from '@angular/material';
-import { PageHeaderComponent } from './page/page-header.component';
-import { ConfirmationDialogComponent } from './dialogs/confirmation/confirmation-dialog.component';
-import { IndicatorPatternFieldComponent } from './indicator-pattern-field/indicator-pattern-field.component';
-import { SelectSearchFieldComponent } from './select-search-field/select-search-field.component';
-import { ExternalReferenceComponent } from './external-reference/external-reference.component';
-import { KillChainPhasesComponent } from './kill-chain-phases/kill-chain-phases.component';
-import { ListStixObjectComponent } from './list-stix-objects/list-stix-objects.component';
-import { ReadonlyContentComponent } from './readonly-content/readonly-content.component';
-import { FilterSearchBoxComponent } from './filter-search-box/filter-search-box.component';
-import { RelationshipListComponent } from './relationship-list/relationship-list.component';
-import { MitigateListComponent } from './mitigate-list/mitigate-list.component';
+// import { CalendarModule, AccordionModule, DataListModule, CheckboxModule } from 'primeng/primeng';
+import { MatAutocompleteModule, MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatIconModule, MatInputModule, MatSelectModule } from '@angular/material';
+import { RouterModule } from '@angular/router';
+import { CheckboxModule } from 'primeng/components/checkbox/checkbox';
+import { DataListModule } from 'primeng/components/datalist/datalist';
+import { GlobalModule } from '../global/global.module';
 import { BaseComponentService } from './base-service.component';
 import { ButtonsFilterComponent } from './buttons-filter/buttons-filter.component';
+import { ConfirmationDialogComponent } from './dialogs/confirmation/confirmation-dialog.component';
+import { ExternalReferenceComponent } from './external-reference/external-reference.component';
+import { FilterSearchBoxComponent } from './filter-search-box/filter-search-box.component';
+import { IndicatorPatternFieldComponent } from './indicator-pattern-field/indicator-pattern-field.component';
+import { KillChainPhasesComponent } from './kill-chain-phases/kill-chain-phases.component';
 import { LinkNodeGraphComponent } from './link-node-graph/link-node-graph.component';
-import { GlobalModule } from '../global/global.module';
+import { ListStixObjectComponent } from './list-stix-objects/list-stix-objects.component';
+import { MitigateListComponent } from './mitigate-list/mitigate-list.component';
+import { PageHeaderComponent } from './page/page-header.component';
+import { ReadonlyContentComponent } from './readonly-content/readonly-content.component';
+import { RelationshipListComponent } from './relationship-list/relationship-list.component';
+import { SelectSearchFieldComponent } from './select-search-field/select-search-field.component';
 import { StixTextArrayComponent } from './stix-text-array/stix-text-array.component';
 import { ValidationErrorsComponent } from './validation-errors/validation-errors.component';
 
@@ -79,4 +80,4 @@ import { ValidationErrorsComponent } from './validation-errors/validation-errors
   providers: [BaseComponentService],
   entryComponents: [ConfirmationDialogComponent]
 })
-export class ComponentModule {}
+export class ComponentModule { }

--- a/src/app/components/list-stix-objects/link-stix-objects.component.spec.ts
+++ b/src/app/components/list-stix-objects/link-stix-objects.component.spec.ts
@@ -1,14 +1,10 @@
-import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Location } from '@angular/common';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { MatChipsModule, MatDialog, MatIconModule } from '@angular/material';
 import { ActivatedRoute, Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { Location } from '@angular/common';
-import { By } from '@angular/platform-browser';
+import { DataListModule } from 'primeng/components/datalist/datalist';
 import { Observable } from 'rxjs/Observable';
-
-import { FormsModule } from '@angular/forms';
-import { DataListModule } from 'primeng/primeng';
-import { MatChipsModule, MatIconModule, MatDialog } from '@angular/material';
-
 import { ListStixObjectComponent } from './list-stix-objects.component';
 
 describe('ListStixObjectComponent', () => {
@@ -16,9 +12,9 @@ describe('ListStixObjectComponent', () => {
     let component: ListStixObjectComponent;
     let fixture: ComponentFixture<ListStixObjectComponent>;
 
-    const routes: Routes = [{path: 'test', component: ListStixObjectComponent}];
+    const routes: Routes = [{ path: 'test', component: ListStixObjectComponent }];
     const mockRouter = {
-        navigate: (paths: string[]) => {},
+        navigate: (paths: string[]) => { },
     }
     const mockDialog = {
         open: () => {
@@ -26,7 +22,7 @@ describe('ListStixObjectComponent', () => {
                 afterClosed: () => Observable.of({})
             };
         },
-        closeAll: () => {},
+        closeAll: () => { },
     };
 
     beforeEach(async(() => {
@@ -44,10 +40,10 @@ describe('ListStixObjectComponent', () => {
                 { provide: ActivatedRoute, useValue: {} },
                 { provide: Router, useValue: mockRouter },
                 { provide: MatDialog, useValue: mockDialog },
-                { provide: Location, useValue: {back: () => {}} },
+                { provide: Location, useValue: { back: () => { } } },
             ]
         })
-        .compileComponents();
+            .compileComponents();
     }));
 
     beforeEach(() => {

--- a/src/app/intrusion-set-dashboard/intrusion-set-dashboard.module.ts
+++ b/src/app/intrusion-set-dashboard/intrusion-set-dashboard.module.ts
@@ -1,8 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatButtonModule, MatCardModule, MatCheckboxModule, MatIconModule, MatInputModule, MatProgressBarModule, MatProgressSpinnerModule, MatSelectModule, MatSnackBarModule, MatTabsModule, MatTooltipModule } from '@angular/material';
-import { AccordionModule, AutoCompleteModule, CarouselModule } from 'primeng/primeng';
+import { MatButtonModule, MatCardModule, MatCheckboxModule, MatIconModule, MatInputModule, MatProgressBarModule, MatProgressSpinnerModule, 
+    MatSelectModule, MatSnackBarModule, MatTabsModule, MatTooltipModule } from '@angular/material';
+import { AccordionModule } from 'primeng/components/accordion/accordion';
+import { AutoCompleteModule } from 'primeng/components/autocomplete/autocomplete';
+import { CarouselModule } from 'primeng/components/carousel/carousel';
 import { ComponentModule } from '../components';
 import { GlobalModule } from '../global/global.module';
 import { AttackPatternsCarouselComponent } from './attack-patterns-carousel/attack-patterns-carousel.component';
@@ -15,30 +18,28 @@ import { IntrusionSetsPanelComponent } from './intrusion-sets-panel/intrusion-se
 import { CollapsibleTreeComponent } from './intrusion-sets-tree/collapsible-tree.component';
 import { IntrusionSetsTreeComponent } from './intrusion-sets-tree/intrusion-sets-tree.component';
 
-
-
 const unfetterComponents = [
+    AttackPatternsCarouselComponent,
+    AttackPatternsLegendComponent,
+    CollapsibleTreeComponent,
+    CriticalSecurityControlsComponent,
     IntrusionSetDashboardComponent,
     IntrusionSetsPanelComponent,
-    CollapsibleTreeComponent,
-    AttackPatternsLegendComponent,
-    AttackPatternsCarouselComponent,
     IntrusionSetsTreeComponent,
-    CriticalSecurityControlsComponent,
 ];
 
 const materialModules = [
     MatButtonModule,
     MatCardModule,
     MatCheckboxModule,
-    MatInputModule,
     MatIconModule,
+    MatInputModule,
+    MatProgressBarModule,
+    MatProgressSpinnerModule,
     MatSelectModule,
     MatSnackBarModule,
-    MatTooltipModule,
     MatTabsModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule
+    MatTooltipModule,
 ];
 
 const primengModules = [

--- a/src/app/settings/stix-objects/categories/categories-list/categories-list.component.spec.ts
+++ b/src/app/settings/stix-objects/categories/categories-list/categories-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatIconModule, MatNativeDateModule, MatProgressSpinnerModule, MatSelectModule } from '@angular/material';
@@ -14,7 +15,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { RouterTestingModule } from '@angular/router/testing';
-import { AccordionModule, CalendarModule, DataListModule } from 'primeng/primeng';
+import { AccordionModule } from 'primeng/components/accordion/accordion';
+import { CalendarModule } from 'primeng/components/calendar/calendar';
+import { DataListModule } from 'primeng/components/datalist/datalist';
 import { ButtonsFilterComponent } from '../../../../components/buttons-filter/buttons-filter.component';
 import { FilterSearchBoxComponent } from '../../../../components/filter-search-box/filter-search-box.component';
 import { ListStixObjectComponent } from '../../../../components/list-stix-objects/list-stix-objects.component';
@@ -27,7 +30,6 @@ import { PublishedCheckboxComponent } from '../../../../global/components/publis
 import { StixService } from '../../../stix.service';
 import { RelationshipNewComponent, RelationshipsComponent } from '../../relationships';
 import { CategoriesListComponent } from './categories-list.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('CategoriesListComponent', () => {
   let component: CategoriesListComponent;
@@ -38,29 +40,29 @@ describe('CategoriesListComponent', () => {
       MatAutocompleteModule,
       MatButtonModule,
       MatCardModule,
-      MatChipsModule,
       MatCheckboxModule,
+      MatChipsModule,
       MatDatepickerModule,
       MatExpansionModule,
-      MatSnackBarModule,
-      MatInputModule,
       MatIconModule,
+      MatInputModule,
       MatListModule,
       MatNativeDateModule,
       MatProgressSpinnerModule,
       MatSelectModule,
+      MatSnackBarModule,
     ];
 
     const stixComponents = [
-      PublishedCheckboxComponent,
-      ListStixObjectComponent,
-      RelationshipsComponent,
-      RelationshipNewComponent,
-      RelationshipListComponent,
-      PageHeaderComponent,
-      ValidationErrorsComponent,
       ButtonsFilterComponent,
       FilterSearchBoxComponent,
+      ListStixObjectComponent,
+      PageHeaderComponent,
+      PublishedCheckboxComponent,
+      RelationshipListComponent,
+      RelationshipNewComponent,
+      RelationshipsComponent,
+      ValidationErrorsComponent,
     ];
 
     TestBed.configureTestingModule({

--- a/src/app/settings/stix.module.ts
+++ b/src/app/settings/stix.module.ts
@@ -1,9 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatAutocompleteModule, MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, MatExpansionModule, MatInputModule, 
-  MatListModule, MatNativeDateModule, MatProgressSpinnerModule, MatRadioModule, MatSelectModule, MatSlideToggleModule, MatSnackBarModule } from '@angular/material';
-import { AccordionModule, CalendarModule, DataListModule } from 'primeng/primeng';
+import { MatAutocompleteModule, MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, 
+  MatExpansionModule, MatInputModule, MatListModule, MatNativeDateModule, MatProgressSpinnerModule, MatRadioModule, 
+  MatSelectModule, MatSlideToggleModule, MatSnackBarModule } from '@angular/material';
+import { AccordionModule } from 'primeng/components/accordion/accordion';
+import { CalendarModule } from 'primeng/components/calendar/calendar';
+import { DataListModule } from 'primeng/components/datalist/datalist';
 import { ComponentModule } from '../components/component.module';
 import { GlobalModule } from '../global/global.module';
 import { IdentifierSummarizedPipe, IdentifierTypePipe } from '../pipes';
@@ -33,11 +36,10 @@ const materialModules = [
   MatAutocompleteModule,
   MatButtonModule,
   MatCardModule,
-  MatChipsModule,
   MatCheckboxModule,
+  MatChipsModule,
   MatDatepickerModule,
   MatExpansionModule,
-  MatSnackBarModule,
   MatInputModule,
   MatListModule,
   MatNativeDateModule,
@@ -45,92 +47,87 @@ const materialModules = [
   MatRadioModule,
   MatSelectModule,
   MatSlideToggleModule,
+  MatSnackBarModule,
 ];
 
 const stixComponents = [
-  AttackPatternsHomeComponent,
-  AttackPatternListComponent,
   AttackPatternComponent,
-  AttackPatternNewComponent,
   AttackPatternEditComponent,
-
-  CategoriesComponent,
-  CategoriesHomeComponent,
-  CategoriesEditComponent,
-  CategoriesListComponent,
-
+  AttackPatternListComponent,
+  AttackPatternNewComponent,
+  AttackPatternsHomeComponent,
+  CampaignComponent,
+  CampaignsEditComponent,
   CampaignsHomeComponent,
   CampaignsListComponent,
   CampaignsNewComponent,
-  CampaignsEditComponent,
-  CampaignComponent,
-
+  CategoriesComponent,
+  CategoriesEditComponent,
+  CategoriesHomeComponent,
+  CategoriesListComponent,
+  CourseOfActionComponent,
+  CourseOfActionEditComponent,
   CourseOfActionHomeComponent,
   CourseOfActionListComponent,
-  CourseOfActionEditComponent,
   CourseOfActionNewComponent,
-  CourseOfActionComponent,
-
-  SightingHomeComponent,
-  SightingListComponent,
-  SightingNewComponent,
-  SightingEditComponent,
-  SightingComponent,
-
+  IdentifierSummarizedPipe,
+  IdentifierTypePipe,
+  IdentityComponent,
+  IdentityEditComponent,
+  IdentityHomeComponent,
+  IdentityListComponent,
+  IdentityNewComponent,
+  IndicatorComponent,
+  IndicatorEditComponent,
+  IndicatorHomeComponent,
+  IndicatorListComponent,
+  IndicatorNewComponent,
+  IntrusionSetComponent,
+  IntrusionSetEditComponent,
+  IntrusionSetHomeComponent,
+  IntrusionSetListComponent,
+  IntrusionSetNewComponent,
+  IntrusionUsesAttackComponent,
+  LinkExplorerComponent,
+  MalwareComponent,
+  MalwareEditComponent,
+  MalwareHomeComponent,
+  MalwareListComponent,
+  MalwareNewComponent,
+  MitigateComponent,
+  MitigateListComponent,
+  RelationshipNewComponent,
+  RelationshipsComponent,
+  ReportNewComponent,
+  ReportsComponent,
+  ReportsListComponent,
+  SensorComponent,
+  SensorEditComponent,
   SensorHomeComponent,
   SensorListComponent,
   SensorNewComponent,
-  SensorEditComponent,
-  SensorComponent,
-
-  ReportsComponent,
-  ReportsListComponent,
-  ReportNewComponent,
-
+  SightingComponent,
+  SightingEditComponent,
+  SightingHomeComponent,
+  SightingListComponent,
+  SightingNewComponent,
+  StixHomeComponent,
+  ThreatActorEditComponent,
   ThreatActorHomeComponent,
   ThreatActorListComponent,
-  ThreatActorsComponent,
   ThreatActorNewComponent,
-  ThreatActorEditComponent,
-
-  IntrusionSetHomeComponent,
-  IntrusionSetListComponent,
-  IntrusionSetComponent,
-  IntrusionSetEditComponent,
-  IntrusionSetNewComponent,
-
-  MitigateListComponent,
-  MitigateComponent,
-  IntrusionUsesAttackComponent,
-  IndicatorHomeComponent,
-  IndicatorListComponent,
-  IndicatorEditComponent,
-  IndicatorNewComponent,
-  IndicatorComponent,
-
-  IdentityHomeComponent,
-  IdentityListComponent,
-  IdentityEditComponent,
-  IdentityNewComponent,
-  IdentityComponent,
-
-  IdentifierTypePipe,
-  IdentifierSummarizedPipe,
-
-  MalwareHomeComponent,
-  MalwareListComponent,
-  MalwareEditComponent,
-  MalwareComponent,
-  MalwareNewComponent,
-  RelationshipsComponent,
-  RelationshipNewComponent,
-  ToolHomeComponent,
-  ToolListComponent,
+  ThreatActorsComponent,
   ToolComponent,
   ToolEditComponent,
+  ToolHomeComponent,
+  ToolListComponent,
   ToolNewComponent,
-  LinkExplorerComponent,
-  StixHomeComponent
+];
+
+const primengModules = [
+  AccordionModule,
+  CalendarModule,
+  DataListModule,
 ];
 
 @NgModule({
@@ -140,9 +137,7 @@ const stixComponents = [
     ReactiveFormsModule,
     ...materialModules,
     ComponentModule,
-    CalendarModule,
-    AccordionModule,
-    DataListModule,
+    ...primengModules,
     GlobalModule,
     routing,
   ],

--- a/src/app/threat-dashboard/threat-dashboard.module.ts
+++ b/src/app/threat-dashboard/threat-dashboard.module.ts
@@ -3,11 +3,10 @@ import { PlatformModule } from '@angular/cdk/platform';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, MatDialogModule, 
-  MatExpansionModule, MatFormFieldModule, MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatNativeDateModule, 
-  MatPaginatorModule, MatProgressBarModule, MatSelectModule, MatSlideToggleModule, MatSnackBarModule, MatStepperModule, MatTableModule, 
-  MatTabsModule, MatTooltipModule } from '@angular/material';
-import { CarouselModule } from 'primeng/primeng';
+import { MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, MatDialogModule, MatExpansionModule, 
+  MatFormFieldModule, MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatNativeDateModule, MatPaginatorModule, MatProgressBarModule, 
+  MatSelectModule, MatSlideToggleModule, MatSnackBarModule, MatStepperModule, MatTableModule, MatTabsModule, MatTooltipModule } from '@angular/material';
+import { CarouselModule } from 'primeng/components/carousel/carousel';
 import { GlobalModule } from '../global/global.module';
 import { BarChartComponent } from './bar-chart/bar-chart.component';
 import { CollapsibleTreeComponent } from './collapsible-tree/collapsible-tree.component';
@@ -31,17 +30,17 @@ const moduleComponents = [
   ExportComponent,
   KillChainTableComponent,
   RadarChartComponent,
-  ThreatDashboardComponent,
-  ThreatReportEditorComponent,
   ReportEditorComponent,
   ReportImporterComponent,
+  ThreatDashboardComponent,
+  ThreatReportEditorComponent,
 ];
 
 const moduleServices = [
-  ThreatReportOverviewService,
-  ThreatReportSharedService,
   ReportTranslationService,
   ReportUploadService,
+  ThreatReportOverviewService,
+  ThreatReportSharedService,
 ];
 
 const materialModules = [
@@ -71,7 +70,9 @@ const materialModules = [
   PlatformModule,
 ];
 
-const primengModules = [CarouselModule];
+const primengModules = [
+  CarouselModule,
+];
 
 @NgModule({
   declarations: [

--- a/src/rxjs-operators.ts
+++ b/src/rxjs-operators.ts
@@ -1,4 +1,3 @@
-// Statics
 import 'rxjs/add/observable/combineLatest';
 import 'rxjs/add/observable/concat';
 import 'rxjs/add/observable/empty';
@@ -10,7 +9,6 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/observable/zip';
-// Operators
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/concat';
 import 'rxjs/add/operator/concatAll';
@@ -33,8 +31,8 @@ import 'rxjs/add/operator/mapTo';
 import 'rxjs/add/operator/merge';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/multicast';
-import 'rxjs/add/operator/partition';
 import 'rxjs/add/operator/pairwise';
+import 'rxjs/add/operator/partition';
 import 'rxjs/add/operator/pluck';
 import 'rxjs/add/operator/reduce';
 import 'rxjs/add/operator/share';
@@ -49,3 +47,4 @@ import 'rxjs/add/operator/toPromise';
 import 'rxjs/add/operator/withLatestFrom';
 import 'rxjs/add/operator/zip';
 import 'rxjs/operators/tap';
+import 'rxjs/util/pipe';


### PR DESCRIPTION
fixes unfetter-discover/unfetter#991

# problem
the vendor bundle is big, with lots of unnecessary primeng components

# solution
change imports for better tree shaking

# test
run `npm run analyze:dev` verify you see smaller vendor footprint
run the ui, make sure it works

# before 
![screen shot 2018-04-26 at 2 25 25 pm](https://user-images.githubusercontent.com/30807406/39324606-ea6af9de-495d-11e8-8eba-2cbb204d4867.png)

# after
![screen shot 2018-04-26 at 2 25 35 pm](https://user-images.githubusercontent.com/30807406/39324615-f092aed8-495d-11e8-8813-cf439e8c53dc.png)

