### PR TITLE
Issue 1066 (saving of baselines)

### DIFF
--- a/src/app/baseline/baseline.routing.ts
+++ b/src/app/baseline/baseline.routing.ts
@@ -21,11 +21,6 @@ const routes = [
         ]
     },
     { path: 'result/summary/:baselineId', component: SummaryComponent },
-    // { path: 'result/full/:rollupId', component: FullComponent },
-    // { path: 'result/full/:rollupId/:baselineId', component: FullComponent },
-    // { path: 'result/full/:rollupId/:baselineId/phase/:phase', component: FullComponent },
-    // { path: 'result/full/:rollupId/:baselineId/phase/:phase/attackPattern/:attackPattern', component: FullComponent },
-    // { path: 'result/group/:id/:phase', component: AssessmentsGroupComponent },
 ];
 
 export const routing = RouterModule.forChild(routes);

--- a/src/app/baseline/services/baseline.service.ts
+++ b/src/app/baseline/services/baseline.service.ts
@@ -116,13 +116,13 @@ export class BaselineService {
      * @param {string} filter
      * @return {Observable<Category[]>}
      */
-    // public getCategories(filter?: string): Observable<Category[]> {
-    //     const url = filter ?
-    //         `${this.categoryBaseUrl}?${encodeURI(filter)}` : this.categoryBaseUrl;
-    //     return this.genericApi
-    //         .getAs<JsonApiData<Category>[]>(url)
-    //         .map(RxjsHelpers.mapAttributes);
-    // }
+    public getCategories(filter?: string): Observable<Category[]> {
+        const url = filter ?
+            `${this.categoryBaseUrl}?${encodeURI(filter)}` : this.categoryBaseUrl;
+        return this.genericApi
+            .getAs<JsonApiData<Category>[]>(url)
+            .map(RxjsHelpers.mapAttributes);
+    }
 
     /**
      * @description load capabilities

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -20,6 +20,8 @@ export const SET_CAPABILITIES = '[Baseline] SET_CAPABILITIES';
 export const SET_BASELINE_CAPABILITIES = '[Baseline] SET_BASELINE_CAPABILITIES';
 export const SET_CURRENT_BASELINE_CAPABILITY = '[Baseline] SET_CURRENT_BASELINE_CAPABILITY';
 export const SET_BASELINE = '[Baseline] SET_BASELINE';
+export const SAVE_OBJECT_ASSESSMENTS = '[Baseline] SAVE_OBJECT_ASSESSMENTS';
+export const FAILED_TO_LOAD = '[Assess] FAILED_TO_LOAD';
 
 // For reducers
 export const UPDATE_PAGE_TITLE = '[Baseline] UPDATE_PAGE_TITLE';
@@ -41,6 +43,7 @@ export const SET_CURRENT_BASELINE_OBJECT_ASSESSMENT = '[Baseline] SET_CURRENT_BA
 export const SET_CATEGORY_STEPS = '[Baseline] SET_CATEGORY_STEPS';
 export const SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS = '[Baseline] SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS';
 export const WIZARD_PAGE = '[Baseline] WIZARD_PAGE';
+export const ADD_OBJECT_ASSESSMENT = '[Baseline] ADD_OBJECT_ASSESSMENT';
 
 export class UpdatePageTitle implements Action {
     public readonly type = UPDATE_PAGE_TITLE;
@@ -62,6 +65,18 @@ export class SaveBaseline implements Action {
     public readonly type = SAVE_BASELINE;
 
     constructor(public payload: AssessmentSet) { }
+}
+
+export class AddObjectAssessment implements Action {
+    public readonly type = ADD_OBJECT_ASSESSMENT;
+
+    constructor(public payload: string) { }
+}
+
+export class SaveObjectAssessments implements Action {
+    public readonly type = SAVE_OBJECT_ASSESSMENTS;
+
+    constructor(public payload: ObjectAssessment[]) { }
 }
 
 export class FetchBaseline implements Action {
@@ -178,7 +193,7 @@ export class FinishedLoading implements Action {
 export class FinishedSaving implements Action {
     public readonly type = FINISHED_SAVING;
 
-    constructor(public payload: { finished: boolean, id: string }) { }
+    constructor(public payload: { finished: boolean; id: string }) { }
 }
 
 export class AnswerQuestion implements Action {
@@ -197,34 +212,40 @@ export class CleanBaselineWizardData {
     constructor() { }
 }
 
+export class FailedToLoad implements Action {
+    public readonly type = FAILED_TO_LOAD;
+  
+    constructor(public payload: boolean) {}
+  }  
+
 export type BaselineActions =
+    AddObjectAssessment |
     AnswerQuestion |
     CleanBaselineWizardData |
+    FailedToLoad |
     FetchBaseline |
-    SetBaseline |
-    FetchCapabilityGroups |
-    SetCapabilityGroups |
-    SetBaselineGroups |
-    SetCurrentBaselineGroup |
+    FetchAttackPatterns |
     FetchCapabilities |
-    SetCapabilities |
-    SetBaselineCapabilities |
-    SetCurrentBaselineCapability |
-    SetBaselineObjectAssessments |
-    SetCurrentBaselineObjectAssessment |
+    FetchCapabilityGroups |
     FinishedLoading |
     FinishedSaving |
     LoadBaselineWizardData |
-    StartBaseline |
-    StartBaselineSuccess |
     SaveBaseline |
-    AnswerQuestion |
-    FetchAttackPatterns |
-    FinishedLoading |
-    FinishedSaving |
+    SaveObjectAssessments |
     SetAttackPatterns |
+    SetBaseline |
+    SetBaselineCapabilities |
+    SetBaselineGroups |
+    SetBaselineObjectAssessments |
+    SetCapabilities |
+    SetCapabilityGroups |
     SetCategories |
     SetCategorySteps |
+    SetCurrentBaselineCapability |
+    SetCurrentBaselineGroup |
+    SetCurrentBaselineObjectAssessment |
     SetSelectedFrameworkAttackPatterns |
+    StartBaseline |
+    StartBaselineSuccess |
     UpdatePageTitle |
     WizardPage;

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -1,5 +1,5 @@
 import { Action } from '@ngrx/store';
-import { Capability, Category, ObjectAssessment } from 'stix/assess/v3/baseline';
+import { Capability, Category, ObjectAssessment, AssessmentSet } from 'stix/assess/v3/baseline';
 import { Baseline } from '../../models/baseline/baseline';
 import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { AttackPattern } from 'stix/unfetter/attack-pattern';
@@ -19,6 +19,7 @@ export const FETCH_CAPABILITIES = '[Baseline] FETCH_CAPABILITIES';
 export const SET_CAPABILITIES = '[Baseline] SET_CAPABILITIES';
 export const SET_BASELINE_CAPABILITIES = '[Baseline] SET_BASELINE_CAPABILITIES';
 export const SET_CURRENT_BASELINE_CAPABILITY = '[Baseline] SET_CURRENT_BASELINE_CAPABILITY';
+export const SET_BASELINE = '[Baseline] SET_BASELINE';
 
 // For reducers
 export const UPDATE_PAGE_TITLE = '[Baseline] UPDATE_PAGE_TITLE';
@@ -60,15 +61,19 @@ export class StartBaselineSuccess implements Action {
 export class SaveBaseline implements Action {
     public readonly type = SAVE_BASELINE;
 
-    // Saving a baseline assumes the assessment set and
-    //  object assessments in this ngrx store are current
-    constructor() { }
+    constructor(public payload: AssessmentSet) { }
 }
 
 export class FetchBaseline implements Action {
     public readonly type = FETCH_BASELINE;
 
     constructor(public payload: any[]) { }
+}
+
+export class SetBaseline implements Action {
+    public readonly type = SET_BASELINE;
+
+    constructor(public payload: AssessmentSet) { }
 }
 
 export class FetchCapabilityGroups implements Action {
@@ -196,6 +201,7 @@ export type BaselineActions =
     AnswerQuestion |
     CleanBaselineWizardData |
     FetchBaseline |
+    SetBaseline |
     FetchCapabilityGroups |
     SetCapabilityGroups |
     SetBaselineGroups |

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -44,6 +44,7 @@ export const SET_CATEGORY_STEPS = '[Baseline] SET_CATEGORY_STEPS';
 export const SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS = '[Baseline] SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS';
 export const WIZARD_PAGE = '[Baseline] WIZARD_PAGE';
 export const ADD_OBJECT_ASSESSMENT = '[Baseline] ADD_OBJECT_ASSESSMENT';
+export const ADD_OBJECT_ASSESSMENTS_TO_BASELINE = '[Baseline] ADD_OBJECT_ASSESSMENTS_TO_BASELINE';
 
 export class UpdatePageTitle implements Action {
     public readonly type = UPDATE_PAGE_TITLE;
@@ -77,6 +78,12 @@ export class SaveObjectAssessments implements Action {
     public readonly type = SAVE_OBJECT_ASSESSMENTS;
 
     constructor(public payload: ObjectAssessment[]) { }
+}
+
+export class AddObjectAssessmentsToBaseline implements Action {
+    public readonly type = ADD_OBJECT_ASSESSMENTS_TO_BASELINE;
+
+    constructor(public payload: string[]) { }
 }
 
 export class FetchBaseline implements Action {
@@ -220,6 +227,7 @@ export class FailedToLoad implements Action {
 
 export type BaselineActions =
     AddObjectAssessment |
+    AddObjectAssessmentsToBaseline |
     AnswerQuestion |
     CleanBaselineWizardData |
     FailedToLoad |

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -25,16 +25,11 @@ export const FAILED_TO_LOAD = '[Assess] FAILED_TO_LOAD';
 
 // For reducers
 export const UPDATE_PAGE_TITLE = '[Baseline] UPDATE_PAGE_TITLE';
-export const ANSWER_QUESTION = '[Baseline] ANSWER_QUESTION';
 export const FINISHED_LOADING = '[Baseline] FINISHED_LOADING';
 export const FINISHED_SAVING = '[Baseline] FINISHED_SAVING';
 export const CLEAN_ASSESSMENT_WIZARD_DATA = '[Baseline] CLEAN_ASSESSMENT_WIZARD_DATA';
-export const FETCH_ASSESSMENT = '[Baseline] FETCH_ASSESSMENT';
 export const FETCH_ATTACK_PATTERNS = '[Baseline] FETCH_ATTACK_PATTERNS';
 export const FETCH_CATEGORIES = '[Baseline] FETCH_CATEGORIES';
-export const LOAD_ASSESSMENT_WIZARD_DATA = '[Baseline] LOAD_ASSESSMENT_WIZARD_DATA';
-export const SAVE_ASSESSMENT = '[Baseline] SAVE_ASSESSMENT';
-export const START_ASSESSMENT = '[Baseline] START_ASSESSMENT';
 export const START_ASSESSMENT_SUCCESS = '[Baseline] START_ASSESSMENT_SUCCESS';
 export const SET_ATTACK_PATTERNS = '[Baseline] SET_ATTACK_PATTERNS';
 export const SET_CATEGORIES = '[Baseline] SET_CATEGORIES';
@@ -42,7 +37,6 @@ export const SET_BASELINE_OBJECT_ASSESSMENTS = '[Baseline] SET_BASELINE_OBJECT_A
 export const SET_CURRENT_BASELINE_OBJECT_ASSESSMENT = '[Baseline] SET_CURRENT_BASELINE_OBJECT_ASSESSMENT';
 export const SET_CATEGORY_STEPS = '[Baseline] SET_CATEGORY_STEPS';
 export const SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS = '[Baseline] SET_SELECTED_FRAMEWORK_ATTACK_PATTERNS';
-export const WIZARD_PAGE = '[Baseline] WIZARD_PAGE';
 export const ADD_OBJECT_ASSESSMENT = '[Baseline] ADD_OBJECT_ASSESSMENT';
 export const ADD_OBJECT_ASSESSMENTS_TO_BASELINE = '[Baseline] ADD_OBJECT_ASSESSMENTS_TO_BASELINE';
 
@@ -203,16 +197,6 @@ export class FinishedSaving implements Action {
     constructor(public payload: { finished: boolean; id: string }) { }
 }
 
-export class AnswerQuestion implements Action {
-    public readonly type = ANSWER_QUESTION;
-    constructor(public payload: any) { }
-}
-
-export class WizardPage implements Action {
-    public readonly type = WIZARD_PAGE;
-    constructor(public payload: number) { }
-}
-
 export class CleanBaselineWizardData {
     public readonly type = CLEAN_BASELINE_WIZARD_DATA;
 
@@ -228,7 +212,6 @@ export class FailedToLoad implements Action {
 export type BaselineActions =
     AddObjectAssessment |
     AddObjectAssessmentsToBaseline |
-    AnswerQuestion |
     CleanBaselineWizardData |
     FailedToLoad |
     FetchBaseline |
@@ -255,5 +238,4 @@ export type BaselineActions =
     SetSelectedFrameworkAttackPatterns |
     StartBaseline |
     StartBaselineSuccess |
-    UpdatePageTitle |
-    WizardPage;
+    UpdatePageTitle;

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -60,9 +60,9 @@ export class StartBaselineSuccess implements Action {
 export class SaveBaseline implements Action {
     public readonly type = SAVE_BASELINE;
 
-    // an baseline can contain multiple baseline types
-    //  these baselines will be saved w/ the same parentId
-    constructor(public payload: Baseline[]) { }
+    // Saving a baseline assumes the assessment set and
+    //  object assessments in this ngrx store are current
+    constructor() { }
 }
 
 export class FetchBaseline implements Action {

--- a/src/app/baseline/store/baseline.effects.ts
+++ b/src/app/baseline/store/baseline.effects.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, Effect } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
-import { Category, AssessmentSet } from 'stix/assess/v3/baseline';
+import { Category, AssessmentSet, ObjectAssessment } from 'stix/assess/v3/baseline';
 import { AttackPattern } from 'stix/unfetter/attack-pattern';
 import { AttackPatternService } from '../../core/services/attack-pattern.service';
 import { GenericApi } from '../../core/services/genericapi.service';
@@ -14,6 +14,7 @@ import { JsonApiData } from '../../models/json/jsonapi-data';
 import { BaselineStateService } from '../services/baseline-state.service';
 import { BaselineService } from '../services/baseline.service';
 import * as assessActions from './baseline.actions';
+import { map, flatMap, catchError } from 'rxjs/operators';
 
 @Injectable()
 export class BaselineEffects {
@@ -63,39 +64,39 @@ export class BaselineEffects {
     //     .switchMap(() => this.baselineService.getCapabilities())
     //     .map((arr: Category[]) => new assessActions.SetCapabilities(arr));
 
-    //     @Effect()
-    //     public fetchAttackPatterns = this.actions$
-    //         .ofType(assessActions.FETCH_ATTACK_PATTERNS)
-    //         .pluck('payload')
-    //         .switchMap((selectedFramework: string) => {
-    //             const o1$ = Observable.of(selectedFramework);
-    //             // select all the attack patterns
-    //             const o2$ = this.attackPatternService
-    //                 .fetchAttackPatterns()
-    //                 .catch((ex) => Observable.of([] as AttackPattern[]));
-    //             // merge selected framework and all system attack patterns                
-    //             return Observable.forkJoin(o1$, o2$);
-    //         })
-    //         .mergeMap(([framework, allAttackPatterns]) => {
-    //             // if no framework given, use all attack patterns
-    //             let selectedAttackPatterns = allAttackPatterns;
-    //             if (framework) {
-    //                 // filter if we are given a selected framework
-    //                 const isFromSelectedFramework = (el) => {
-    //                     return el 
-    //                         && el.kill_chain_phases
-    //                         .findIndex((_) => _.kill_chain_name === framework) > -1;
-    //                 };
-    //                 selectedAttackPatterns = allAttackPatterns
-    //                     .filter(isFromSelectedFramework);
-    //             }
-    
-    //             // tell reducer to set the attack pattern states
-    //             return [
-    //                 new assessActions.SetAttackPatterns(allAttackPatterns),
-    //                 new assessActions.SetSelectedFrameworkAttackPatterns(selectedAttackPatterns),
-    //             ];
-    //         });
+    @Effect()
+    public fetchAttackPatterns = this.actions$
+        .ofType(assessActions.FETCH_ATTACK_PATTERNS)
+        .pluck('payload')
+        .switchMap((selectedFramework: string) => {
+            const o1$ = Observable.of(selectedFramework);
+            // select all the attack patterns
+            const o2$ = this.attackPatternService
+                .fetchAttackPatterns()
+                .catch((ex) => Observable.of([] as AttackPattern[]));
+            // merge selected framework and all system attack patterns                
+            return Observable.forkJoin(o1$, o2$);
+        })
+        .mergeMap(([framework, allAttackPatterns]) => {
+            // if no framework given, use all attack patterns
+            let selectedAttackPatterns = allAttackPatterns;
+            if (framework) {
+                // filter if we are given a selected framework
+                const isFromSelectedFramework = (el) => {
+                    return el 
+                        && el.kill_chain_phases
+                        .findIndex((_) => _.kill_chain_name === framework) > -1;
+                };
+                selectedAttackPatterns = allAttackPatterns
+                    .filter(isFromSelectedFramework);
+            }
+
+            // tell reducer to set the attack pattern states
+            return [
+                new assessActions.SetAttackPatterns(allAttackPatterns),
+                new assessActions.SetSelectedFrameworkAttackPatterns(selectedAttackPatterns),
+            ];
+        });
     
     @Effect({ dispatch: false })
     public startAssessment = this.actions$
@@ -116,22 +117,52 @@ export class BaselineEffects {
 
     @Effect()
     public saveAssessment = this.actions$
-        .ofType(assessActions.SAVE_BASELINE)
+        .ofType(assessActions.SAVE_ASSESSMENT)
         .pluck('payload')
         .switchMap((baseline: AssessmentSet) => {
-            const json = { 'data': { 'attributes': baseline } } as JsonApi<JsonApiData<AssessmentSet>>;
-            let url = 'api/x-unfetter-assessment-sets';
+            const json = {
+                data: { attributes: baseline }
+            } as JsonApi<JsonApiData<AssessmentSet>>;
+            let url = 'api/v3/x-unfetter-assessment-sets';
             if (baseline.id) {
                 url = `${url}/${baseline.id}`;
-                return this.genericServiceApi.patchAs<JsonApiData<AssessmentSet>>(url, json);
+                return this.genericServiceApi
+                .patchAs<AssessmentSet>(url, json);
             } else {
-                return this.genericServiceApi.postAs<JsonApiData<AssessmentSet>>(url, json);
+                return this.genericServiceApi
+                .postAs<AssessmentSet>(url, json);
             }
         })
-        .do((set: AssessmentSet) => {
-            return new assessActions.FinishedSaving({ 
+        .map((objAssessment) => {
+            return new assessActions.FinishedSaving({
                 finished: true,
+                id: objAssessment.id || '',
             });
-        })
+        });
+
+  @Effect()
+  public saveObjectAssessments = this.actions$
+    .ofType(assessActions.SAVE_OBJECT_ASSESSMENTS)
+    .pluck('payload')
+    .switchMap((objAssessments: ObjectAssessment[]) => {
+      let url = 'api/v3/x-unfetter-object-assessments';
+      const observables = objAssessments
+        .map((objAssessment) => {
+            const json = {
+                data: { attributes: objAssessment }
+            } as JsonApi<JsonApiData<ObjectAssessment>>;
+            console.log(JSON.stringify(json));
+            if (objAssessment.id) {
+                url = `${url}/${objAssessment.id}`;
+                return this.genericServiceApi
+                    .patchAs<ObjectAssessment>(url, json);
+            } else {
+                return this.genericServiceApi
+                    .postAs<ObjectAssessment>(url, json);
+            }
+      });
+
+      return Observable.forkJoin(...observables);
+    });
 
 }

--- a/src/app/baseline/store/baseline.effects.ts
+++ b/src/app/baseline/store/baseline.effects.ts
@@ -116,8 +116,8 @@ export class BaselineEffects {
 
 
     @Effect()
-    public saveAssessment = this.actions$
-        .ofType(baselineActions.SAVE_ASSESSMENT)
+    public saveBaseline = this.actions$
+        .ofType(baselineActions.SAVE_BASELINE)
         .pluck('payload')
         .switchMap((baseline: AssessmentSet) => {
             const json = {
@@ -133,10 +133,10 @@ export class BaselineEffects {
                 .postAs<AssessmentSet>(url, json);
             }
         })
-        .map((objAssessment) => {
+        .map((assessmentSet) => {
             return new baselineActions.FinishedSaving({
                 finished: true,
-                id: objAssessment.id || '',
+                id: assessmentSet[0].id || '',
             });
         });
 

--- a/src/app/baseline/store/baseline.effects.ts
+++ b/src/app/baseline/store/baseline.effects.ts
@@ -3,18 +3,18 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, Effect } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
-import { Category, AssessmentSet, ObjectAssessment } from 'stix/assess/v3/baseline';
+import { catchError, map, flatMap } from 'rxjs/operators';
+import { AssessmentSet, Category, ObjectAssessment } from 'stix/assess/v3/baseline';
 import { AttackPattern } from 'stix/unfetter/attack-pattern';
 import { AttackPatternService } from '../../core/services/attack-pattern.service';
 import { GenericApi } from '../../core/services/genericapi.service';
-import { Baseline } from '../../models/baseline/baseline';
 import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { JsonApi } from '../../models/json/jsonapi';
 import { JsonApiData } from '../../models/json/jsonapi-data';
 import { BaselineStateService } from '../services/baseline-state.service';
 import { BaselineService } from '../services/baseline.service';
-import * as assessActions from './baseline.actions';
-import { map, flatMap, catchError } from 'rxjs/operators';
+import * as baselineActions from './baseline.actions';
+import { RxjsHelpers } from '../../global/static/rxjs-helpers';
 
 @Injectable()
 export class BaselineEffects {
@@ -31,7 +31,7 @@ export class BaselineEffects {
 
     @Effect()
     public fetchAssessmentWizardData = this.actions$
-        .ofType(assessActions.LOAD_BASELINE_WIZARD_DATA)
+        .ofType(baselineActions.LOAD_BASELINE_WIZARD_DATA)
         .pluck('payload')
         // .switchMap((meta: Partial<Assessment3Meta>) => {
         //     const includeMeta = `?metaproperties=true`;
@@ -42,31 +42,31 @@ export class BaselineEffects {
         // })
         .mergeMap(() => {
             return [
-                new assessActions.FinishedLoading(true)
+                new baselineActions.FinishedLoading(true)
             ];
         });
 
     @Effect()
     public fetchAssessment = this.actions$
-        .ofType(assessActions.FETCH_BASELINE)
+        .ofType(baselineActions.FETCH_BASELINE)
         .switchMap(() => this.baselineService.load())
-        .map((arr: any[]) => new assessActions.FetchBaseline(arr[0]));
+        .map((arr: any[]) => new baselineActions.FetchBaseline(arr[0]));
 
-    // @Effect()
-    // public fetchCapabilityGroups = this.actions$
-    //     .ofType(assessActions.FETCH_CAPABILITY_GROUPS)
-    //     .switchMap(() => this.baselineService.getCategories())
-    //     .map((arr: Category[]) => new assessActions.SetCapabilityGroups(arr));
+    @Effect()
+    public fetchCapabilityGroups = this.actions$
+        .ofType(baselineActions.FETCH_CAPABILITY_GROUPS)
+        .switchMap(() => this.baselineService.getCategories())
+        .map((arr: Category[]) => new baselineActions.SetCapabilityGroups(arr));
 
-    // @Effect()
-    // public fetchCapabilities = this.actions$
-    //     .ofType(assessActions.FETCH_CAPABILITIES)
-    //     .switchMap(() => this.baselineService.getCapabilities())
-    //     .map((arr: Category[]) => new assessActions.SetCapabilities(arr));
+    @Effect()
+    public fetchCapabilities = this.actions$
+        .ofType(baselineActions.FETCH_CAPABILITIES)
+        .switchMap(() => this.baselineService.getCapabilities())
+        .map((arr: Category[]) => new baselineActions.SetCapabilities(arr));
 
     @Effect()
     public fetchAttackPatterns = this.actions$
-        .ofType(assessActions.FETCH_ATTACK_PATTERNS)
+        .ofType(baselineActions.FETCH_ATTACK_PATTERNS)
         .pluck('payload')
         .switchMap((selectedFramework: string) => {
             const o1$ = Observable.of(selectedFramework);
@@ -93,14 +93,14 @@ export class BaselineEffects {
 
             // tell reducer to set the attack pattern states
             return [
-                new assessActions.SetAttackPatterns(allAttackPatterns),
-                new assessActions.SetSelectedFrameworkAttackPatterns(selectedAttackPatterns),
+                new baselineActions.SetAttackPatterns(allAttackPatterns),
+                new baselineActions.SetSelectedFrameworkAttackPatterns(selectedAttackPatterns),
             ];
         });
     
     @Effect({ dispatch: false })
     public startAssessment = this.actions$
-        .ofType(assessActions.START_BASELINE)
+        .ofType(baselineActions.START_BASELINE)
         .pluck('payload')
         .map((el: BaselineMeta) => {
             this.baselineStateService.saveCurrent(el);
@@ -117,7 +117,7 @@ export class BaselineEffects {
 
     @Effect()
     public saveAssessment = this.actions$
-        .ofType(assessActions.SAVE_ASSESSMENT)
+        .ofType(baselineActions.SAVE_ASSESSMENT)
         .pluck('payload')
         .switchMap((baseline: AssessmentSet) => {
             const json = {
@@ -134,7 +134,7 @@ export class BaselineEffects {
             }
         })
         .map((objAssessment) => {
-            return new assessActions.FinishedSaving({
+            return new baselineActions.FinishedSaving({
                 finished: true,
                 id: objAssessment.id || '',
             });
@@ -142,27 +142,40 @@ export class BaselineEffects {
 
   @Effect()
   public saveObjectAssessments = this.actions$
-    .ofType(assessActions.SAVE_OBJECT_ASSESSMENTS)
+    .ofType(baselineActions.SAVE_OBJECT_ASSESSMENTS)
     .pluck('payload')
-    .switchMap((objAssessments: ObjectAssessment[]) => {
+    .switchMap(( objAssessments: ObjectAssessment[] ) => {
       let url = 'api/v3/x-unfetter-object-assessments';
       const observables = objAssessments
         .map((objAssessment) => {
             const json = {
-                data: { attributes: objAssessment }
+              data: { attributes: objAssessment }
             } as JsonApi<JsonApiData<ObjectAssessment>>;
-            console.log(JSON.stringify(json));
             if (objAssessment.id) {
-                url = `${url}/${objAssessment.id}`;
-                return this.genericServiceApi
-                    .patchAs<ObjectAssessment>(url, json);
+              url = `${url}/${objAssessment.id}`;
+              return this.genericServiceApi
+                .patchAs<ObjectAssessment[]>(url, json)
+                .map<any[], ObjectAssessment[]>(RxjsHelpers.mapArrayAttributes);
             } else {
-                return this.genericServiceApi
-                    .postAs<ObjectAssessment>(url, json);
+              return this.genericServiceApi
+                .postAs<ObjectAssessment[]>(url, json)
+                .map<any[], ObjectAssessment[]>(RxjsHelpers.mapArrayAttributes);
             }
       });
 
-      return Observable.forkJoin(...observables);
+      return Observable.forkJoin(...observables).pipe(
+        flatMap((arr: ObjectAssessment[][]) => arr),
+        map((arr) => {
+          const idArr = arr.map(objAssess => objAssess.id);
+          return new baselineActions.AddObjectAssessmentsToBaseline(
+            idArr,
+          );
+        }),
+        catchError((err) => {
+          console.log(err);
+          return Observable.of(new baselineActions.FailedToLoad(true));
+        })
+      );
     });
 
 }

--- a/src/app/baseline/store/baseline.effects.ts
+++ b/src/app/baseline/store/baseline.effects.ts
@@ -119,43 +119,20 @@ export class BaselineEffects {
         .ofType(assessActions.SAVE_BASELINE)
         .pluck('payload')
         .switchMap((baselines: Baseline[]) => {
-            // const rollupIds = baselines
-            //     .map((baseline) => baseline.metaProperties)
-            //     .filter((el) => el !== undefined)
-            //     .map((meta) => meta.rollupId)
-            //     .filter((el) => el !== undefined);
-            // let rollupId = '';
-            // if (rollupIds.length > 0) {
-            //     rollupId = rollupIds[0];
-            // } else {
-            //     rollupId = UUID.v4();
-            // }
-
             const observables = baselines
-                // .map((baseline) => {
-                //     baseline.metaProperties = baseline.metaProperties || {};
-                //     baseline.metaProperties.rollupId = rollupId;
-                //     return baseline;
-                // })
                 .map((baseline) => {
                     const json = { 'data': { 'attributes': baseline } } as JsonApi<JsonApiData<Baseline>>;
-                    let url = 'api/x-unfetter-object-baselines';
+                    let url = 'api/x-unfetter-assessment-sets';
                     if (baseline.id) {
                         url = `${url}/${baseline.id}`;
-                        return this.genericServiceApi.patchAs<JsonApiData<Baseline>[]>(url, json);
+                        return this.genericServiceApi.patchAs<JsonApiData<Baseline>>(url, json);
                     } else {
-                        return this.genericServiceApi.postAs<JsonApiData<Baseline>[]>(url, json);
+                        return this.genericServiceApi.postAs<JsonApiData<Baseline>>(url, json);
                     }
                 });
             return Observable.forkJoin(...observables)
                 .map((arr: any) => {
-                    // if (Array.isArray(arr[0])) {
-                    //     return arr;
-                    // } else {
-                    //     // stoopid hack to handle the fact that update returns a single object, not an array, and drops the metadata
-                    //     arr[0].attributes.metaProperties = { rollupId: rollupId };
-                        return [arr];
-                    // }
+                    return [arr];
                 });
         })
         .flatMap((arr: JsonApiData<Baseline>[][]) => arr)

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -100,6 +100,16 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
             return genAssessState({
                 ...state,
             });
+        case baselineActions.ADD_OBJECT_ASSESSMENTS_TO_BASELINE:
+            let currBaseline = state.baseline;
+            if (!currBaseline.assessments) {
+                currBaseline.assessments = [];
+            }
+            currBaseline.assessments.push(...action.payload);
+            return genAssessState({
+                ...state,
+                baseline: currBaseline,
+            });
         case baselineActions.SET_BASELINE_OBJECT_ASSESSMENTS:
             return genAssessState({
                 ...state,

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -96,6 +96,15 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 ...state,
                 currentCapability: action.payload,
             });
+        case baselineActions.SAVE_OBJECT_ASSESSMENTS:
+            return genAssessState({
+                ...state,
+            });
+        case baselineActions.SET_BASELINE_OBJECT_ASSESSMENTS:
+            return genAssessState({
+                ...state,
+                baselineObjAssessments: [...action.payload],
+            });
         case baselineActions.SET_BASELINE_OBJECT_ASSESSMENTS:
             return genAssessState({
                 ...state,

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -61,6 +61,11 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
             return genAssessState({
                 ...state,
             });
+        case baselineActions.SET_BASELINE:
+            return genAssessState({
+                ...state,
+                baseline: action.payload,
+            });
         case baselineActions.SET_CAPABILITY_GROUPS:
             return genAssessState({
                 ...state,
@@ -158,6 +163,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
         case baselineActions.SAVE_BASELINE:
             return genAssessState({
                 ...state,
+                baseline: action.payload,
             });
         default:
             return state;

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -102,9 +102,6 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
             });
         case baselineActions.ADD_OBJECT_ASSESSMENTS_TO_BASELINE:
             let currBaseline = state.baseline;
-            if (!currBaseline.assessments) {
-                currBaseline.assessments = [];
-            }
             currBaseline.assessments.push(...action.payload);
             return genAssessState({
                 ...state,
@@ -136,15 +133,17 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 selectedFrameworkAttackPatterns: [...action.payload],
             });
         case baselineActions.START_BASELINE:
-            const a0 = new AssessmentSet();
+            const newBaseline = new AssessmentSet();
             const meta = action.payload;
-            a0.name = meta.title;
-            // Object.assign(a0, action.payload);
-            a0.description = meta.description;
-            a0.created_by_ref = meta.created_by_ref;
+            newBaseline.name = meta.title;
+            newBaseline.description = meta.description;
+            newBaseline.created_by_ref = meta.created_by_ref;
+            newBaseline.created = new Date().toISOString();
+            newBaseline.assessments = [];
+            newBaseline.metaProperties = { published: false };
             return genAssessState({
-                ...state,
-                baseline: a0,
+              ...state,
+              baseline: newBaseline,
             });
         case baselineActions.UPDATE_PAGE_TITLE:
             const a1 = new AssessmentSet();
@@ -174,10 +173,6 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 saved: {
                     ...action.payload,
                 }
-            });
-        case baselineActions.WIZARD_PAGE:
-            return genAssessState({
-                ...state,
             });
         case baselineActions.SAVE_BASELINE:
             return genAssessState({

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
@@ -3,8 +3,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import * as _ from 'lodash';
 import { Subscription } from 'rxjs/Subscription';
-import { Capability, Category, ObjectAssessment } from 'stix/assess/v3/baseline';
-import { SetBaselineCapabilities, SetBaselineObjectAssessments } from '../../store/baseline.actions';
+import { Capability, Category, ObjectAssessment, AssessedObject } from 'stix/assess/v3/baseline';
+import { SetBaselineCapabilities, SetBaselineObjectAssessments, SaveObjectAssessments } from '../../store/baseline.actions';
 import * as assessReducers from '../../store/baseline.reducers';
 import { Stix } from 'stix/unfetter/stix';
 import { Constance } from '../../../utils/constance';
@@ -203,6 +203,9 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
 
       newOAs.push(newOA);
     });
+
+    // Save new object assessments so we have IDs for them
+    this.wizardStore.dispatch(new SaveObjectAssessments(newOAs));
 
     // Filter out capabilities that have been deleted
     let existingOAs = this.baselineObjAssessments.filter(bOA => this.baselineCapabilities.findIndex(blCap => bOA.object_ref === blCap.id) !== -1);

--- a/src/app/baseline/wizard/wizard.component.html
+++ b/src/app/baseline/wizard/wizard.component.html
@@ -91,7 +91,7 @@
       <button mat-button color="primary" *ngIf="!isFirstPage()" (click)="onBack($event)"> Back</button>
       <button mat-button color="primary" (click)="onBackGroup($event)" *ngIf="hasBackGroup()">Previous Group</button>
       <button mat-button color="primary" (click)="onNextGroup($event)" *ngIf="hasNextGroup(1)">Next Group</button>
-      <button mat-button color="primary" (click)="onSave($event)" *ngIf="buttonLabel === 'SAVE'" [disabled]="isTitleEmpty()">{{buttonLabel}}</button>
+      <button focus="true" mat-raised-button color="primary" (click)="onSave($event)" *ngIf="buttonLabel === 'SAVE'" [disabled]="isTitleEmpty()">{{buttonLabel}}</button>
       <button focus="true" mat-raised-button color="primary" (click)="onNext($event)" *ngIf="buttonLabel !== 'SAVE'">{{buttonLabel}}</button>
     </mat-card-actions>
 

--- a/src/app/baseline/wizard/wizard.component.html
+++ b/src/app/baseline/wizard/wizard.component.html
@@ -11,10 +11,10 @@
     </mat-expansion-panel>
     <div *ngIf="baselineGroups.length > 0">
       <mat-expansion-panel *ngFor="let group of baselineGroups" hideToggle="true" [expanded]="currentBaselineGroup && group.name === currentBaselineGroup.name"
-        (opened)="onOpenSidePanel('capability-selector', group)">
-        <mat-expansion-panel-header>
-          <mat-panel-title>
-            {{group.name}}
+        (opened)="onOpenSidePanel('capability-selector', group)" class="stepper-vertical">
+        <mat-expansion-panel-header [expandedHeight]="sidePanelExpandedHeight" [collapsedHeight]="sidePanelCollapseHeight">
+          <mat-panel-title >
+            {{group.name | uppercase}}
           </mat-panel-title>
         </mat-expansion-panel-header>
         <ul *ngIf="baselineCapabilities.length > 0" class="stepper stepper-vertical">

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -14,7 +14,7 @@ import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { AppState } from '../../root-store/app.reducers';
-import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SetCurrentBaselineCapability, SetCurrentBaselineGroup, SetCurrentBaselineObjectAssessment, UpdatePageTitle } from '../store/baseline.actions';
+import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SetCurrentBaselineCapability, SetCurrentBaselineGroup, SetCurrentBaselineObjectAssessment, UpdatePageTitle, SaveBaseline } from '../store/baseline.actions';
 import { BaselineState } from '../store/baseline.reducers';
 import { AttackPatternChooserComponent } from './attack-pattern-chooser/attack-pattern-chooser.component';
 import { Measurements } from './models/measurements';
@@ -721,25 +721,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
    * @return {void}
    */
   private saveAssessments(): void {
-    // TODO: once model is set, implement this to save AssessmentSet
-    // if (this.model) {
-    //   const baselines = Object.values(this.model.relationships);
-    //   baselines.forEach(baseline => {
-    //     baseline.modified = this.publishDate.toISOString();
-    //     baseline.description = this.meta.description;
-    //     if (this.meta.created_by_ref) {
-    //       baseline.created_by_ref = this.meta.created_by_ref;
-    //     }
-    //   });
-    //   this.wizardStore.dispatch(new SaveAssessment(baselines));
-    // } else {
-    //   const baselines = this.sidePanelOrder
-    //     .map((name) => this.categories[name])
-    //     .filter((el) => el !== undefined)
-    //     .map((el) => el.scoresModel)
-    //     .filter((el) => el !== undefined)
-    //     .map((el) => this.generateBaselineAssessment(el, this.meta))
-    //   this.wizardStore.dispatch(new SaveAssessment(baselines));
-    // }
+    this.wizardStore.dispatch(new SaveBaseline());
   }
+
 }

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -14,7 +14,7 @@ import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { AppState } from '../../root-store/app.reducers';
-import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SetCurrentBaselineCapability, SetCurrentBaselineGroup, SetCurrentBaselineObjectAssessment, UpdatePageTitle, SaveBaseline } from '../store/baseline.actions';
+import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SaveBaseline, SetBaseline, SetCurrentBaselineCapability, SetCurrentBaselineGroup, SetCurrentBaselineObjectAssessment, UpdatePageTitle } from '../store/baseline.actions';
 import { BaselineState } from '../store/baseline.reducers';
 import { AttackPatternChooserComponent } from './attack-pattern-chooser/attack-pattern-chooser.component';
 import { Measurements } from './models/measurements';
@@ -48,6 +48,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   public navigation: { id: string, label: string, page: number };
   public navigations: any[];
   
+  private currentBaseline: AssessmentSet;
   private objAssessments: ObjectAssessment[];
   private currentObjAssessment: ObjectAssessment;
   public allCategories: Category[] = [];
@@ -57,6 +58,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   public baselineCapabilities: Capability[] = [];
   public currentCapability = {} as Capability;
   private baselineObjAssessments: ObjectAssessment[] = [];
+  private currentObjectAssessment: ObjectAssessment;
 
   public showHeatmap = false;
   public allAttackPatterns: Observable<AttackPattern[]> = Observable.of([]);
@@ -147,6 +149,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
           meta.description = assessmentSet.description || meta.description;
           meta.created_by_ref = assessmentSet.created_by_ref || meta.created_by_ref;
           this.meta = meta;
+          this.currentBaseline = assessmentSet;
         },
         (err) => console.log(err));
 
@@ -237,6 +240,8 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
         .subscribe(
           (baselineObjAssessments: ObjectAssessment[]) => {
             this.baselineObjAssessments = baselineObjAssessments;
+            this.currentBaseline.assessments = this.baselineObjAssessments.map(objAssess => objAssess.id);
+            this.wizardStore.dispatch(new SetBaseline(this.currentBaseline));
           },
         (err) => console.log(err));
       
@@ -721,7 +726,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
    * @return {void}
    */
   private saveAssessments(): void {
-    this.wizardStore.dispatch(new SaveBaseline());
+    this.wizardStore.dispatch(new SaveBaseline(this.currentBaseline));
   }
 
 }

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -14,7 +14,7 @@ import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { Stix } from '../../models/stix/stix';
 import { UserProfile } from '../../models/user/user-profile';
 import { AppState } from '../../root-store/app.reducers';
-import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SetCurrentBaselineCapability, SetCurrentBaselineGroup, UpdatePageTitle } from '../store/baseline.actions';
+import { CleanBaselineWizardData, FetchAttackPatterns, FetchCapabilities, FetchCapabilityGroups, LoadBaselineWizardData, SetCurrentBaselineCapability, SetCurrentBaselineGroup, SetCurrentBaselineObjectAssessment, UpdatePageTitle } from '../store/baseline.actions';
 import { BaselineState } from '../store/baseline.reducers';
 import { AttackPatternChooserComponent } from './attack-pattern-chooser/attack-pattern-chooser.component';
 import { Measurements } from './models/measurements';
@@ -439,7 +439,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
     this.updateWizardData();
   }
 
-  public hasNextGroup(page: number): boolean {
+  public hasNextGroup(): boolean {
     return this.page > 1 && this.currentBaselineGroup &&
            this.baselineGroups.findIndex(group => group.id === this.currentBaselineGroup.id) < this.baselineGroups.length - 1;
   }

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -680,38 +680,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   }
 
   /*
-   * @description
-   * @param {any}
-   * @return {Assessment}
-   */
-  private generateBaseline(tempModel: WeightsModel, baselineMeta: BaselineMeta): AssessmentSet {
-    const baseline = new AssessmentSet();
-    baseline.name = this.meta.title;
-    baseline.description = this.meta.description;
-    baseline.created = new Date().toISOString();
-    baseline.created_by_ref = this.meta.created_by_ref;
-    const objAssessments = new Set<ObjectAssessment>();
-
-    Object.keys(tempModel)
-      .forEach((baselineId) => {
-        const baselineObj = tempModel[baselineId];
-        const temp = new ObjectAssessment();
-        const stix = new Stix();
-        stix.id = baselineObj.baseline.id;
-        stix.type = baselineObj.baseline.type;
-        stix.description = baselineObj.baseline.description || '';
-        stix.name = baselineObj.baseline.name;
-        stix.created_by_ref = baselineObj.baseline.created_by_ref;
-        Object.assign(temp, stix);
-        temp.assessments_objects = [];
-        objAssessments.add(temp);
-      });
-
-    baseline['baseline_objects'] = Array.from(objAssessments);
-    return baseline;
-  }
-
-  /*
    * @description save an baseline object to the database
    * @param {void}
    * @return {void}

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -50,7 +50,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   
   private currentBaseline: AssessmentSet;
   private objAssessments: ObjectAssessment[];
-  private currentObjAssessment: ObjectAssessment;
   public allCategories: Category[] = [];
   public baselineGroups: Category[] = [];
   public currentBaselineGroup = {} as Category;
@@ -58,8 +57,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
   public baselineCapabilities: Capability[] = [];
   public currentCapability = {} as Capability;
   private baselineObjAssessments: ObjectAssessment[] = [];
-  private currentObjectAssessment: ObjectAssessment;
-
+  
   public showHeatmap = false;
   public allAttackPatterns: Observable<AttackPattern[]> = Observable.of([]);
   public selectedFrameworkAttackPatterns: Observable<AttackPattern[]> = Observable.of([]);
@@ -206,8 +204,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
         .subscribe(
           (capabilities: Capability[]) => {
             this.baselineCapabilities = (capabilities) ? capabilities.slice() : [];
-            console.log('Current baseline capabilities:');
-            console.log(JSON.stringify(this.baselineCapabilities));
             this.updateNavigations();
           },
           (err) => console.log(err));
@@ -597,11 +593,9 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
     let index = 2;   // start at 2; 1 is 'GROUP SETUP'
     this.baselineGroups.forEach((category) => {
       this.navigations.push( { id: category.id, label: category.name,  page: index++ } );
-      console.log('Added category: ', category.name);
       let capsForThisCategory = this.baselineCapabilities.filter(cap => cap.category === category.name);
       capsForThisCategory.forEach((cap) => {
           this.navigations.push( { id: cap.id, label: cap.name,  page: index++ } );
-          console.log('Added capability: ', cap.name);
         })
     });
   }
@@ -660,7 +654,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
       const sub$ = dialog.afterClosed().subscribe(
         (result) => {
           if (result) {
-            console.log('selected patterns', result);
             this.selectedAttackPatterns = result;
           }
           this.showHeatmap = false;

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -236,11 +236,9 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
         .subscribe(
           (baselineObjAssessments: ObjectAssessment[]) => {
             this.baselineObjAssessments = baselineObjAssessments;
-            this.currentBaseline.assessments = this.baselineObjAssessments.map(objAssess => objAssess.id);
-            this.wizardStore.dispatch(new SetBaseline(this.currentBaseline));
           },
         (err) => console.log(err));
-      
+
       this.allAttackPatterns = this.wizardStore
         .select('baseline')
         .pluck<{}, AttackPattern[]>('allAttackPatterns')


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1066

There is an issue with how the object assessment list in the assessment set is maintained, but that issue is independent of this issue and will be addressed in my next PR.

## To test:
1. Pull this PR
2. Restart unfetter-ui:  `docker-compose restart unfetter-ui`
3. Create a baseline with one or more categories and one or more capabilities
4. Save it
5. Should navigate back to summary screen (though summary data currently doesn't reflect baseline contents)
6. Examine DB and note new x-unfetter-assessment-set entry
