### PR TITLE
Baseline wizard heatmap

### DIFF
--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
@@ -4,7 +4,7 @@
         <span class="flex1"></span>
         <button mat-button (click)="clearSelections()">CLEAR</button>
         <button mat-button [mat-dialog-close]="false">CANCEL</button>
-        <button mat-raised-button color="primary" [mat-dialog-close]="onClose()">SUBMIT</button>
+        <button mat-raised-button color="primary" (click)="close()">SUBMIT</button>
     </div>
 </h2>
 <mat-dialog-content>

--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.scss
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.scss
@@ -36,12 +36,20 @@ $white: #FFFFFF;
             cursor: pointer;
         }
 
+        .heat-map-header rect.odd, .heat-map-batch rect.odd {
+            fill: $assessments-primary-lightest;
+        }
+
         .heat-map-header rect.active, .heat-map-batch rect.active {
             fill: $assessments-primary-lightest;
         }
 
         .heat-map-cell rect.selected {
             fill: $assessments-primary;
+        }
+
+        .heat-map-cell rect.active {
+            fill: $assessments-primary-light;
         }
     }
 }

--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.spec.ts
@@ -69,7 +69,7 @@ describe('AttackPatternChooserComponent', () => {
                 AuthService,
                 {
                     provide: MAT_DIALOG_DATA,
-                    useValue: {active: [mockAttackPatterns[1].id]}
+                    useValue: {active: null}
                 },
                 {
                     provide: MatDialogRef,

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -755,16 +755,19 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
         disableClose: false,
         closeOnNavigation: true,
         data: {
-          active: this.selectedFrameworkAttackPatterns,
+          active: null, // @todo This needs to be replaced with the current capability's list of attack patterns!!
+                        //       The current model appears to have no hook for this.
         },
       });
 
-      const sub$ = dialog.afterClosed().subscribe((result) => {
-        if (result) {
-          this.selectedAttackPatterns = result;
-        }
-        this.showHeatmap = false;
-      },
+      const sub$ = dialog.afterClosed().subscribe(
+        (result) => {
+          if (result) {
+            console.log('selected patterns', result);
+            this.selectedAttackPatterns = result;
+          }
+          this.showHeatmap = false;
+        },
         (err) => console.log(err),
       );
       this.subscriptions.push(sub$);

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heatmap-filter.component.html
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heatmap-filter.component.html
@@ -7,5 +7,5 @@
 </mat-dialog-content>
 <mat-dialog-actions>
     <button mat-button [mat-dialog-close]="false">CANCEL</button>
-    <button mat-raised-button color="primary" [mat-dialog-close]="close()">ACCEPT</button>
+    <button mat-raised-button color="primary" (click)="close()">ACCEPT</button>
 </mat-dialog-actions>

--- a/src/app/indicator-sharing/indicator-heat-map/indicator-heatmap-filter.component.ts
+++ b/src/app/indicator-sharing/indicator-heat-map/indicator-heatmap-filter.component.ts
@@ -58,6 +58,7 @@ export class IndicatorHeatMapFilterComponent implements AfterViewInit {
 
     public attackPatterns = [];
     public selectedPatterns = [];
+    private _selections: string[] = [];
 
     @ViewChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
     private overlayRef: OverlayRef;
@@ -122,6 +123,11 @@ export class IndicatorHeatMapFilterComponent implements AfterViewInit {
     }
 
     /**
+     * @description 
+     */
+    public get selections() { return this._selections; }
+
+    /**
      * @description for selecting and deselecting attack patterns
      */
     public toggleAttackPattern(clicked?: TooltipEvent) {
@@ -136,20 +142,23 @@ export class IndicatorHeatMapFilterComponent implements AfterViewInit {
                 newValue = 'inactive';
                 this.selectedPatterns.splice(index, 1);
             }
-            const target = this.attackPatterns.find(p => p.name === clicked.data.name);
-            if (target) {
-                target.adds.highlights[0].color.style = newValue;
-                this.attackPatterns = this.attackPatterns.slice(0);
-                this.heatmap.redraw();
-            }
+            this.heatmap.view.helper['heatmap'].workspace.data.forEach(batch => {
+                batch.cells.forEach(cell => {
+                    if (cell.id === clicked.data.id) {
+                        cell.value = newValue;
+                    }
+                });
+            });
+            this.heatmap.view.helper.updateCells();
         }
     }
 
     /**
      * @description retrieve the list of selected attack pattern names
      */
-    public close(): string[] {
-        return Array.from(new Set(this.selectedPatterns.map(pattern => pattern.id)));
+    public close() {
+        this._selections = Array.from(new Set(this.selectedPatterns.map(pattern => pattern.id)));
+        this.dialogRef.close(this.selections);
     }
   
 }

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.spec.ts
@@ -12,7 +12,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IndicatorSharingService } from '../indicator-sharing.service';
 import { Observable } from 'rxjs/Observable';
 
-
 describe('IndicatorSharingListComponent', () => {
     let component: IndicatorSharingListComponent;
     let fixture: ComponentFixture<IndicatorSharingListComponent>;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1046.

Heatmap overlay should now render on the baseline wizard. Selections can be made. On submit, console will show IDs of the selected patterns.

Note there are currently no hooks to determine the attack patterns currently on the displayed capability, and no hook to assign the selected attack patterns to the current capability. Also, we may want a confirmation dialog if the user is deselecting any attack patterns that have been "assessed." These will need to be handled in future issues.