### PR TITLE
added support for adding categories

### DIFF
--- a/src/app/baseline/wizard/category/category.component.html
+++ b/src/app/baseline/wizard/category/category.component.html
@@ -3,6 +3,24 @@
         <div class="col-sm-9">
           Capability Groups
         </div>
+        <div class="col-sm-3">
+          <div *ngIf="!isAddCategory" class="button-row">
+            <button mat-raised-button (click)="createNewCategory()"><i class="material-icons">add</i>ADD GROUP</button>
+          </div>          
+        </div>
+      </div>
+      <div *ngIf="isAddCategory">
+        <div class="row margin-bottom flex-sm flexItemsCenter">
+          <div class="col-sm-9">
+            <div class="form-group">
+              <mat-input-container class="full-width">
+                <input matInput class="form-control" required placeholder="Capability Group Name" value="addCategory.name" [(ngModel)]="addCategory.name">
+              </mat-input-container>
+            </div>
+            <button type="submit"  class="mat-primary" mat-raised-button [disabled]="!addCategory.name" (click)="addNewCategory(addCategory)"><i class="material-icons">save</i> SAVE {{ addCategory.name }}</button>
+            <button type="submit"  class="mat-primary" mat-raised-button (click)="cancelAddNewCategory()">CANCEL</button>
+          </div>
+        </div>
       </div>
       <div class="row margin-bottom" *ngFor="let selCategory of selectedCapabilityGroups; index as i; trackBy: trackByFn">
         <div class="col-xs-12">

--- a/src/app/baseline/wizard/category/category.component.spec.ts
+++ b/src/app/baseline/wizard/category/category.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { MatButtonModule, MatCardModule, MatIconModule, MatSelectModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule, combineReducers } from '@ngrx/store';
@@ -22,6 +23,7 @@ describe('CategoryComponent', () => {
     TestBed.configureTestingModule({
       declarations: [CategoryComponent],
       imports: [
+        FormsModule,
         RouterTestingModule,
         NoopAnimationsModule,
         ...matModules,

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -15,6 +15,8 @@ import * as assessReducers from '../../store/baseline.reducers';
 export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {    
   public static readonly DEFAULT_VALUE = undefined;
   
+  public isAddCategory: boolean = false;
+  public addCategory: Category = new Category();
   public selectedCapabilityGroups: Category[] = [];
   public categories: Category[];
   private baselineCapabilities: Capability[];
@@ -79,6 +81,37 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   public trackByFn(index, item) {
     return ((item !== undefined) ? item.id : item) || index;
+  }
+
+  /*
+   * @description Initialize variables to create a new category
+   * @returns {void}
+   */
+  private createNewCategory(): void {
+    this.isAddCategory = true;
+    this.addCategory = new Category();
+  }
+  
+  /*
+   * @description Create a new category and add the category to the categories list
+   * @returns {void}
+   */
+  private addNewCategory(): void {
+    
+    this.categories.push(this.addCategory);
+    this.wizardStore.dispatch(new assessActions.SetCapabilityGroups(this.categories));
+    
+    this.isAddCategory = false;
+    this.addCategory = new Category();
+  }
+
+  /*
+   * @description Cancel creating a new category
+   * @returns {void}
+   */
+  private cancelAddNewCategory(): void {
+    this.isAddCategory = false;
+    this.addCategory = new Category();
   }
 
   /*


### PR DESCRIPTION
Issue 1059: Assessments: Add support for addition of categories within category selector
ADD GROUP button added to category selector baseline wizard component
Click button to open category (Capability Group) creation field, enter new category (Capability Group) name and click SAVE.
New category (Capability Group) will be added to the drop-down list of categories (Capability Groups).