### PR TITLE
added unit tests for config and user selectors

### DIFF
--- a/src/app/root-store/config/config.selectors.spec.ts
+++ b/src/app/root-store/config/config.selectors.spec.ts
@@ -1,0 +1,46 @@
+import { getConfigState, getPreferredKillchainPhases, DEFAULT_KILL_CHAIN } from './config.selectors';
+import { mockConfig } from '../../testing/mock-store';
+import { ConfigState, initialState } from './config.reducers';
+import { AppState } from '../../app.service';
+
+describe('config selectors', () => {
+    let mockConfigStore: ConfigState;    
+
+    beforeEach(() => {
+        mockConfigStore = {
+            configurations: mockConfig
+        };
+    });
+
+    describe('getConfigState', () => {
+        it('should return config State', () => {
+            const appInitialState: AppState | any = {
+                config: initialState
+            };
+            expect(getConfigState(appInitialState)).toEqual(initialState);
+        });
+    })
+
+    describe('getPreferredKillchainPhases', () => {      
+        it('should correct phases given a valid KC name', () => {
+            const mockPreferredKillChain: string = mockConfig.killChains[0].name;
+            const result = getPreferredKillchainPhases.projector(mockConfigStore, mockPreferredKillChain);
+            expect(result).toEqual(mockConfig.killChains[0].phase_names);
+            
+            const mockPreferredKillChain2: string = mockConfig.killChains[1].name;
+            const result2 = getPreferredKillchainPhases.projector(mockConfigStore, mockPreferredKillChain2);
+            expect(result2).toEqual(mockConfig.killChains[1].phase_names);
+        });
+        
+        it('should return [] with an invalid KC name', () => {
+            const result = getPreferredKillchainPhases.projector(mockConfigStore, 'thisIsSoFake');
+            expect(result).toEqual([]);
+        });
+        
+        it('should return default phases with no preference', () => {
+            const defaultPhases = mockConfig.killChains.find((kc) => kc.name === DEFAULT_KILL_CHAIN).phase_names;
+            const result = getPreferredKillchainPhases.projector(mockConfigStore, null);
+            expect(result).toEqual(defaultPhases);
+        });
+    });
+});

--- a/src/app/root-store/config/config.selectors.ts
+++ b/src/app/root-store/config/config.selectors.ts
@@ -3,7 +3,7 @@ import { createSelector } from '@ngrx/store';
 import { AppState } from '../app.reducers';
 import { getPreferredKillchain } from '../users/user.selectors';
 
-const DEFAULT_KILL_CHAIN = 'mitre-attack';
+export const DEFAULT_KILL_CHAIN = 'mitre-attack';
 
 export const getConfigState = (state: AppState) => state.config;
 

--- a/src/app/root-store/users/user.selectors.spec.ts
+++ b/src/app/root-store/users/user.selectors.spec.ts
@@ -1,0 +1,36 @@
+import { demoUser } from '../../testing/demo-user';
+import { UserProfile } from '../../models/user/user-profile';
+import { initialState, UserState } from './users.reducers';
+import { AppState } from '../app.reducers';
+import { getUserState, getPreferredKillchain } from './user.selectors';
+
+describe('user selectors', () => {
+
+    let mockUserStore: UserState | any;
+
+    beforeEach(() => {
+        mockUserStore = {
+            userProfile: { ...demoUser }
+        };
+    });
+
+    describe('getUserState', () => {
+        it('should return config State', () => {
+            const appInitialState: AppState | any = {
+                users: initialState
+            };
+            expect(getUserState(appInitialState)).toEqual(initialState);
+        });
+    });
+
+    describe('getPreferredKillchain', () => {
+        it('should return null when user doesnt have a preferred kill chain', () => {
+            mockUserStore.userProfile.preferences = {};
+            expect(getPreferredKillchain.projector(mockUserStore)).toBe(null);
+        });
+
+        it('should return preferred kill chain', () => {
+            expect(getPreferredKillchain.projector(mockUserStore)).toEqual(demoUser.preferences.killchain);
+        });        
+    });
+});


### PR DESCRIPTION
Unit tests for the NGRX selectors added during a previous issue.

supports unfetter-discover/unfetter#1090