### PR TITLE
Configurable IPGeo service

### DIFF
--- a/docker-compose.build-ui.yml
+++ b/docker-compose.build-ui.yml
@@ -9,7 +9,8 @@ services:
       entrypoint:
       - npm
       - run
-      - build:demo:noclean:ff31
+      - build:prod:noclean:ff31
+      #- build:demo:noclean:ff31
       # - build:prod:noclean
       # - build:demo:noclean
       volumes:

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -23,7 +23,7 @@ class NoopComponent {
 
 }
 
-fdescribe(`App`, () => {
+describe(`App`, () => {
 
     let comp: AppComponent;
     let fixture: ComponentFixture<AppComponent>;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, ComponentFixture, async, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, Component } from '@angular/core';
 import { Location } from '@angular/common';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -18,7 +18,12 @@ import { environment } from '../environments/environment';
 import { reducers } from './root-store/app.reducers';
 import { Themes } from './global/enums/themes.enum';
 
-xdescribe(`App`, () => {
+@Component({template: 'Nothing to see here'})
+class NoopComponent {
+
+}
+
+fdescribe(`App`, () => {
 
     let comp: AppComponent;
     let fixture: ComponentFixture<AppComponent>;
@@ -60,19 +65,19 @@ xdescribe(`App`, () => {
     }
 
     const routes: Routes = [
-        { path: '', component: AppComponent },
-        { path: 'home', component: AppComponent },
-        { path: 'intrusion-set-dashboard', component: AppComponent },
-        { path: 'assessments', component: AppComponent },
-        { path: 'assess', component: AppComponent },
-        { path: 'baseline', component: AppComponent },
-        { path: 'threat-dashboard', component: AppComponent },
-        { path: 'users', component: AppComponent },
-        { path: 'indicator-sharing', component: AppComponent },
-        { path: 'events', component: AppComponent },
-        { path: 'organizations', component: AppComponent },
-        { path: 'admin', component: AppComponent },
-        { path: '**', component: AppComponent },
+        { path: '', component: NoopComponent },
+        { path: 'home', component: NoopComponent },
+        { path: 'intrusion-set-dashboard', component: NoopComponent },
+        { path: 'assessments', component: NoopComponent },
+        { path: 'assess', component: NoopComponent },
+        { path: 'baseline', component: NoopComponent },
+        { path: 'threat-dashboard', component: NoopComponent },
+        { path: 'users', component: NoopComponent },
+        { path: 'indicator-sharing', component: NoopComponent },
+        { path: 'events', component: NoopComponent },
+        { path: 'organizations', component: NoopComponent },
+        { path: 'admin', component: NoopComponent },
+        { path: '**', component: NoopComponent },
     ];
 
     // async beforeEach
@@ -82,9 +87,12 @@ xdescribe(`App`, () => {
                 imports: [
                     RouterTestingModule.withRoutes(routes),
                     HttpClientTestingModule,
-                    StoreModule.forRoot(reducers)
+                    StoreModule.forRoot(reducers),
                 ],
-                declarations: [AppComponent],
+                declarations: [
+                    NoopComponent,
+                    AppComponent,
+                ],
                 schemas: [NO_ERRORS_SCHEMA],
                 providers: [
                     AppState,
@@ -101,8 +109,8 @@ xdescribe(`App`, () => {
             })
             .compileComponents(); // compile template and css
 
-        router = TestBed.get(Router);
-        location = TestBed.get(Location);
+        // router = TestBed.get(Router);
+        // location = TestBed.get(Location);
     }));
 
     it(`should be readly initialized`, () => {
@@ -133,7 +141,7 @@ xdescribe(`App`, () => {
         });
     });
 
-    it(`should handle various router outlets`, fakeAsync(() => {
+    xit(`should handle various router outlets`, fakeAsync(() => {
         const routeChecks = [
             { path: '', title: undefined, theme: Themes.DEFAULT },
             { path: 'admin', title: 'admin', theme: Themes.DEFAULT },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,7 +22,7 @@ export class AppComponent implements OnInit {
   public readonly runMode = environment.runMode;
   public readonly demoMode: boolean = (environment.runMode === 'DEMO');
   public theme: Themes = Themes.DEFAULT;
-  public title;
+  public title = '';
   public showBanner: boolean = false;
   public securityMarkingLabel: string = '';
 

--- a/src/app/assess/v3/result/summary/summary.component.ts
+++ b/src/app/assess/v3/result/summary/summary.component.ts
@@ -127,14 +127,16 @@ export class SummaryComponent implements OnInit, OnDestroy {
         filter((arr: Assessment[]) => arr && arr.length > 0)
       )
       .subscribe((arr: Assessment[]) => {
-        this.summaries = [...arr];
-        this.summary = arr[0];
-        const assessmentType = this.summaries[0].determineAssessmentType();
-        // TODO: temporary
-        if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
-          this.summaryCalculationService.isCapability = true;
-        } else {
-          this.summaryCalculationService.isCapability = false;
+        if (arr && arr.length) {
+          this.summaries = [...arr];
+          this.summary = arr[0];
+          const assessmentType = this.summaries[0].determineAssessmentType();
+          // TODO: temporary
+          if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
+            this.summaryCalculationService.isCapability = true;
+          } else {
+            this.summaryCalculationService.isCapability = false;
+          }
         }
         this.riskByAttackPatternStore.dispatch(new LoadSingleAssessmentRiskByAttackPatternData(this.assessmentId));
         this.store.dispatch(new LoadSingleRiskPerKillChainData(this.assessmentId));

--- a/src/app/baseline/create/create3.component.ts
+++ b/src/app/baseline/create/create3.component.ts
@@ -10,6 +10,7 @@ import { BaselineForm } from '../../global/form-models/baseline';
 import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { BaselineStateService } from '../services/baseline-state.service';
 import { UpdatePageTitle } from '../store/baseline.actions';
+import { AssessmentSet } from 'stix/assess/v3/baseline';
 
 @Component({
   selector: 'unf-baseline-create',
@@ -53,9 +54,14 @@ export class Create3Component implements OnInit {
    * @return {void}
    */
   public submitForm(): void {
-    this.assessMeta = this.formToAssessment(this.form);
-    console.log('submit form', this.assessMeta);
-    this.store.dispatch(new assessActions.StartBaseline(this.assessMeta));
+    const newBaseline = new AssessmentSet();
+    newBaseline.name = this.form.value.title;
+    newBaseline.description = this.form.value.description;
+    newBaseline.created_by_ref = this.form.value.created_by_ref;
+    newBaseline.created = new Date().toISOString();
+    newBaseline.assessments = [];
+    newBaseline.metaProperties = { published: false };
+    this.store.dispatch(new assessActions.StartBaseline(newBaseline));
   }
 
   /**

--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -52,7 +52,7 @@ export class UpdatePageTitle implements Action {
 export class StartBaseline implements Action {
     public readonly type = START_BASELINE;
 
-    constructor(public payload: BaselineMeta) { }
+    constructor(public payload: AssessmentSet) { }
 }
 
 export class StartBaselineSuccess implements Action {

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -140,17 +140,9 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 selectedFrameworkAttackPatterns: [...action.payload],
             });
         case baselineActions.START_BASELINE:
-            const newBaseline = new AssessmentSet();
-            const meta = action.payload;
-            newBaseline.name = meta.title;
-            newBaseline.description = meta.description;
-            newBaseline.created_by_ref = meta.created_by_ref;
-            newBaseline.created = new Date().toISOString();
-            newBaseline.assessments = [];
-            newBaseline.metaProperties = { published: false };
             return genAssessState({
               ...state,
-              baseline: newBaseline,
+              baseline: action.payload,
             });
         case baselineActions.UPDATE_PAGE_TITLE:
             const a1 = new AssessmentSet();
@@ -160,8 +152,8 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 const blMeta = action.payload as BaselineMeta;
                 a1.name = blMeta.title;
                 // Object.assign(a1, action.payload);
-                a1.description = meta.description;
-                a1.created_by_ref = meta.created_by_ref;
+                a1.description = blMeta.description;
+                a1.created_by_ref = blMeta.created_by_ref;
             }
             const s1 = genAssessState({
                 ...state,

--- a/src/app/baseline/wizard/wizard.component.html
+++ b/src/app/baseline/wizard/wizard.component.html
@@ -11,7 +11,7 @@
     </mat-expansion-panel>
     <div *ngIf="baselineGroups.length > 0">
       <mat-expansion-panel *ngFor="let group of baselineGroups" hideToggle="true" [expanded]="currentBaselineGroup && group.name === currentBaselineGroup.name"
-        (opened)="onOpenSidePanel('capability-selector', group)" class="stepper-vertical">
+        (opened)="onOpenSidePanel('capability-selector', group, $event)" class="stepper-vertical">
         <mat-expansion-panel-header [expandedHeight]="sidePanelExpandedHeight" [collapsedHeight]="sidePanelCollapseHeight">
           <mat-panel-title >
             {{group.name | uppercase}}

--- a/src/app/core/services/run-config.service.ts
+++ b/src/app/core/services/run-config.service.ts
@@ -19,6 +19,11 @@ export interface PublicConfig {
 }
 
 export interface MasterConfig extends PublicConfig {
+    ipgeo?: {
+        performLookups?: boolean;
+        expiration_time?: number;
+        max_cached_items?: number;
+    };
     contentOwner?: string;
     pagePublisher?: string;
     lastReviewed?: number;

--- a/src/app/events/events/events.component.ts
+++ b/src/app/events/events/events.component.ts
@@ -175,7 +175,7 @@ export class EventsComponent implements OnInit, OnDestroy {
 
   getDummyCity(): string {
     // Default, matches default Ip
-    let dummyCity = 'Hangzhou';
+    let dummyCity = '--';
     if (this.ips[this.dummyValue] && this.ips[this.dummyValue].city) {
       dummyCity = this.ips[this.dummyValue].city;
     } else if (this.ips[Math.abs(this.dummyValue - 1)] && this.ips[Math.abs(this.dummyValue - 1)].city) {
@@ -189,7 +189,7 @@ export class EventsComponent implements OnInit, OnDestroy {
    */
   getDummyCountry(): string {
     // Default, matches default Ip
-    let dummyCountry = 'CN';
+    let dummyCountry = '--';
     if (this.ips[this.dummyValue] && this.ips[this.dummyValue].country) {
       dummyCountry = this.ips[this.dummyValue].country;
     } else if (this.ips[Math.abs(this.dummyValue - 1)] && this.ips[Math.abs(this.dummyValue - 1)].country) {

--- a/src/app/events/events/events.component.ts
+++ b/src/app/events/events/events.component.ts
@@ -29,7 +29,8 @@ export class EventsComponent implements OnInit, OnDestroy {
   private observedData: any[];
   private dummyValue: number;
 
-  constructor(private userStore: Store<AppState>,
+  constructor(
+    private userStore: Store<AppState>,
     private store: Store<EventsState>,
     public service: EventsService,
     public ipgeo: IPGeoService,
@@ -132,11 +133,12 @@ export class EventsComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * 
    */
   public makeIPs() {
     const subips$ = Observable
       .forkJoin([1, 2, 3].map(v4 => this.ipgeo.lookup(v4 === 3 ? '124.91.183.46'
-          : [1, 2, 3, 4].map(b => Math.floor(Math.random() * 256)).join('.'))))
+          : [1, 2, 3, 4].map(() => Math.floor(Math.random() * 256)).join('.'))))
       .finally(() => {
         if (subips$) {
           subips$.unsubscribe();
@@ -146,13 +148,16 @@ export class EventsComponent implements OnInit, OnDestroy {
       })
       .subscribe(resp => {
         console.log('event ipgeo output', resp);
-        const ip = [].concat.apply([], resp).filter(r => r.success);
-        this.ips.push(...ip);
+        const ip = [].concat.apply([], resp).filter(r => r && r.success);
+        if (ip) {
+          this.ips.push(...ip);
+        }
         while (this.ips.length < 2) {
           this.ips.push({});
         }
       });
   }
+
   /**
    * @returns string
    */
@@ -160,9 +165,9 @@ export class EventsComponent implements OnInit, OnDestroy {
     // Default, matches default geo
     let dummyIp = '124.91.183.46';
     this.ipgeo.lookup(dummyIp);
-    if (this.ips[this.dummyValue].city && this.ips[this.dummyValue].ip) {
+    if (this.ips[this.dummyValue] && this.ips[this.dummyValue].city && this.ips[this.dummyValue].ip) {
       dummyIp = this.ips[this.dummyValue].ip;
-    } else if (this.ips[Math.abs(this.dummyValue - 1)].ip) {
+    } else if (this.ips[Math.abs(this.dummyValue - 1)] && this.ips[Math.abs(this.dummyValue - 1)].ip) {
       dummyIp = this.ips[Math.abs(this.dummyValue - 1)].ip;
     }
     return dummyIp;
@@ -171,22 +176,23 @@ export class EventsComponent implements OnInit, OnDestroy {
   getDummyCity(): string {
     // Default, matches default Ip
     let dummyCity = 'Hangzhou';
-    if (this.ips[this.dummyValue].city) {
+    if (this.ips[this.dummyValue] && this.ips[this.dummyValue].city) {
       dummyCity = this.ips[this.dummyValue].city;
-    } else if (this.ips[Math.abs(this.dummyValue - 1)].city) {
+    } else if (this.ips[Math.abs(this.dummyValue - 1)] && this.ips[Math.abs(this.dummyValue - 1)].city) {
       dummyCity = this.ips[Math.abs(this.dummyValue - 1)].city;
     }
     return dummyCity;
   }
+
   /**
    * @returns string
    */
   getDummyCountry(): string {
     // Default, matches default Ip
     let dummyCountry = 'CN';
-    if (this.ips[this.dummyValue].country) {
+    if (this.ips[this.dummyValue] && this.ips[this.dummyValue].country) {
       dummyCountry = this.ips[this.dummyValue].country;
-    } else if (this.ips[Math.abs(this.dummyValue - 1)].country) {
+    } else if (this.ips[Math.abs(this.dummyValue - 1)] && this.ips[Math.abs(this.dummyValue - 1)].country) {
       dummyCountry = this.ips[Math.abs(this.dummyValue - 1)].country;
     }
     return dummyCountry;

--- a/src/app/events/ipgeo.service.spec.ts
+++ b/src/app/events/ipgeo.service.spec.ts
@@ -4,13 +4,18 @@ import { Observable } from 'rxjs/Observable';
 
 import { IPGeoService } from './ipgeo.service';
 import { GenericApi } from '../core/services/genericapi.service';
+import { RunConfigService } from '../core/services/run-config.service';
 
 describe('ipgeo service', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-            providers: [IPGeoService, GenericApi],
+            providers: [
+                RunConfigService,
+                IPGeoService,
+                GenericApi,
+            ],
         });
     });
 

--- a/src/app/events/ipgeo.service.ts
+++ b/src/app/events/ipgeo.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Store } from '@ngrx/store';
 
+import { RunConfigService } from '../core/services/run-config.service';
 import { GenericApi } from '../core/services/genericapi.service';
 import { Constance } from '../utils/constance';
 
@@ -18,23 +18,37 @@ export class IPGeoService {
 
     private ipCache: IPGeoData[] = [];
 
-    // @todo make these configurable
-    private EXPIRATION_TIME = 1 * 60 * 60 * 1000;
-    private MAX_CACHED_ITEMS = 1000;
+    private perform_lookups = true;
+
+    private expiration_time = 1 * 60 * 60 * 1000;
+
+    private max_cached_items = 1000;
 
     constructor(
+        private runConfigService: RunConfigService,
         private genericApi: GenericApi,
     ) {
-        // Nothing to do.
+        this.runConfigService.config.subscribe(
+            config => {
+                if (config && config.ipgeo) {
+                    this.perform_lookups = (config.ipgeo.performLookups !== false);
+                    this.expiration_time = config.ipgeo.expiration_time || (1 * 60 * 60 * 1000);
+                    this.max_cached_items = config.ipgeo.max_cached_items || 1000;
+                }
+            }
+        );
     }
 
     /**
      * @description executes the query function against each IP lookup provider until one returns a valid result
      */
     public lookup(ip: string): Observable<any> {
+        if (!this.perform_lookups) {
+            return Observable.of({});
+        }
         const cached = this.ipCache[ip];
         if (cached !== undefined) {
-            if (Date.now() - cached.time < this.EXPIRATION_TIME) {
+            if (Date.now() - cached.time < this.expiration_time) {
                 return Observable.of(cached.data);
             }
             delete this.ipCache[ip];
@@ -42,7 +56,7 @@ export class IPGeoService {
         return this.genericApi.get(`${Constance.IPGEO_LOOKUP_URL}?ip=${ip}`)
             .do(data => {
                 this.ipCache[ip] = { data: data, time: Date.now(), };
-                while (Object.keys(this.ipCache).length > this.MAX_CACHED_ITEMS) {
+                while (Object.keys(this.ipCache).length > this.max_cached_items) {
                     const eldest = Object.keys(this.ipCache).reduce(
                         (oldest, curr) => 
                             (this.ipCache[curr].time < oldest.time) ? {ip: curr, ...this.ipCache[curr]} : oldest,


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1164.

With PR https://github.com/unfetter-discover/unfetter-store/pull/206.

Adds ability to configure using the IPGeo backend service, including disabling it. Should allow the Events dashboard to load on internal networks that lack access to external IPGeo REST services.

To test:
- If you do not have a src/assets/private-config.json file, create one with an empty JSON object {}.
- Add the following to the src/assets/private-config.json file:
```
    "ipgeo": {
        "performLookups": true
    }
```
- If the UI is not up, bring it up; otherwise, refresh your browser page.
- Go to the Events dashboard. Bottom table should list locations for random IP addresses shown (if it doesn't, the random IPs may actually be unknown, so refresh a couple times to be sure it isn't broken).
- Change the `performLookups` value to `false` and save.
- Refresh the Events dashboard. The bottom table should show `--` values for city and country re the IP addresses listed.