### PR TITLE
fixes unfetter-discover/unfetter#1165

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,9 @@ install:
 script:
   - npm run lint
   - npm run headless:coverage
-  - travis_wait 15 npm run build:prod
+  # Output something every 9 minutes (540 seconds) so Travis doesn't give up
+  - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
+  - npm run build:prod
+  # Kill background sleep loop
+  - kill %1
   - npm run doc


### PR DESCRIPTION
See Travis log for an example of this change in action.

This should allow the build:prod step to go until completion even if it is much longer than 9 minutes.
All logs will be visible as they are produced.