### PR TITLE
allow for capability only assessments

### DIFF
--- a/src/app/assess/v3/store/assess.effects.ts
+++ b/src/app/assess/v3/store/assess.effects.ts
@@ -73,7 +73,6 @@ export class AssessEffects {
             new assessActions.LoadCurrentBaselineQuestions(baseline as AssessmentSet),
             // full capabilities needs to look up category names
             new assessActions.FetchCapabilities(),
-            new assessActions.FinishedLoading(true),
           ];
         }),
         catchError((err) => {
@@ -153,7 +152,12 @@ export class AssessEffects {
     .switchMap(() => {
       // fetch full capability objects, useful for lookups
       return this.baselineService.getCapabilities().pipe(
-        map((arr) => new assessActions.SetCapabilities(arr)),
+        mergeMap((arr) => {
+          return [ 
+            new assessActions.SetCapabilities(arr), 
+            new assessActions.FinishedLoading(true) 
+          ];
+        }),
         catchError((err) => {
           console.log(err);
           return Observable.of(new assessActions.FailedToLoad(true));

--- a/src/app/assess/v3/store/assess.effects.ts
+++ b/src/app/assess/v3/store/assess.effects.ts
@@ -2,6 +2,7 @@ import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { Actions, Effect } from '@ngrx/effects';
+import { Action } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { catchError, flatMap, map, mergeMap, tap } from 'rxjs/operators';
 import { Assess3Meta } from 'stix/assess/v3/assess3-meta';
@@ -65,15 +66,21 @@ export class AssessEffects {
 
       return Observable.forkJoin(...observables).pipe(
         mergeMap(([indicators, mitigations, baseline]) => {
-          return [
+          const actions: Action[] = [
             new assessActions.SetIndicators(indicators as Indicator.UnfetterIndicator[]),
             new assessActions.SetMitigations(mitigations as Stix[]),
             new assessActions.SetCurrentBaseline(baseline as AssessmentSet),
-            // resolve baseline question ids to full questions
-            new assessActions.LoadCurrentBaselineQuestions(baseline as AssessmentSet),
-            // full capabilities needs to look up category names
-            new assessActions.FetchCapabilities(),
           ];
+          const curBaseline = baseline as AssessmentSet;
+          if (curBaseline && curBaseline.assessments) {
+            // resolve baseline question ids to full questions
+            actions.push(new assessActions.LoadCurrentBaselineQuestions(curBaseline));
+            // full capabilities needs to look up category names
+            actions.push(new assessActions.FetchCapabilities());
+          } else {
+            actions.push(new assessActions.FinishedLoading(true));
+          }
+          return actions;
         }),
         catchError((err) => {
           console.log(err);

--- a/src/app/assess/v3/store/assess.effects.ts
+++ b/src/app/assess/v3/store/assess.effects.ts
@@ -153,9 +153,9 @@ export class AssessEffects {
       // fetch full capability objects, useful for lookups
       return this.baselineService.getCapabilities().pipe(
         mergeMap((arr) => {
-          return [ 
-            new assessActions.SetCapabilities(arr), 
-            new assessActions.FinishedLoading(true) 
+          return [
+            new assessActions.SetCapabilities(arr),
+            new assessActions.FinishedLoading(true)
           ];
         }),
         catchError((err) => {

--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -415,9 +415,8 @@ export class WizardComponent extends Measurements
    */
   public determinePanelsWithData(): SidePanelName[] {
     const panels = [...this.sidePanelOrder];
-    const hasContents = panels.filter(name => {
-      return this[name] && this[name].length > 0;
-    });
+    const hasContents = panels
+      .filter(((name) => this[name] && this[name].length > 0));
     return hasContents;
   }
 
@@ -427,6 +426,9 @@ export class WizardComponent extends Measurements
    */
   public determineFirstOpenSidePanel(): SidePanelName {
     const hasContents = this.determinePanelsWithData();
+    if (!hasContents || hasContents.length === 0) {
+      console.warn('failed to determine what panels if any have contents, attempting to move on...');
+    }
     // return first panel w/ data
     return hasContents[0];
   }


### PR DESCRIPTION
fixes unfetter-discover/unfetter#1089

## problem
Capability only assessments do not display the wizard.  There is a race condition where the page thinks all data is loaded but the capabilities are not loaded yet.

## changes
signal the page finished loading flag, and if selected after capabilities are loaded
the capabilities requires a few more calls to load questions than the other types, thus the complexity

## test 
pull this feature branch
build request the wizard to load a page with all permutations of the three types or missing types
_Note_ you do not have to verify a full save of an assessment, just simply get the correct set of question types to load
verification is, ensure the wizard at least renders
