### PR TITLE
add attack patterns to baseline wizard store

### DIFF
--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -20,8 +20,8 @@ import { UserProfile } from '../../../models/user/user-profile';
 import { AppState } from '../../../root-store/app.reducers';
 import { Constance } from '../../../utils/constance';
 import { LoadAssessmentsByRollupId } from '../result/store/full-result.actions';
-import { CleanAssessmentWizardData, LoadAssessmentWizardData, SaveAssessment, UpdatePageTitle } from '../store/assess.actions';
 import { FullAssessmentResultState } from '../result/store/full-result.reducers';
+import { CleanAssessmentWizardData, LoadAssessmentWizardData, SaveAssessment, UpdatePageTitle } from '../store/assess.actions';
 import * as assessReducers from '../store/assess.reducers';
 import { Measurements } from './models/measurements';
 import { SidePanelName } from './models/side-panel-name.enum';
@@ -111,16 +111,16 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   private readonly sidePanelOrder: SidePanelName[] = ['indicators', 'mitigations', 'sensors', 'summary'];
 
   constructor(
+    private assessStore: Store<FullAssessmentResultState>,
+    private changeDetection: ChangeDetectorRef,
     private genericApi: GenericApi,
-    private snackBar: MatSnackBar,
     private location: Location,
+    private renderer: Renderer2,
     private route: ActivatedRoute,
     private router: Router,
-    private renderer: Renderer2,
+    private snackBar: MatSnackBar,
     private userStore: Store<AppState>,
-    private assessStore: Store<FullAssessmentResultState>,
     private wizardStore: Store<assessReducers.AssessState>,
-    private changeDetection: ChangeDetectorRef
   ) {
     super();
     this.CHART_TYPE = 'doughnut';

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -1,26 +1,28 @@
 import { Action } from '@ngrx/store';
-import { BaselineMeta } from '../../models/baseline/baseline-meta';
-import { Stix } from '../../models/stix/stix';
-import { JsonApiData } from '../../models/json/jsonapi-data';
-import { Baseline } from '../../models/baseline/baseline';
 import { Category } from 'stix';
+import { AttackPattern } from 'stix/unfetter/attack-pattern';
+import { Baseline } from '../../models/baseline/baseline';
+import { BaselineMeta } from '../../models/baseline/baseline-meta';
 
 // For effects
-export const START_ASSESSMENT = '[Baseline] START_ASSESSMENT';
-export const START_ASSESSMENT_SUCCESS = '[Baseline] START_ASSESSMENT_SUCCESS';
-export const SAVE_ASSESSMENT = '[Baseline] SAVE_ASSESSMENT';
-export const LOAD_ASSESSMENT_WIZARD_DATA = '[Baseline] LOAD_ASSESSMENT_WIZARD_DATA';
 export const CLEAN_ASSESSMENT_WIZARD_DATA = '[Baseline] CLEAN_ASSESSMENT_WIZARD_DATA';
 export const FETCH_ASSESSMENT = '[Baseline] FETCH_ASSESSMENT';
+export const FETCH_ATTACK_PATTERNS = '[Baseline] FETCH_ATTACK_PATTERNS';
 export const FETCH_CATEGORIES = '[Baseline] FETCH_CATEGORIES';
-export const SET_CATEGORIES = '[Baseline] SET_CATEGORIES';
-export const SET_CATEGORY_STEPS = '[Baseline] SET_CATEGORY_STEPS';
+export const LOAD_ASSESSMENT_WIZARD_DATA = '[Baseline] LOAD_ASSESSMENT_WIZARD_DATA';
+export const SAVE_ASSESSMENT = '[Baseline] SAVE_ASSESSMENT';
+export const START_ASSESSMENT = '[Baseline] START_ASSESSMENT';
+export const START_ASSESSMENT_SUCCESS = '[Baseline] START_ASSESSMENT_SUCCESS';
 
 // For reducers
-export const UPDATE_PAGE_TITLE = '[Baseline] UPDATE_PAGE_TITLE';
 export const ANSWER_QUESTION = '[Baseline] ANSWER_QUESTION';
 export const FINISHED_LOADING = '[Baseline] FINISHED_LOADING';
 export const FINISHED_SAVING = '[Baseline] FINISHED_SAVING';
+export const SET_ATTACK_PATTERNS = '[Baseline] SET_ATTACK_PATTERNS';
+export const SET_CATEGORIES = '[Baseline] SET_CATEGORIES';
+export const SET_CATEGORY_STEPS = '[Baseline] SET_CATEGORY_STEPS';
+export const SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS = '[Baseline] SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS';
+export const UPDATE_PAGE_TITLE = '[Baseline] UPDATE_PAGE_TITLE';
 export const WIZARD_PAGE = '[Baseline] WIZARD_PAGE';
 
 export class UpdatePageTitle implements Action {
@@ -59,10 +61,25 @@ export class FetchCategories implements Action {
     constructor() { }
 }
 
+export class FetchAttackPatterns implements Action {
+    public readonly type = FETCH_ATTACK_PATTERNS;
+    constructor(public payload?: string) { }
+}
+
 export class SetCategories implements Action {
     public readonly type = SET_CATEGORIES;
-
     constructor(public payload: Category[]) { }
+}
+
+export class SetAttackPatterns implements Action {
+    public readonly type = SET_ATTACK_PATTERNS;
+    constructor(public payload: AttackPattern[]) { }
+}
+
+export class SetSelectedFrameworkAttackPatterns implements Action {
+    public readonly type = SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS;
+
+    constructor(public payload: AttackPattern[]) { }
 }
 
 export class SetCategorySteps implements Action {
@@ -104,19 +121,21 @@ export class CleanAssessmentWizardData {
 
     constructor() { }
 }
-
 export type AssessmentActions =
     AnswerQuestion |
     CleanAssessmentWizardData |
     FetchAssessment |
+    FetchAttackPatterns |
     FetchCategories |
-    SetCategories |
-    SetCategorySteps |
     FinishedLoading |
     FinishedSaving |
     LoadAssessmentWizardData |
+    SaveAssessment |
+    SetAttackPatterns |
+    SetCategories |
+    SetCategorySteps |
+    SetSelectedFrameworkAttackPatterns |
     StartAssessment |
     StartAssessmentSuccess |
-    SaveAssessment |
     UpdatePageTitle |
     WizardPage;

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -1,38 +1,39 @@
-import * as baselineActions from './baseline.actions';
-import * as fromApp from '../../root-store/app.reducers'
-import { Baseline } from '../../models/baseline/baseline';
-import { Stix } from '../../models/stix/stix';
-import { JsonApiData } from '../../models/json/jsonapi-data';
 import { Category } from 'stix';
+import { AttackPattern } from 'stix/unfetter/attack-pattern';
+import { Baseline } from '../../models/baseline/baseline';
+import * as fromApp from '../../root-store/app.reducers';
 import { CategoryComponent } from '../wizard/category/category.component';
+import * as baselineActions from './baseline.actions';
 
 export interface BaselineFeatureState extends fromApp.AppState {
     baseline: Baseline
 };
 
 export interface BaselineState {
-    baseline: Baseline;
+    allAttackPatterns?: AttackPattern[];
     backButton: boolean;
+    baseline: Baseline;
     categories: Category[];
     categorySteps: Category[];
-    // TODO: add attack pattern array
-    // attackPatterns?: JsonApiData<AttackPattern>[];
     finishedLoading: boolean;
-    saved: { finished: boolean, id: string };
-    showSummary: boolean;
     page: number;
+    saved: { finished: boolean, id: string };
+    selectedFrameworkAttackPatterns?: AttackPattern[];
+    showSummary: boolean;
 };
 
 const genAssessState = (state?: Partial<BaselineState>) => {
     const tmp = {
-        baseline: new Baseline(),
+        allAttackPatterns: [],
         backButton: false,
+        baseline: new Baseline(),
         categories: [],
-        categorySteps: [ CategoryComponent.DEFAULT_VALUE ],
+        categorySteps: [CategoryComponent.DEFAULT_VALUE],
         finishedLoading: false,
-        saved: { finished: false, id: '' },
-        showSummary: false,
         page: 1,
+        saved: { finished: false, id: '' },
+        selectedFrameworkAttackPatterns: [],
+        showSummary: false,
     };
     if (state) {
         Object.assign(tmp, state);
@@ -59,7 +60,17 @@ export function baselineReducer(state = initialState, action: baselineActions.As
                 ...state,
                 categorySteps: [...action.payload],
             });
-         case baselineActions.START_ASSESSMENT:
+        case baselineActions.SET_ATTACK_PATTERNS:
+            return genAssessState({
+                ...state,
+                allAttackPatterns: [...action.payload],
+            });
+        case baselineActions.SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS:
+            return genAssessState({
+                ...state,
+                selectedFrameworkAttackPatterns: [...action.payload],
+            });
+        case baselineActions.START_ASSESSMENT:
             const a0 = new Baseline();
             a0.baselineMeta = { ...action.payload };
             return genAssessState({

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -102,7 +102,7 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
       return CategoryComponent.DEFAULT_VALUE;
     } else {
       const selIndex = this.categories.findIndex(category => category.id === selValue.id);
-      console.log(`value is -` + JSON.stringify(selValue) + `- and index is ` + selIndex);
+      // console.log(`value is -` + JSON.stringify(selValue) + `- and index is ` + selIndex);
       return this.categories[selIndex];
     }
   }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,15 +1,14 @@
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { ModuleWithProviders, NgModule } from '@angular/core';
+import { AttackPatternService } from './services/attack-pattern.service';
 import { AuthInterceptor } from './services/auth-interceptor.service';
 import { AuthGuard } from './services/auth.guard';
 import { AuthService } from './services/auth.service';
 import { ConfigService } from './services/config.service';
 import { GenericApi } from './services/genericapi.service';
+import { UserPreferencesService } from './services/user-preferences.service';
 import { UsersService } from './services/users.service';
 import { WebsocketService } from './services/web-socket.service';
-import { UserPreferences } from '../models/user/user-preferences';
-import { UserPreferencesService } from './services/user-preferences.service';
-
 
 @NgModule({
 })
@@ -21,6 +20,7 @@ export class CoreModule {
                 GenericApi,
                 AuthGuard,
                 AuthService,
+                AttackPatternService,
                 ConfigService,
                 UsersService,
                 UserPreferencesService,

--- a/src/app/core/services/attack-pattern.service.ts
+++ b/src/app/core/services/attack-pattern.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, Optional, SkipSelf } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import * as Stix from 'stix/unfetter/attack-pattern';
+import { AttackPattern } from '../../models';
+import { UserProfile } from '../../models/user/user-profile';
+import { Constance } from '../../utils/constance';
+import { GenericApi } from './genericapi.service';
+
+@Injectable()
+export class AttackPatternService {
+
+    constructor(
+        protected genericApiService: GenericApi,
+        @SkipSelf() @Optional() protected parent: AttackPatternService
+    ) {
+        if (parent) {
+            throw new Error(
+                'AttackPatternService is already loaded. Import it in one module only');
+        }
+    }
+
+    /**
+     * @description fetch by framework if it is given, otherwise get all the attack patterns across frameworks
+     * @param  {UserProfile} userProfile
+     * @returns Observable<Stix.AttackPattern[]>
+     */
+    public fetchAttackPatterns(userFramework?: string): Observable<Stix.AttackPattern[]> {
+        return this.fetchByFramework(userFramework)
+            .map((el) => {
+                return el.map((_) => Object.assign(new Stix.AttackPattern(), _.attributes));
+            });
+    }
+
+    /**
+     * @deprecated uses the old AttackPattern model, use the new stix models
+     * @see fetchAttackPatterns
+     * @see Stix.AttackPattern
+     * @description fetch by framework if it is given, otherwise get all the attack patterns across frameworks
+     * @param  {string} userFramework?
+     * @returns Observable<AttackPattern[]>
+     */
+    public fetchAttackPatterns1(userFramework?: string): Observable<AttackPattern[]> {
+        return this.fetchByFramework(userFramework);
+    }
+
+    /**
+     * @description fetch by framework if it is given, otherwise get all the attack patterns across frameworks
+     * @param  {string} userFramework?
+     * @returns Observable<AttackPattern[]>
+     */
+    public fetchByFramework(userFramework?: string): Observable<AttackPattern[]> {
+        let url = '';
+        const sort = `sort=${encodeURIComponent(JSON.stringify({ name: '1' }))}`;
+        const projectConfig = {
+            'stix.name': 1,
+            'stix.description': 1,
+            'stix.kill_chain_phases': 1,
+            'extendedProperties.x_mitre_data_sources': 1,
+            'extendedProperties.x_mitre_platforms': 1,
+            'stix.id': 1
+        };
+        const project = `project=${encodeURI(JSON.stringify(projectConfig))}`;
+        if (userFramework) {
+            const userFrameworkFilter = { 'stix.kill_chain_phases.kill_chain_name': { $exists: true, $eq: userFramework } };
+            const filter = 'filter=' + encodeURIComponent(JSON.stringify(userFrameworkFilter));
+            url = `${Constance.ATTACK_PATTERN_URL}?${filter}&${project}&${sort}`;
+        } else {
+            url = `${Constance.ATTACK_PATTERN_URL}?${project}&${sort}`;
+        }
+        return this.genericApiService.getAs<AttackPattern[]>(url);
+    }
+}

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -5,6 +5,7 @@ import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { ConfirmationDialogComponent } from '../components/dialogs/confirmation/confirmation-dialog.component';
+import { AttackPatternService } from '../core/services/attack-pattern.service';
 import { GenericApi } from '../core/services/genericapi.service';
 import { simpleFadeIn, slideInOutAnimation } from '../global/animations/animations';
 import { MasterListDialogTableHeaders } from '../global/components/master-list-dialog/master-list-dialog.component';
@@ -82,14 +83,15 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
   };
 
   constructor(
-    protected router: Router,
-    protected route: ActivatedRoute,
-    protected genericApi: GenericApi,
+    protected attackPatternService: AttackPatternService,
     protected dialog: MatDialog,
+    protected genericApi: GenericApi,
     protected renderer: Renderer2,
-    protected threatReportService: ThreatReportOverviewService,
+    protected route: ActivatedRoute,
+    protected router: Router,
     protected sharedService: ThreatReportSharedService,
-    private userStore: Store<AppState>,
+    protected threatReportService: ThreatReportOverviewService,
+    protected userStore: Store<AppState>,
   ) { }
 
   /**
@@ -107,24 +109,24 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
       .subscribe(
         (id: string) => {
           const getUser$ = this.userStore
-          .select('users')
-          .pluck('userProfile')
-          .take(1)
-          .subscribe((user: UserProfile) => {
-            this.user = user;
-            this.threatReport = null;
-            if (!id || id.trim() === '') {
-              this.notifyDoneLoading();
-            } else {
-              id = id.trim();
-              if (!this.id || (id !== this.id)) {
-                this.id = id.trim();
-                this.fetchDataAndRender();
+            .select('users')
+            .pluck('userProfile')
+            .take(1)
+            .subscribe((user: UserProfile) => {
+              this.user = user;
+              this.threatReport = null;
+              if (!id || id.trim() === '') {
+                this.notifyDoneLoading();
+              } else {
+                id = id.trim();
+                if (!this.id || (id !== this.id)) {
+                  this.id = id.trim();
+                  this.fetchDataAndRender();
+                }
               }
-            }
-          },
-            (err) => console.log(err));
-        this.subscriptions.push(getUser$);
+            },
+              (err) => console.log(err));
+          this.subscriptions.push(getUser$);
         },
         (err) => {
           console.log(err);
@@ -261,28 +263,9 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
    * @return {Observable<any>}
    */
   public loadAttackPatterns(): Observable<AttackPattern[]> {
-    let filter = '';
-    if (this.user && this.user.preferences && this.user.preferences.killchain) {
-      const userFramework = this.user.preferences.killchain;
-      const userFrameworkFilter = { 'stix.kill_chain_phases.kill_chain_name': { $exists: true, $eq: userFramework } };
-      filter = 'filter=' + encodeURIComponent(JSON.stringify(userFrameworkFilter));
-    }
-    const projects = {
-      'stix.name': 1,
-      'stix.description': 1,
-      'stix.kill_chain_phases': 1,
-      'extendedProperties.x_mitre_data_sources': 1,
-      'extendedProperties.x_mitre_platforms': 1,
-      'stix.id': 1
-    };
-    const project = `project=${encodeURI(JSON.stringify(projects))}`;
-    let url = '';
-    if (filter) {
-      url = `${Constance.ATTACK_PATTERN_URL}?${filter}&${project}&${this.sort}`;
-    }else {
-      url = `${Constance.ATTACK_PATTERN_URL}?${project}&${this.sort}`;
-    }
-    return this.genericApi.get(url)
+    const userFramework = (this.user && this.user.preferences && this.user.preferences.killchain)
+      ? this.user.preferences.killchain : '';
+    return this.attackPatternService.fetchAttackPatterns1(userFramework)
       .map((el) => this.attackPatterns = el)
       .do(() => {
         this.uniqChainNames = this.generateUniqChainNames(this.attackPatterns);

--- a/src/app/threat-dashboard/threat-report-editor/report-editor/report-editor.component.spec.ts
+++ b/src/app/threat-dashboard/threat-report-editor/report-editor/report-editor.component.spec.ts
@@ -3,14 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatChipsModule, MatDialogModule, MatDialogRef, MatFormFieldModule, MatIconModule, MatOptionModule, MatSelectModule } from '@angular/material';
 import { ActionReducerMap, StoreModule } from '@ngrx/store';
+import { BaseComponentService } from '../../../components/base-service.component';
+import { AttackPatternService } from '../../../core/services/attack-pattern.service';
 import { GenericApi } from '../../../core/services/genericapi.service';
-import { GlobalModule } from '../../../global/global.module';
+import { CreatedByRefComponent } from '../../../global/components/created-by-ref/created-by-ref.component';
 import { AttackPattern } from '../../../models/attack-pattern';
 import { Report } from '../../../models/report';
 import { ExternalReference } from '../../../models/stix/external_reference';
 import { ReportEditorComponent } from './report-editor.component';
-import { CreatedByRefComponent } from '../../../global/components/created-by-ref/created-by-ref.component';
-import { BaseComponentService } from '../../../components/base-service.component';
 
 describe('ReportEditorComponent', () => {
 
@@ -49,14 +49,15 @@ describe('ReportEditorComponent', () => {
                 CreatedByRefComponent,
             ],
             imports: [
-                HttpClientTestingModule, 
+                HttpClientTestingModule,
                 FormsModule,
                 ...materialModules,
                 StoreModule.forRoot(mockReducer),
             ],
             providers: [
-                GenericApi,
+                AttackPatternService,
                 BaseComponentService,
+                GenericApi,
                 { provide: MAT_DIALOG_DATA, useValue: {} },
                 {
                     provide: MatDialogRef,


### PR DESCRIPTION
**to be merged by @sbertrandmitre or team**  

Note: Travis now will report `@deprecated` jsdoc tag warnings. The build should still pass.

fixes unfetter-discover/unfetter#1002

# problem
categories builder needs to display attack pattern information on edit.  For a new category builder page, the attack patterns could come from the heatmap, but cannot assume that will be clicked for an edit

# solution
add attack patterns to the baseline wizard store.  Contains 2 fields, the first is `allAttackPatterns` the second is `selectedFrameworkAttackPatterns`. Also refactors fetching the attack patterns to share w/ existing code.  Store uses the stix module attack patterns

# test
visit the baseline
open redux tools
create the metadata and click next
on the wizard page notice in redux tools that `allAttackPatterns` and `selectedFrameworkAttackPatterns` are populated
verify threat dashboard still works due to refactoring
  create a report
  create a workproduct