### PR TITLE
cleaned up intrusion set filter

### DIFF
--- a/src/app/indicator-sharing/models/search-parameters.ts
+++ b/src/app/indicator-sharing/models/search-parameters.ts
@@ -11,5 +11,6 @@ export interface SearchParameters {
     dataSources: string[],
     intrusionSets: string[], // Intrusion sets are not handled by the backend, they are used to add attack patterns to the filter
     validStixPattern: boolean,
-    observedData: PatternHandlerPatternObject[]
+    observedData: PatternHandlerPatternObject[],
+    intrusionSetAttackPatterns?: string[], // Only used for final request to server
 }

--- a/src/app/indicator-sharing/store/indicator-sharing.effects.ts
+++ b/src/app/indicator-sharing/store/indicator-sharing.effects.ts
@@ -143,7 +143,6 @@ export class IndicatorSharingEffects {
             // If intrusion set, add attack patterns
             if (searchParameters.intrusionSets.length) {
                 const apSet = new Set();
-                searchParameters.attackPatterns.forEach((apId) => apSet.add(apId));
                 Object.keys(intrusionSetsByAttackpattern)
                     .forEach((apId) => {
                         searchParameters.intrusionSets
@@ -154,11 +153,11 @@ export class IndicatorSharingEffects {
                                 }
                             });
                     });
-                if (apSet.size > 0) {
-                    searchParametersCopy.attackPatterns = Array.from(apSet);
-                }
+                
+                searchParametersCopy.intrusionSetAttackPatterns = Array.from(apSet);
             }
 
+            // Delete intrusion set since its driven by the derived attack patterns
             delete searchParametersCopy.intrusionSets;
 
             return this.indicatorSharingService.doSearch(searchParametersCopy, sortBy);


### PR DESCRIPTION
Requires `issue-1124` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/205

Instructions:
- Confirm that intrusions which should return no results return no results, eg `APT12`
- Confirm that applying intrusion sets *and* techniques narrows (not broadens) the filter, eg, `APT1` (IS) and `Accessibility Features` (Technique) should return results individually, but not when applied together

fixes unfetter-discover/unfetter#1124