### PR TITLE
indicators sharing techniques filter preferred threat framework

### DIFF
--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -214,10 +214,7 @@
             <h4 class="fw400">
               <a routerLink="/stix/x-unfetter-sensors/{{sensor.id}}">{{sensor.name}}</a>
             </h4>
-            <p>
-              <label>Observed Data</label>
-              <observable-data-summary [observedData]="sensor.metaProperties.observedData"></observable-data-summary>
-            </p>
+            <p *ngIf="sensor.description">{{ sensor.description }}</p>
           </div>
         </mat-tab>
 

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.spec.ts
@@ -12,6 +12,7 @@ import { configReducer } from '../../root-store/config/config.reducers';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
 import { OverlayContainer } from '@angular/cdk/overlay';
+import { usersReducer } from '../../root-store/users/users.reducers';
 
 describe('IndicatorSharingFiltersComponent', () => {
     let overlayContainerElement: HTMLElement;
@@ -20,6 +21,7 @@ describe('IndicatorSharingFiltersComponent', () => {
     let store;
 
     let mockReducer: ActionReducerMap<any> = {
+        users: usersReducer,
         config: configReducer,
         indicatorSharing: indicatorSharingReducer
     };

--- a/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-filters/indicator-sharing-filters.component.ts
@@ -12,6 +12,7 @@ import { IndicatorHeatMapFilterComponent } from '../indicator-tactics/indicator-
 import { getPreferredKillchainPhases } from '../../root-store/config/config.selectors';
 import { RxjsHelpers } from '../../global/static/rxjs-helpers';
 import { ConfigKeys } from '../../global/enums/config-keys.enum';
+import { UserState } from '../../root-store/users/users.reducers';
 
 @Component({
   selector: 'indicator-sharing-filters',
@@ -81,9 +82,20 @@ export class IndicatorSharingFiltersComponent implements OnInit {
 
     const getAttackPatterns$ = this.store.select('indicatorSharing')
       .pluck('attackPatterns')
+      .withLatestFrom(this.store.select('users'))
       .subscribe(
-        (attackPatterns: any[]) => {
-          this.attackPatterns = attackPatterns;
+        ([attackPatterns, user]: [any[], UserState]) => {
+          if (user.userProfile.preferences && user.userProfile.preferences.killchain) {
+            this.attackPatterns = attackPatterns
+              .filter((ap) => {
+                return ap.kill_chain_phases &&
+                  ap.kill_chain_phases
+                    .map((kc) => kc.kill_chain_name)
+                    .includes(user.userProfile.preferences.killchain);
+              });
+          } else {
+            this.attackPatterns = attackPatterns;
+          }
         },
         (err) => {
           console.log(err);

--- a/src/app/indicator-sharing/indicator-sharing.service.ts
+++ b/src/app/indicator-sharing/indicator-sharing.service.ts
@@ -102,6 +102,7 @@ export class IndicatorSharingService {
         const projectObj = {
             'stix.name': 1,
             'stix.id': 1,
+            'stix.description': 1,
             'metaProperties.observedData': 1
         };
         const filterObj = {

--- a/src/app/testing/test-user.ts
+++ b/src/app/testing/test-user.ts
@@ -34,6 +34,9 @@ export const testUser = {
             };
         })
     },
+    preferences: {
+        killchain: 'mitre-attack'
+    },
     token: 'Bearer 123',
     authenticated: true,
     approved: true,


### PR DESCRIPTION
Proper testing of this issue will create a bug that is unrelated to the changed in this issue.  This unrelated bug is being addressed via: https://github.com/unfetter-discover/unfetter/issues/1122

In the meantime, to run this testing procedure, you must go to `unfetter-ui/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html` and comment out the `indicator-tactics` component on lines 77-79.

Goal of this PR:
- AE techniques filter only displays techniques with kill chain phases of the users preferred threat framework

Instructions:
- Create an attack pattern in STIX crud, in the kill chain section add a kill chain with `mitre-mobile-attack` as the framework and `effects` as the phase
- Go to analytic exchange, create an indicator, and in Relationships => Indicated Techniques, add the attack pattern you created
- In the AE, confirm the AP you created is *not* on the indicated technique filters as it should only show techniques of the preferred threat framework
- Go to user Settings => Preferred Threat Framework, select Mitre Mobile Attack
- Go to AE => filters => Indicated Techniques, select the AP you made, and confirm the indicator you created displays (this list should likely only have the AP you created as well)

supports unfetter-discover/unfetter#1113
fixes unfetter-discover/unfetter#1112