### PR TITLE
allow for edit of beta assessments

### DIFF
--- a/src/app/assess/v3/result/store/full-result.actions.ts
+++ b/src/app/assess/v3/result/store/full-result.actions.ts
@@ -1,33 +1,31 @@
 import { Action } from '@ngrx/store';
-import { Assessment } from 'stix/assess/v3/assessment';
 import { AssessmentObject } from 'stix/assess/v2/assessment-object';
 import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
+import { Assessment } from 'stix/assess/v3/assessment';
 import { Stix } from 'stix/unfetter/stix';
 import { Relationship } from '../../../../models';
 
 // For effects
 export const LOAD_ASSESSMENTS_BY_ROLLUP_ID = '[Assess Result] LOAD_ASSESSMENTS_BY_ROLLUP_ID';
 export const LOAD_ASSESSMENT_BY_ID = '[Assess Result] LOAD_ASSESSMENT_BY_ID';
-export const LOAD_GROUP_DATA = '[Assess Result Group] LOAD_GROUP_DATA';
-export const LOAD_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] LOAD_GROUP_CURRENT_ATTACK_PATTERN';
 export const LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] LOAD_ATTACK_PATTERN_RELATIONSHIPS';
-
+export const LOAD_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] LOAD_GROUP_CURRENT_ATTACK_PATTERN';
+export const LOAD_GROUP_DATA = '[Assess Result Group] LOAD_GROUP_DATA';
 export const UPDATE_ASSESSMENT_OBJECT = '[Assess Result Group] UPDATE_ASSESSMENT_OBJECT';
 
-
 // For reducers
-export const SET_ASSESSMENTS = '[Assess Result] SET_ASSESSMENTS';
-export const SET_ASSESSMENT = '[Assess Result] SET_ASSESSMENT';
-export const SET_GROUP_DATA = '[Assess Result Group] SET_GROUP_DATA';
-export const SET_GROUP_ASSESSMENT_OBJECTS = '[Assess Result Group] SET_GROUP_ASSESSMENT_OBJECTS_DATA';
-export const SET_GROUP_RISK_BY_ATTACK_PATTERN = '[Assess Result Group] SET_RISK_BY_ATTACK_PATTERN';
-export const SET_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] SET_GROUP_CURRENT_ATTACK_PATTERN';
-export const SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS';
-export const PUSH_URL = '[Assess Result] PUSH_URL';
-export const DONE_PUSH_URL = '[Assess Result] DONE_PUSH_URL';
 export const CLEAN_ASSESSMENT_RESULT_DATA = '[Assess Result Group] CLEAN_ASSESSMENT_RESULT_DATA';
+export const DONE_PUSH_URL = '[Assess Result] DONE_PUSH_URL';
 export const FINISHED_LOADING = '[Assess Result] FINISHED_LOADING';
+export const PUSH_URL = '[Assess Result] PUSH_URL';
 export const RELOAD_AFTER_UPDATE_ASSESSMENT_OBJECT = '[Assess Result Group] RELOAD_AFTER_UPDATE_ASSESSMENT_OBJECT';
+export const SET_ASSESSMENT = '[Assess Result] SET_ASSESSMENT';
+export const SET_ASSESSMENTS = '[Assess Result] SET_ASSESSMENTS';
+export const SET_GROUP_ASSESSMENT_OBJECTS = '[Assess Result Group] SET_GROUP_ASSESSMENT_OBJECTS_DATA';
+export const SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS = '[Assess Result Group] SET_GROUP_ATTACK_PATTERN_RELATIONSHIPS';
+export const SET_GROUP_CURRENT_ATTACK_PATTERN = '[Assess Result Group] SET_GROUP_CURRENT_ATTACK_PATTERN';
+export const SET_GROUP_DATA = '[Assess Result Group] SET_GROUP_DATA';
+export const SET_GROUP_RISK_BY_ATTACK_PATTERN = '[Assess Result Group] SET_RISK_BY_ATTACK_PATTERN';
 
 export class SetAssessments implements Action {
     public readonly type = SET_ASSESSMENTS;
@@ -139,19 +137,19 @@ export type FullAssessmentResultActions =
     CleanAssessmentResultData |
     DonePushUrl |
     FinishedLoading |
-    LoadAssessmentsByRollupId |
     LoadAssessmentById |
-    LoadGroupData |
-    LoadGroupCurrentAttackPattern |
+    LoadAssessmentsByRollupId |
     LoadGroupAttackPatternRelationships |
+    LoadGroupCurrentAttackPattern |
+    LoadGroupData |
     PushUrl |
     ReloadAfterAssessmentObjectUpdate |
-    SetAssessments |
     SetAssessment |
-    SetGroupData |
+    SetAssessments |
     SetGroupAssessedObjects |
     SetGroupAttackPatternRelationships |
-    SetGroupRiskByAttackPattern |
     SetGroupCurrentAttackPattern |
+    SetGroupData |
+    SetGroupRiskByAttackPattern |
     UpdateAssessmentObject;
 

--- a/src/app/assess/v3/store/assess.actions.ts
+++ b/src/app/assess/v3/store/assess.actions.ts
@@ -8,16 +8,13 @@ import { Indicator } from 'stix/stix/indicator';
 import { Stix } from 'stix/unfetter/stix';
 
 // For effects
-export const CLEAN_ASSESSMENT_WIZARD_DATA =
-  '[Assess] CLEAN_ASSESSMENT_WIZARD_DATA';
+export const CLEAN_ASSESSMENT_WIZARD_DATA = '[Assess] CLEAN_ASSESSMENT_WIZARD_DATA';
 export const FAILED_TO_LOAD = '[Assess] FAILED_TO_LOAD';
 export const FETCH_ASSESSMENT = '[Assess] FETCH_ASSESSMENT';
 export const FETCH_CAPABILITIES = '[Assess] FETCH_CAPABILITIES';
-export const LOAD_ASSESSMENT_WIZARD_DATA =
-  '[Assess] LOAD_ASSESSMENT_WIZARD_DATA';
+export const LOAD_ASSESSMENT_WIZARD_DATA = '[Assess] LOAD_ASSESSMENT_WIZARD_DATA';
 export const LOAD_BASELINES = '[Assess] LOAD_BASELINES';
-export const LOAD_CURRENT_BASELINE_QUESTIONS =
-  '[Assess] LOAD_CURRENT_BASELINE_QUESTIONS';
+export const LOAD_CURRENT_BASELINE_QUESTIONS = '[Assess] LOAD_CURRENT_BASELINE_QUESTIONS';
 export const SAVE_ASSESSMENT = '[Assess] SAVE_ASSESSMENT';
 export const START_ASSESSMENT = '[Assess] START_ASSESSMENT';
 export const START_ASSESSMENT_SUCCESS = '[Assess] START_ASSESSMENT_SUCCESS';
@@ -27,25 +24,24 @@ export const ANSWER_QUESTION = '[Assess] ANSWER_QUESTION';
 export const FINISHED_LOADING = '[Assess] FINISHED_LOADING';
 export const FINISHED_SAVING = '[Assess] FINISHED_SAVING';
 export const SET_BASELINES = '[Assess] SET_BASELINES';
+export const SET_CAPABILITIES = '[Assess] SET_CAPABILITIES';
 export const SET_CURRENT_BASELINE = '[Assess] SET_CURRENT_BASELINE';
-export const SET_CURRENT_BASELINE_QUESTIONS =
-  '[Assess] SET_CURRENT_BASELINE_QUESTIONS';
+export const SET_CURRENT_BASELINE_QUESTIONS = '[Assess] SET_CURRENT_BASELINE_QUESTIONS';
 export const SET_INDICATORS = '[Assess] SET_INDICATORS';
 export const SET_MITIGATONS = '[Assess] SET_MITIGATIONS';
-export const SET_CAPABILITIES = '[Assess] SET_CAPABILITIES';
 export const UPDATE_PAGE_TITLE = '[Assess] UPDATE_PAGE_TITLE';
 export const WIZARD_PAGE = '[Asses] WIZARD_PAGE';
 
 export class UpdatePageTitle implements Action {
   public readonly type = UPDATE_PAGE_TITLE;
 
-  constructor(public payload?: string | Object) {}
+  constructor(public payload?: string | Object) { }
 }
 
 export class StartAssessment implements Action {
   public readonly type = START_ASSESSMENT;
 
-  constructor(public payload: Assess3Meta) {}
+  constructor(public payload: Assess3Meta) { }
 }
 
 export class StartAssessmentSuccess implements Action {
@@ -57,43 +53,43 @@ export class SaveAssessment implements Action {
 
   // an assessment can contain multiple assessment types
   //  these assessments will be saved w/ the same parentId
-  constructor(public payload: Assessment[]) {}
+  constructor(public payload: Assessment[]) { }
 }
 
 export class FetchAssessment implements Action {
   public readonly type = FETCH_ASSESSMENT;
 
-  constructor(public payload: any[]) {}
+  constructor(public payload: any[]) { }
 }
 
 export class LoadAssessmentWizardData implements Action {
   public readonly type = LOAD_ASSESSMENT_WIZARD_DATA;
 
-  constructor(public payload: Partial<Assess3Meta>) {}
+  constructor(public payload: Partial<Assess3Meta>) { }
 }
 
 export class LoadCurrentBaselineQuestions implements Action {
   public readonly type = LOAD_CURRENT_BASELINE_QUESTIONS;
 
-  constructor(public payload: AssessmentSet) {}
+  constructor(public payload: AssessmentSet) { }
 }
 
 export class SetIndicators implements Action {
   public readonly type = SET_INDICATORS;
 
-  constructor(public payload: Indicator[]) {}
+  constructor(public payload: Indicator[]) { }
 }
 
 export class SetMitigations implements Action {
   public readonly type = SET_MITIGATONS;
 
-  constructor(public payload: Stix[]) {}
+  constructor(public payload: Stix[]) { }
 }
 
 export class FinishedLoading implements Action {
   public readonly type = FINISHED_LOADING;
 
-  constructor(public payload: boolean) {}
+  constructor(public payload: boolean) { }
 }
 
 export class FinishedSaving implements Action {
@@ -101,23 +97,23 @@ export class FinishedSaving implements Action {
 
   constructor(
     public payload: { finished: boolean; rollupId: string; id: string }
-  ) {}
+  ) { }
 }
 
 export class AnswerQuestion implements Action {
   public readonly type = ANSWER_QUESTION;
-  constructor(public payload: any) {}
+  constructor(public payload: any) { }
 }
 
 export class WizardPage implements Action {
   public readonly type = WIZARD_PAGE;
-  constructor(public payload: number) {}
+  constructor(public payload: number) { }
 }
 
 export class CleanAssessmentWizardData implements Action {
   public readonly type = CLEAN_ASSESSMENT_WIZARD_DATA;
 
-  constructor() {}
+  constructor() { }
 }
 
 export class LoadBaselines implements Action {
@@ -127,25 +123,25 @@ export class LoadBaselines implements Action {
 export class SetCurrentBaseline implements Action {
   public readonly type = SET_CURRENT_BASELINE;
 
-  constructor(public payload: AssessmentSet) {}
+  constructor(public payload: AssessmentSet) { }
 }
 
 export class SetCurrentBaselineQuestions implements Action {
   public readonly type = SET_CURRENT_BASELINE_QUESTIONS;
 
-  constructor(public payload: ObjectAssessment[]) {}
+  constructor(public payload: ObjectAssessment[]) { }
 }
 
 export class SetBaselines implements Action {
   public readonly type = SET_BASELINES;
 
-  constructor(public payload: AssessmentSet[]) {}
+  constructor(public payload: AssessmentSet[]) { }
 }
 
 export class FailedToLoad implements Action {
   public readonly type = FAILED_TO_LOAD;
 
-  constructor(public payload: boolean) {}
+  constructor(public payload: boolean) { }
 }
 
 export class FetchCapabilities implements Action {
@@ -155,27 +151,27 @@ export class FetchCapabilities implements Action {
 export class SetCapabilities implements Action {
   public readonly type = SET_CAPABILITIES;
 
-  constructor(public payload: Capability[]) {}
+  constructor(public payload: Capability[]) { }
 }
 export type AssessmentActions =
-    AnswerQuestion
-    | CleanAssessmentWizardData
-    | FailedToLoad
-    | FetchAssessment
-    | FetchCapabilities
-    | FinishedLoading
-    | FinishedSaving
-    | LoadAssessmentWizardData
-    | LoadBaselines
-    | LoadCurrentBaselineQuestions
-    | SaveAssessment
-    | SetBaselines
-    | SetCapabilities
-    | SetCurrentBaseline
-    | SetCurrentBaselineQuestions
-    | SetIndicators
-    | SetMitigations
-    | StartAssessment
-    | StartAssessmentSuccess
-    | UpdatePageTitle
-    | WizardPage;
+  AnswerQuestion
+  | CleanAssessmentWizardData
+  | FailedToLoad
+  | FetchAssessment
+  | FetchCapabilities
+  | FinishedLoading
+  | FinishedSaving
+  | LoadAssessmentWizardData
+  | LoadBaselines
+  | LoadCurrentBaselineQuestions
+  | SaveAssessment
+  | SetBaselines
+  | SetCapabilities
+  | SetCurrentBaseline
+  | SetCurrentBaselineQuestions
+  | SetIndicators
+  | SetMitigations
+  | StartAssessment
+  | StartAssessmentSuccess
+  | UpdatePageTitle
+  | WizardPage;

--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -184,31 +184,30 @@ export class WizardComponent extends Measurements
     this.summaryDoughnutChartLabels = this.CHART_LABELS;
     this.summaryDoughnutChartType = this.CHART_TYPE;
 
-    const idParamSub$ = this.route.params.subscribe(
-      params => {
-        const isTrue = (val: number) => val === 1;
-        const includesIndicators = isTrue(
-          +this.route.snapshot.paramMap.get('includesIndicators')
-        );
-        const includesMitigations = isTrue(
-          +this.route.snapshot.paramMap.get('includesMitigations')
-        );
-        const baselineRef = this.route.snapshot.paramMap.get('baselineRef');
-        const meta: Partial<Assess3Meta> = {
-          includesIndicators,
-          includesMitigations,
-          baselineRef,
-        };
+    const idParamSub$ = this.route.params.subscribe((params) => {
+      const isTrue = (val: number) => val === 1;
+      const includesIndicators = isTrue(
+        +this.route.snapshot.paramMap.get('includesIndicators')
+      );
+      const includesMitigations = isTrue(
+        +this.route.snapshot.paramMap.get('includesMitigations')
+      );
+      const baselineRef = this.route.snapshot.paramMap.get('baselineRef');
+      const meta: Partial<Assess3Meta> = {
+        includesIndicators,
+        includesMitigations,
+        baselineRef,
+      };
 
-        const rollupId = params.rollupId || '';
-        if (rollupId) {
-          // this is an edit
-          this.loadExistingAssessment(rollupId, meta);
-        } else {
-          // this is a new wizard
-          this.wizardStore.dispatch(new LoadAssessmentWizardData(meta));
-        }
-      },
+      const rollupId = params.rollupId || '';
+      if (rollupId) {
+        // this is an edit
+        this.loadExistingAssessment(rollupId, meta);
+      } else {
+        // this is a new wizard
+        this.wizardStore.dispatch(new LoadAssessmentWizardData(meta));
+      }
+    },
       (err) => console.log(err),
       () => idParamSub$.unsubscribe()
     );
@@ -311,10 +310,7 @@ export class WizardComponent extends Measurements
    * @param  {Partial<Assess3Meta>} meta
    * @returns void
    */
-  public loadExistingAssessment(
-    rollupId: string,
-    meta: Partial<Assess3Meta>
-  ): void {
+  public loadExistingAssessment(rollupId: string, meta: Partial<Assess3Meta>): void {
     const sub$ = this.userStore
       .select('users')
       .pipe(pluck('userProfile'), take(1))
@@ -341,20 +337,14 @@ export class WizardComponent extends Measurements
    * @param  {Partial<Assess3Meta>} meta
    * @returns void
    */
-  public loadAssessments(rollupId: string, arr: Array<Assessment>, meta: Partial<Assess3Meta>): void {
+  public loadAssessments(rollupId: string, arr: Array<Assessment>, meta: Partial<Assess3Meta> = new Assess3Meta()): void {
     if (!arr || arr.length === 0) {
       return;
     }
 
-    meta.includesIndicators = false;
-    meta.includesMitigations = false;
-    meta.baselineRef = undefined;
-
-    /*
-     * making the model a collection of all the assessments matching the given rollup id, plus a summary of all the
-     * assessed objects to make it easier to use the existing code to display the questions and existing answers
-     */
-
+    // making the model a collection of all the assessments matching the given rollup id, 
+    //  plus a summary of all the assessed objects to make it easier to use the existing code 
+    //  to display the questions and existing answers
     const typedAssessments = {};
     const summary = new Assessment();
     arr.forEach((assessment) => {
@@ -386,6 +376,7 @@ export class WizardComponent extends Measurements
       } else if (assessment.assessment_objects
         .every((el) => el.stix.type === StixEnum.OBJECT_ASSESSMENT)) {
         typedAssessments[this.sidePanelOrder[2]] = assessment;
+        meta.baselineRef = assessment.metaProperties.baselineRef;
       } else {
         console.log(
           'We got a weird assessment document that is not all of one category, or has unknown categories',


### PR DESCRIPTION
*Requires* https://github.com/unfetter-discover/unfetter-store/pull/171
Supports unfetter-discover/unfetter#994

## problem
edit of assessment beta, just shows loading spinner
metaproperties and baseline id were not stored and retrieved correctly

## changes
store the baseline id into the metaproperties
use that baseline id when loading an edit page

## test
* pull the and verify the store pr is merged, see reference above
* verify travis
* clear your mongo of old data
* restart stack
* create a beta assessment 
* from the summary page, bring up the master dialog and click edit
* verify the page comes up and the question scores are the same
* change them and save