### PR TITLE
Set page on capability click in sidebar; also corrected back navigation

### DIFF
--- a/src/app/baseline/wizard/wizard.component.html
+++ b/src/app/baseline/wizard/wizard.component.html
@@ -11,7 +11,7 @@
     </mat-expansion-panel>
     <div *ngIf="baselineGroups.length > 0">
       <mat-expansion-panel *ngFor="let group of baselineGroups" hideToggle="true" [expanded]="currentBaselineGroup && group.name === currentBaselineGroup.name"
-        (opened)="onOpenSidePanel('capability-selector', group)" class="stepper-vertical">
+        (opened)="onOpenSidePanel('capability-selector', group, $event)" class="stepper-vertical">
         <mat-expansion-panel-header [expandedHeight]="sidePanelExpandedHeight" [collapsedHeight]="sidePanelCollapseHeight">
           <mat-panel-title >
             {{group.name | uppercase}}

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -354,7 +354,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
     this.prevPage = this.page;
     this.page = this.navigations.find(navigation => navigation.id === capabilityId).page;
-    const capability = this.baselineCapabilities.find((capability) => capability.id === capabilityId);
+    const capability = this.baselineCapabilities.find((c) => c.id === capabilityId);
     this.wizardStore.dispatch(capability);
     this.wizardStore.dispatch(new SetCurrentBaselineGroup(this.baselineGroups.find(category => category.id === capability.category)));
 

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -40,12 +40,13 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
   public meta = new Assess3Meta();
   public showSummary = false;
+  public prevPage = 1;  // for avoiding skip to group on back button presses
   public page = 1;
   public totalPages = 0;
   public insertMode = false;
   public openedSidePanel: string = this.sidePanelNames[0];
   public navigation: { id: string, label: string, page: number };
-  public navigations: any[];
+  public navigations: any[];   // These are group and capability nodes only - not including 'Group Setup' and 'Summary'
   
   private currentBaseline: AssessmentSet;
   private objAssessments: ObjectAssessment[];
@@ -296,8 +297,20 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
    * @return {void}
    */
   public onOpenSidePanel(panelName: string, group?: Category): void {
+    if (event) {
+      event.preventDefault();
+    }
+
+    // Bail if this was implicitly called as the result of a Back button press from a group or summary page
+    const prevNav = this.navigations.find(navigation => navigation.page === this.prevPage);
+    const lastNavWasGroup = prevNav && this.allCategories.find((category) => category.id === prevNav.id) !== undefined;
+    if (lastNavWasGroup || this.prevPage > 1 + this.navigations.length) {
+      return;
+    }
+
     if (group) {
       // Adjust page based on given group
+      this.prevPage = this.page;
       this.page = this.navigations.find(navigation => navigation.id === group.id).page;
 
       this.wizardStore.dispatch(new SetCurrentBaselineGroup(group));
@@ -339,11 +352,13 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
       event.preventDefault();
     }
 
-    this.page = this.navigations.find(navigation => navigation.id === capabilityId);
-    this.wizardStore.dispatch(this.baselineCapabilities.find((capability) => capability.id === capability.id));
-    this.wizardStore.dispatch(new SetCurrentBaselineGroup(this.baselineGroups.find(category => category.id === this.currentCapability.category)));
+    this.prevPage = this.page;
+    this.page = this.navigations.find(navigation => navigation.id === capabilityId).page;
+    const capability = this.baselineCapabilities.find((capability) => capability.id === capabilityId);
+    this.wizardStore.dispatch(capability);
+    this.wizardStore.dispatch(new SetCurrentBaselineGroup(this.baselineGroups.find(category => category.id === capability.category)));
 
-    this.openedSidePanel = 'capabilities';
+    this.updateWizardData();
   }
 
   /*
@@ -384,6 +399,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
     // Set page to next group in the list
     let groupIndex = this.baselineGroups.findIndex(group => group.id === this.currentBaselineGroup.id);
+    this.prevPage = this.page;
     this.page = this.navigations.find(nav => nav.id === this.baselineGroups[groupIndex + 1].id).page;
 
     this.updateWizardData();
@@ -404,6 +420,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
       event.preventDefault();
     }
 
+    this.prevPage = this.page;
     this.page = this.page - 1;
 
     this.updateWizardData();
@@ -421,6 +438,7 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
     // Set page to previous group in the list
     let groupIndex = this.baselineGroups.findIndex(group => group.id === this.currentBaselineGroup.id);
+    this.prevPage = this.page;
     this.page = this.navigations.find(nav => nav.id === this.baselineGroups[groupIndex - 1].id).page;
 
     this.updateWizardData();


### PR DESCRIPTION
Fixed unfetter-discover/unfetter#1158

Current page in wizard wasn't being correctly set when user clicks directly on a capability in the sidebar.  Now it is.

## To test:
1. Pull this
2. Restart UI:   `docker-compose restart unfetter-ui`
3. Start a new baseline
4. Add some groups and capabilities
5. Click Continue and Back to navigate around in wizard
6. Click directly on a Capability in the sidebar - ensure the correct capability page appears
7. When navigating backwards in wizard from a group or the summary page, make sure the page that appears is the previous capability and that it doesn't jump up to the previous group
