### PR TITLE
assessments beta full results tab

### DIFF
--- a/src/app/assess/v2/result/full/full.component.ts
+++ b/src/app/assess/v2/result/full/full.component.ts
@@ -9,6 +9,7 @@ import { Assessment } from 'stix/assess/v2/assessment';
 import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
 import { ConfirmationDialogComponent } from '../../../../components/dialogs/confirmation/confirmation-dialog.component';
 import { MasterListDialogTableHeaders } from '../../../../global/components/master-list-dialog/master-list-dialog.component';
+import { AngularHelper } from '../../../../global/static/angular-helper';
 import { UserProfile } from '../../../../models/user/user-profile';
 import { AppState } from '../../../../root-store/app.reducers';
 import { Constance } from '../../../../utils/constance';
@@ -312,14 +313,15 @@ export class FullComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description angular track by list function, uses the items id if
-   *  it exists, otherwise uses the index
+   * @description angular track by list function, 
+   *  uses the items id iff (if and only if) it exists, 
+   *  otherwise uses the index
    * @param {number} index
    * @param {item}
    * @return {number}
    */
   public trackByFn(index: number, item: any): number {
-    return item.id || index;
+    return AngularHelper.genericTrackBy(index, item);
   }
 
   /**

--- a/src/app/assess/v2/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v2/result/full/group/assessments-group.component.html
@@ -4,7 +4,7 @@
             <div class="phase-header">{{activePhase | capitalize}}</div>
             <div *ngIf="attackPatternsByPhase && attackPatternsByPhase.length">
                 <span class="fs-12">Attack Patterns</span>
-                <div *ngFor="let ap of attackPatternsByPhase" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(ap.attackPatternId) }"
+                <div *ngFor="let ap of attackPatternsByPhase; trackBy: trackByFn" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(ap.attackPatternId) }"
                     (click)="setAttackPattern(ap.attackPatternId)">
                     <risk-icon [risk]="getRiskByAttackPatternId(ap.attackPatternId)" [showTooltip]="true" showTextShadow="false"></risk-icon>&nbsp;
                     <span>{{ ap.attackPatternName }}</span>
@@ -15,14 +15,12 @@
             </div>
             <div *ngIf="unassessedAttackPatterns && unassessedAttackPatterns.length > 0">
                 <span class="fs-12">Unassessed Attack Patterns</span>
-                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)"
-                    [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)
-                }">
+                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns; trackBy: trackByFn" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)"
+                    [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)}">
                     <span>{{ unassessedAttackPattern.name }}</span>
                 </div>
             </div>
         </div>
-
         <div class="flex-grow centered ap-section" *ngIf="currentAttackPattern">
             <div class="ap-details">
                 <div class="ap-header">{{ currentAttackPattern.name }}</div>
@@ -33,11 +31,11 @@
                     <p>{{ getRiskByAttackPatternId(currentAttackPattern.id) | percent:'2.1-1' }}</p>
                 </div>
 
-                <div *ngIf=" currentAttackPattern.kill_chain_phases && currentAttackPattern.kill_chain_phases.length> 0">
+                <div *ngIf="currentAttackPattern.kill_chain_phases && currentAttackPattern.kill_chain_phases.length> 0">
                     <p>
                         <strong>Tactics</strong>
                     </p>
-                    <p *ngFor="let killchain of currentAttackPattern.kill_chain_phases">{{ killchain.kill_chain_name | capitalize }} &bull;
+                    <p *ngFor="let killchain of currentAttackPattern.kill_chain_phases; trackBy: trackByFn">{{ killchain.kill_chain_name | capitalize }} &bull;
                         <span class="text-muted">{{ killchain.phase_name | capitalize }}</span>
                     </p>
                 </div>
@@ -60,7 +58,7 @@
                     <p>
                         <strong>External References</strong>
                     </p>
-                    <p *ngFor="let ref of currentAttackPattern.external_references">
+                    <p *ngFor="let ref of currentAttackPattern.external_references; trackBy: trackByFn">
                         <a href="{{ ref.url }}" target="_blank">{{ ref.source_name }}
                             <span *ngIf="ref.external_id">&bull; {{ ref.external_id }}</span>
                         </a>
@@ -75,7 +73,7 @@
                     [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment(assessmentId) : 0"></unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
-                    <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'">
+                    <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'; trackBy: trackByFn">
                         <mat-card class="uf-mat-card">
                             <mat-card-title>
                                 <img src="{{ getStixIcon(assessedObj.stix.type) }}" alt=""> {{ assessedObj.stix.name }}</mat-card-title>
@@ -88,11 +86,11 @@
 
                             <mat-card-content>
                                 <div *ngIf="assessedObj.editActive">
-                                    <div *ngFor="let measurement of assessedObj.questions">
+                                    <div *ngFor="let measurement of assessedObj.questions; trackBy: trackByFn">
                                         <label class="mat-label">{{measurement.name | capitalize}}</label>
                                         <mat-form-field class="full-width">
                                             <mat-select [(ngModel)]="measurement.risk" class="full-width matSelectBotMargin">
-                                                <mat-option *ngFor="let option of measurement.options" [value]="option.risk">
+                                                <mat-option *ngFor="let option of measurement.options; trackBy: trackByFn" [value]="option.risk">
                                                     {{ option.name }}
                                                 </mat-option>
                                             </mat-select>

--- a/src/app/assess/v2/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v2/result/full/group/assessments-group.component.ts
@@ -3,17 +3,19 @@ import { distinctUntilChanged, filter, pluck } from 'rxjs/operators';
 import { AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, ViewChildren } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { Observable ,  Subscription } from 'rxjs';
-import { AuthService } from '../../../../../core/services/auth.service';
-import { FormatHelpers } from '../../../../../global/static/format-helpers';
-import { SortHelper } from '../../../../../global/static/sort-helper';
-import { StixPermissions } from '../../../../../global/static/stix-permissions';
-import { Relationship } from '../../../../../models';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 import { AssessAttackPatternMeta } from 'stix/assess/v2/assess-attack-pattern-meta';
 import { Assessment } from 'stix/assess/v2/assessment';
 import { AssessmentObject } from 'stix/assess/v2/assessment-object';
 import { AssessmentQuestion } from 'stix/assess/v2/assessment-question';
 import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
+import { AuthService } from '../../../../../core/services/auth.service';
+import { AngularHelper } from '../../../../../global/static/angular-helper';
+import { FormatHelpers } from '../../../../../global/static/format-helpers';
+import { SortHelper } from '../../../../../global/static/sort-helper';
+import { StixPermissions } from '../../../../../global/static/stix-permissions';
+import { Relationship } from '../../../../../models';
 import { Stix } from '../../../../../models/stix/stix';
 import { Constance } from '../../../../../utils/constance';
 import { AssessService } from '../../../services/assess.service';
@@ -77,7 +79,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     private route: ActivatedRoute,
     private changeDetector: ChangeDetectorRef,
     private store: Store<FullAssessmentResultState>,
-    private authService: AuthService    
+    private authService: AuthService
   ) { }
 
   /**
@@ -127,6 +129,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public initData(attackPatternIndex: number = 0): void {
     this.assessment = this.assessment || new Assessment();
+    this.unassessedPhases = [];
     this.listenForDataChanges(attackPatternIndex);
     // request for initial data changes
     this.requestDataLoad(this.assessmentId);
@@ -134,7 +137,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     const stixPermissions: StixPermissions = this.authService.getStixPermissions();
     this.canAddAssessedObjects = stixPermissions.canCreate(this.assessment);
   }
-  
+
   /**
    * @description request data
    * @returns {void}
@@ -271,6 +274,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public setPhase(phaseName: string, attackPatternIndex: number = 0) {
     this.resetNewAssessmentObjects();
+    this.unassessedAttackPatterns = [];
     this.activePhase = phaseName;
     this.attackPatternsByPhase = this.getAttackPatternsByPhase(this.activePhase);
     let currentAttackPatternId = '';
@@ -382,10 +386,17 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
       .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}?filter=${encodeURI(JSON.stringify(query))}`)
       .subscribe(
         (data: Stix[]) => {
-          // Get unassessed attack patterns
-          this.unassessedAttackPatterns = data
-            .filter((ap) => !assessedAps.includes(ap.id))
-            .sort(SortHelper.sortDescByField('name'));
+            const start = Date.now();
+            // Get unassessed attack patterns
+            this.unassessedAttackPatterns = data
+              .filter((ap) => !assessedAps.includes(ap.id))
+              .sort(SortHelper.sortDescByField('name'));
+            const end = Date.now();
+            const diff = start - end;
+            console.log(`filter and sort for unassessed took ${diff} millis`);
+            console.log(`hinting to change detect assessments-group.component`);
+            // trigger change detection when finished
+            this.changeDetector.detectChanges();
         },
         (err) => console.log(err)
       );
@@ -514,5 +525,17 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public isCurrentAttackPattern(attackPatternId = ''): boolean {
     return this.currentAttackPattern ? this.currentAttackPattern.id === attackPatternId : false;
+  }
+
+  /**
+   * @description angular track by list function, 
+   *  uses the items id iff (if and only if) it exists, 
+   *  otherwise uses the index
+   * @param {number} index
+   * @param {item}
+   * @return {number}
+   */
+  public trackByFn(index: number, item: any): number {
+    return AngularHelper.genericTrackBy(index, item);
   }
 }

--- a/src/app/assess/v2/wizard/wizard.component.ts
+++ b/src/app/assess/v2/wizard/wizard.component.ts
@@ -168,11 +168,16 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
             includesMitigations,
             includesSensors,
           };
-          let rollupId = params.rollupId || '';
+
+          const rollupId = params.rollupId || '';
           if (rollupId) {
+            // this is an edit
             this.loadExistingAssessment(rollupId, meta);
+          } else {
+            // this is a new wizard
+            this.wizardStore.dispatch(new LoadAssessmentWizardData(meta));
           }
-          this.wizardStore.dispatch(new LoadAssessmentWizardData(meta));
+          
         },
         (err) => console.log(err),
         () => idParamSub$.unsubscribe());

--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -9,6 +9,7 @@ import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
 import { Assessment } from 'stix/assess/v3/assessment';
 import { ConfirmationDialogComponent } from '../../../../components/dialogs/confirmation/confirmation-dialog.component';
 import { MasterListDialogTableHeaders } from '../../../../global/components/master-list-dialog/master-list-dialog.component';
+import { AngularHelper } from '../../../../global/static/angular-helper';
 import { UserProfile } from '../../../../models/user/user-profile';
 import { AppState } from '../../../../root-store/app.reducers';
 import { Constance } from '../../../../utils/constance';
@@ -143,7 +144,7 @@ export class FullComponent implements OnInit, OnDestroy {
         pluck<object, Assessment>('fullAssessment'),
         distinctUntilChanged(),
         map((assessment: Assessment) => {
-          const assessmentType = assessment.determineAssessmentType();
+          const assessmentType = assessment.determineAssessmentType() || 'Unkown';
           return `${assessment.name} - ${assessmentType}`;
         }),
         catchError((err, caught) => {
@@ -292,20 +293,21 @@ export class FullComponent implements OnInit, OnDestroy {
    * @description noop
    * @return {Promise<boolean>}
    */
-  public onFilterTabChanged($event?: UIEvent): Promise<boolean> {
+  public onFilterTabChanged(event?: Event): Promise<boolean> {
     console.log('noop');
     return Promise.resolve(false);
   }
 
   /**
-   * @description angular track by list function, uses the items id if
-   *  it exists, otherwise uses the index
+   * @description angular track by list function, 
+   *  uses the items id iff (if and only if) it exists, 
+   *  otherwise uses the index
    * @param {number} index
    * @param {item}
    * @return {number}
    */
   public trackByFn(index: number, item: any): number {
-    return item.id || index;
+    return AngularHelper.genericTrackBy(index, item);
   }
 
   /**

--- a/src/app/assess/v3/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.html
@@ -72,7 +72,7 @@
                 <unf-add-assessed-object #addAssessedObjectComponent *ngIf="assessment && canAddAssessedObjects" [assessment]="assessment" [addAssessedObject]="addAssessedObject"
                     [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [indicator]="indicator"
                     [courseOfAction]="courseOfAction" [xUnfetterSensor]="xUnfetterSensor" [displayedAssessedObjects]="displayedAssessedObjects"
-                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment(assessmentId) : 0"></unf-add-assessed-object>
+                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment() : 0"></unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
                     <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'; trackBy: trackByFn">

--- a/src/app/assess/v3/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.html
@@ -4,7 +4,7 @@
             <div class="phase-header">{{activePhase | capitalize}}</div>
             <div *ngIf="attackPatternsByPhase && attackPatternsByPhase.length">
                 <span class="fs-12">Attack Patterns</span>
-                <div *ngFor="let ap of attackPatternsByPhase" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(ap.attackPatternId) }"
+                <div *ngFor="let ap of attackPatternsByPhase; trackBy: trackByFn" class="ap-list-item cursor-pointer" [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(ap.attackPatternId) }"
                     (click)="setAttackPattern(ap.attackPatternId)">
                     <risk-icon [risk]="getRiskByAttackPatternId(ap.attackPatternId)" [showTooltip]="true" showTextShadow="false"></risk-icon>&nbsp;
                     <span>{{ ap.attackPatternName }}</span>
@@ -15,7 +15,7 @@
             </div>
             <div *ngIf="unassessedAttackPatterns && unassessedAttackPatterns.length > 0">
                 <span class="fs-12">Unassessed Attack Patterns</span>
-                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)"
+                <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns; trackBy: trackByFn" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)"
                     [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)
                 }">
                     <span>{{ unassessedAttackPattern.name }}</span>
@@ -37,7 +37,7 @@
                     <p>
                         <strong>Tactics</strong>
                     </p>
-                    <p *ngFor="let killchain of currentAttackPattern.kill_chain_phases">{{ killchain.kill_chain_name | capitalize }} &bull;
+                    <p *ngFor="let killchain of currentAttackPattern.kill_chain_phases; trackBy: trackByFn">{{ killchain.kill_chain_name | capitalize }} &bull;
                         <span class="text-muted">{{ killchain.phase_name | capitalize }}</span>
                     </p>
                 </div>
@@ -60,7 +60,7 @@
                     <p>
                         <strong>External References</strong>
                     </p>
-                    <p *ngFor="let ref of currentAttackPattern.external_references">
+                    <p *ngFor="let ref of currentAttackPattern.external_references; trackBy: trackByFn">
                         <a href="{{ ref.url }}" target="_blank">{{ ref.source_name }}
                             <span *ngIf="ref.external_id">&bull; {{ ref.external_id }}</span>
                         </a>
@@ -75,7 +75,7 @@
                     [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment(assessmentId) : 0"></unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
-                    <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'">
+                    <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'; trackBy: trackByFn">
                         <mat-card class="uf-mat-card">
                             <mat-card-title>
                                 <img src="{{ getStixIcon(assessedObj.stix.type) }}" alt=""> {{ assessedObj.stix.name }}</mat-card-title>
@@ -88,11 +88,11 @@
 
                             <mat-card-content>
                                 <div *ngIf="assessedObj.editActive">
-                                    <div *ngFor="let measurement of assessedObj.questions">
+                                    <div *ngFor="let measurement of assessedObj.questions; trackBy: trackByFn">
                                         <label class="mat-label">{{measurement.name | capitalize}}</label>
                                         <mat-form-field class="full-width">
                                             <mat-select [(ngModel)]="measurement.risk" class="full-width matSelectBotMargin">
-                                                <mat-option *ngFor="let option of measurement.options" [value]="option.risk">
+                                                <mat-option *ngFor="let option of measurement.options; trackBy: trackByFn" [value]="option.risk">
                                                     {{ option.name }}
                                                 </mat-option>
                                             </mat-select>

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -1,21 +1,25 @@
 
-import { pluck,  distinctUntilChanged ,  filter  } from 'rxjs/operators';
 import { AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, ViewChildren } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { Store } from '@ngrx/store';
-import { Observable ,  Subscription } from 'rxjs';
-import { AttackPattern } from 'stix/unfetter/attack-pattern';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { distinctUntilChanged, filter, pluck, switchMap } from 'rxjs/operators';
+import { Subscription } from 'rxjs/Subscription';
 import { AssessAttackPatternMeta } from 'stix/assess/v2/assess-attack-pattern-meta';
 import { AssessmentObject } from 'stix/assess/v2/assessment-object';
 import { AssessmentQuestion } from 'stix/assess/v2/assessment-question';
 import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
 import { Assessment } from 'stix/assess/v3/assessment';
+import { AttackPattern } from 'stix/unfetter/attack-pattern';
 import { Stix } from 'stix/unfetter/stix';
 import { AuthService } from '../../../../../core/services/auth.service';
+import { Tactic } from '../../../../../global/components/tactics-pane/tactics.model';
+import { AngularHelper } from '../../../../../global/static/angular-helper';
 import { FormatHelpers } from '../../../../../global/static/format-helpers';
 import { SortHelper } from '../../../../../global/static/sort-helper';
 import { StixPermissions } from '../../../../../global/static/stix-permissions';
 import { Relationship } from '../../../../../models';
+import { AppState } from '../../../../../root-store/app.reducers';
 import { Constance } from '../../../../../utils/constance';
 import { AssessService } from '../../../services/assess.service';
 import { LoadGroupAttackPatternRelationships, LoadGroupCurrentAttackPattern, LoadGroupData, PushUrl, UpdateAssessmentObject } from '../../store/full-result.actions';
@@ -52,7 +56,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Output('riskByAttackPatternChanged')
   public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
-
+  
   @ViewChildren('addAssessedObjectComponent')
   public addAssessedObjectComponents: QueryList<AddAssessedObjectComponent>;
   public addAssessedObjectComponent: AddAssessedObjectComponent;
@@ -74,10 +78,10 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   private readonly subscriptions: Subscription[] = [];
 
   constructor(
+    private appStore: Store<AppState>,
     private assessService: AssessService,
     private authService: AuthService,
     private changeDetector: ChangeDetectorRef,
-    private route: ActivatedRoute,
     private store: Store<FullAssessmentResultState>,
   ) { }
 
@@ -86,7 +90,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public ngOnInit(): void {
     this.assessmentId = this.assessment.id || '';
-    // TODO: translate the initialAttackPatternId to and index
+    // TODO: translate the initialAttackPatternId to an index
     this.initData();
   }
 
@@ -99,9 +103,12 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
-   * @description init after view
+   * @description init after child views initialize, called once
    */
   public ngAfterViewInit(): void {
+    if (!this.addAssessedObjectComponents) {
+      return;
+    }
     const sub = this.addAssessedObjectComponents.changes
       .subscribe(
         (comps: QueryList<AddAssessedObjectComponent>) => {
@@ -128,12 +135,12 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public initData(attackPatternIndex: number = 0): void {
     this.assessment = this.assessment || new Assessment();
+    this.unassessedPhases = [];
+    const stixPermissions: StixPermissions = this.authService.getStixPermissions();
+    this.canAddAssessedObjects = stixPermissions.canCreate(this.assessment);
     this.listenForDataChanges(attackPatternIndex);
     // request for initial data changes
     this.requestDataLoad(this.assessmentId);
-
-    const stixPermissions: StixPermissions = this.authService.getStixPermissions();
-    this.canAddAssessedObjects = stixPermissions.canCreate(this.assessment);
   }
 
   /**
@@ -277,6 +284,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public setPhase(phaseName: string, attackPatternIndex: number = 0) {
     this.resetNewAssessmentObjects();
+    this.unassessedAttackPatterns = [];
     this.activePhase = phaseName;
     this.attackPatternsByPhase = this.getAttackPatternsByPhase(this.activePhase);
     let currentAttackPatternId = '';
@@ -323,7 +331,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
         return 1;
       }
     });
-    return attackPatterns;
+    return ranked;
   }
 
   /**
@@ -383,19 +391,38 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     const assessedAps = this.getAttackPatternsByPhase(this.activePhase)
       .map((ap) => ap.attackPatternId);
 
-    const query = { 'stix.kill_chain_phases.phase_name': this.activePhase };
-    const s1$ = this.assessService
-      .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}?filter=${encodeURI(JSON.stringify(query))}`)
+    const s$ = this.appStore
+      .select('config')
+      .pipe(
+        switchMap(
+          (state) => {
+            // get all the phases across the frameworks
+            const phases = Object.keys(state.tacticsChains)
+              .map((curFramework) => {
+                return state.tacticsChains[curFramework].phases;
+              })
+              .reduce((acc, val) => acc.concat(val), []);
+            // look for the currently viewed phase
+            // TODO: there is potential to get the wrong phase if the phase id exists in two frameworks
+            //  however the only framework I have to match against is the users preferences
+            //  but that might not be the correct framework for this assessment
+            const curPhase = phases.filter((phase) => phase.id === this.activePhase)[0];
+            return of(curPhase.tactics);
+          }),
+    )
       .subscribe(
-        (data: Stix[]) => {
-          // Get unassessed attack patterns
-          this.unassessedAttackPatterns = data
-            .filter((ap) => !assessedAps.includes(ap.id))
+        (tactics: Tactic[]) => {
+          // Give tactics for this current phase
+          //  Get unassessed and transform to attack patterns
+          this.unassessedAttackPatterns = tactics
+            .filter((tactic) => !assessedAps.includes(tactic.id))
+            .map((tactic) => Object.assign(new AttackPattern(), tactic))
             .sort(SortHelper.sortDescByField('name'));
+          // trigger change detection when finished
+          this.changeDetector.detectChanges();
         },
-        (err) => console.log(err)
-      );
-    this.subscriptions.push(s1$);
+        (err) => console.log(err));
+    this.subscriptions.push(s$);
   }
 
   /**
@@ -520,5 +547,17 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
    */
   public isCurrentAttackPattern(attackPatternId = ''): boolean {
     return this.currentAttackPattern ? this.currentAttackPattern.id === attackPatternId : false;
+  }
+
+  /**
+   * @description angular track by list function, 
+   *  uses the items id iff (if and only if) it exists, 
+   *  otherwise uses the index
+   * @param {number} index
+   * @param {item}
+   * @return {number}
+   */
+  public trackByFn(index: number, item: any): number {
+    return AngularHelper.genericTrackBy(index, item);
   }
 }

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -27,6 +27,7 @@ import { FullAssessmentResultState } from '../../store/full-result.reducers';
 import { AddAssessedObjectComponent } from './add-assessed-object/add-assessed-object.component';
 import { DisplayedAssessmentObject } from './models/displayed-assessment-object';
 import { FullAssessmentGroup } from './models/full-assessment-group';
+import { AssessmentEvalTypeEnum } from 'stix/assess/v3/assessment-eval-type.enum';
 
 @Component({
   selector: 'unf-assess-group',
@@ -140,16 +141,21 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     this.canAddAssessedObjects = stixPermissions.canCreate(this.assessment);
     this.listenForDataChanges(attackPatternIndex);
     // request for initial data changes
-    this.requestDataLoad(this.assessmentId);
+    this.requestDataLoad();
   }
 
   /**
    * @description request data
-   * @param {string} assessmentId
    * @returns {void}
    */
-  public requestDataLoad(assessmentId: string): void {
-    this.store.dispatch(new LoadGroupData(assessmentId));
+  public requestDataLoad(): void {
+    const id = this.assessmentId;
+    const assessmentType = this.assessment.determineAssessmentType();
+    let isCapability = false;
+    if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
+      isCapability = true;
+    }
+    this.store.dispatch(new LoadGroupData({ id, isCapability }));
   }
 
   /**
@@ -158,7 +164,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public onAddAssessment(): void {
     // clear objects for the observable will detect a change
     this.displayedAssessedObjects = undefined;
-    this.requestDataLoad(this.assessmentId);
+    this.requestDataLoad();
   }
 
   /**

--- a/src/app/assess/v3/result/store/full-result.actions.ts
+++ b/src/app/assess/v3/result/store/full-result.actions.ts
@@ -61,7 +61,7 @@ export class LoadAssessmentById implements Action {
 export class LoadGroupData implements Action {
     public readonly type = LOAD_GROUP_DATA;
 
-    constructor(public payload: string) { }
+    constructor(public payload: { id: string, isCapability: boolean }) { }
 }
 export class SetGroupAssessedObjects implements Action {
     public readonly type = SET_GROUP_ASSESSMENT_OBJECTS;

--- a/src/app/assess/v3/result/store/full-result.effects.ts
+++ b/src/app/assess/v3/result/store/full-result.effects.ts
@@ -1,4 +1,3 @@
-
 import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
@@ -11,11 +10,12 @@ import { Stix } from 'stix/unfetter/stix';
 import { Relationship } from '../../../../models';
 import { Constance } from '../../../../utils/constance';
 import { AssessService } from '../../services/assess.service';
-import { 
-    DonePushUrl, FinishedLoading, LoadGroupData, LOAD_ASSESSMENTS_BY_ROLLUP_ID, LOAD_ASSESSMENT_BY_ID, LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS, 
-    LOAD_GROUP_CURRENT_ATTACK_PATTERN, LOAD_GROUP_DATA, PUSH_URL, SetAssessment, SetAssessments, SetGroupAttackPatternRelationships, 
-    SetGroupCurrentAttackPattern, SetGroupData, UPDATE_ASSESSMENT_OBJECT 
+import {
+    DonePushUrl, FinishedLoading, LoadGroupData, LOAD_ASSESSMENTS_BY_ROLLUP_ID, LOAD_ASSESSMENT_BY_ID, LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS,
+    LOAD_GROUP_CURRENT_ATTACK_PATTERN, LOAD_GROUP_DATA, PUSH_URL, SetAssessment, SetAssessments, SetGroupAttackPatternRelationships,
+    SetGroupCurrentAttackPattern, SetGroupData, UPDATE_ASSESSMENT_OBJECT
 } from './full-result.actions';
+import { AssessmentEvalTypeEnum } from 'stix';
 
 
 @Injectable()
@@ -30,124 +30,143 @@ export class FullResultEffects {
 
     @Effect()
     public fetchAssessmentsByRollupId = this.actions$
-        .ofType(LOAD_ASSESSMENTS_BY_ROLLUP_ID).pipe(
-        pluck('payload'),
-        switchMap((rollupId: string) => {
-            return this.assessService
-                .getByRollupId(rollupId).pipe(
-                mergeMap((data: Assessment[]) => [new SetAssessments(data), new FinishedLoading(true)]),
-                catchError((err) => {
-                    console.log(err);
-                    return observableEmpty();
-                }));
-        }));
+        .ofType(LOAD_ASSESSMENTS_BY_ROLLUP_ID)
+        .pipe(
+            pluck('payload'),
+            switchMap((rollupId: string) => {
+                return this.assessService
+                    .getByRollupId(rollupId).pipe(
+                        mergeMap((data: Assessment[]) => [new SetAssessments(data), new FinishedLoading(true)]),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableEmpty();
+                        }));
+            })
+        );
 
 
     @Effect()
     public fetchAssessmentById = this.actions$
-        .ofType(LOAD_ASSESSMENT_BY_ID).pipe(
-        pluck('payload'),
-        switchMap((id: string) => {
-            return this.assessService
-                .getById(id).pipe(
-                mergeMap((data: Assessment) => [new SetAssessment(data), new FinishedLoading(true)]),
-                catchError((err) => {
-                    console.log(err);
-                    return observableEmpty();
-                }));
-        }));
+        .ofType(LOAD_ASSESSMENT_BY_ID)
+        .pipe(
+            pluck('payload'),
+            switchMap((id: string) => {
+                return this.assessService
+                    .getById(id).pipe(
+                        mergeMap((data: Assessment) => [new SetAssessment(data), new FinishedLoading(true)]),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableEmpty();
+                        }));
+            })
+        );
 
 
     @Effect()
     public fetchAssessmentGroupData = this.actions$
-        .ofType(LOAD_GROUP_DATA).pipe(
-        pluck('payload'),
-        switchMap((assessmentId: string) => {
-            const getAssessedObjects$ = this.assessService.getAssessedObjects(assessmentId);
-            const getRiskByAttackPattern$ = this.assessService.getRiskPerAttackPattern(assessmentId);
-            return observableForkJoin(getAssessedObjects$, getRiskByAttackPattern$).pipe(
-                map(([assessedObjects, riskByAttackPattern]) => {
-                    riskByAttackPattern = riskByAttackPattern || new RiskByAttack();
-                    return new SetGroupData({ assessedObjects, riskByAttackPattern });
-                }),
-                catchError((err) => {
-                    console.log(err);
-                    return observableOf([]);
-                }));
-        }));
+        .ofType(LOAD_GROUP_DATA)
+        .pipe(
+            pluck('payload'),
+            switchMap((loadData: { id: string, isCapability: boolean }) => {
+                const getAssessedObjects$ = this.assessService.getAssessedObjects(loadData.id);
+                const isCapability = loadData.isCapability || false;
+                const getRiskByAttackPattern$ = this.assessService.getRiskPerAttackPattern(loadData.id, true, isCapability);
+                return observableForkJoin(getAssessedObjects$, getRiskByAttackPattern$).pipe(
+                    map(([assessedObjects, riskByAttackPattern]) => {
+                        riskByAttackPattern = riskByAttackPattern || new RiskByAttack();
+                        return new SetGroupData({ assessedObjects, riskByAttackPattern });
+                    }),
+                    catchError((err) => {
+                        console.log(err);
+                        return observableOf([]);
+                    }));
+            })
+        );
 
 
     @Effect()
     public loadGroupCurrentAttackPattern = this.actions$
         // .do((action) => console.log(`v3 - full-result.effects.ts Received ${action.type}`))
         // .filter((action) => action.type === LOAD_GROUP_CURRENT_ATTACK_PATTERN)
-        .ofType(LOAD_GROUP_CURRENT_ATTACK_PATTERN).pipe(
-        pluck('payload'),
-        switchMap((attackPatternId: string) => {
-            return this.assessService
-                .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}/${attackPatternId}`).pipe(
-                map((data: Stix) => {
-                    return new SetGroupCurrentAttackPattern({ currentAttackPattern: data });
-                }),
-                catchError((err) => {
-                    console.log(err);
-                    return observableEmpty();
-                }));
-        }));
+        .ofType(LOAD_GROUP_CURRENT_ATTACK_PATTERN)
+        .pipe(
+            pluck('payload'),
+            switchMap((attackPatternId: string) => {
+                return this.assessService
+                    .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}/${attackPatternId}`).pipe(
+                        map((data: Stix) => {
+                            return new SetGroupCurrentAttackPattern({ currentAttackPattern: data });
+                        }),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableEmpty();
+                        }));
+            })
+        );
 
 
     @Effect()
     public loadGroupAttackPatternRelationships = this.actions$
-        .ofType(LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS).pipe(
-        pluck('payload'),
-        switchMap((attackPatternId: string) => {
-            return this.assessService
-                .getAttackPatternRelationships(attackPatternId).pipe(
-                mergeMap((relationships: Relationship[]) => {
-                    return [
-                        new SetGroupAttackPatternRelationships(relationships),
-                        new FinishedLoading(true),
-                    ];
-                }),
-                catchError((err) => {
-                    console.log(err);
-                    return observableEmpty();
-                }));
-        }));
+        .ofType(LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS)
+        .pipe(
+            pluck('payload'),
+            switchMap((attackPatternId: string) => {
+                return this.assessService
+                    .getAttackPatternRelationships(attackPatternId).pipe(
+                        mergeMap((relationships: Relationship[]) => {
+                            return [
+                                new SetGroupAttackPatternRelationships(relationships),
+                                new FinishedLoading(true),
+                            ];
+                        }),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableEmpty();
+                        }));
+            }));
 
 
     @Effect()
     public pushUrlState = this.actions$
-        .ofType(PUSH_URL).pipe(
-        pluck('payload'),
-        filter((payload) => payload !== undefined),
-        tap((payload: any) => {
-            const rollupId = payload.rollupId;
-            const assessmentId = payload.assessmentId;
-            const phase = payload.phase;
-            const attackPattern = payload.attackPattern;
-            // const url = `${Constance.API_HOST}/assess-beta/result/full/${rollupId}/${assessmentId}/phase/${phase}/attackPattern/${attackPattern}`;
-            const url = `${Constance.API_HOST}/assess-beta/result/full/${rollupId}/${assessmentId}/phase/${phase}`;
-            this.location.replaceState(url);
-        }),
-        switchMap(() => observableOf(new DonePushUrl())));
+        .ofType(PUSH_URL)
+        .pipe(
+            pluck('payload'),
+            filter((payload) => payload !== undefined),
+            tap((payload: any) => {
+                const rollupId = payload.rollupId;
+                const assessmentId = payload.assessmentId;
+                const phase = payload.phase;
+                const attackPattern = payload.attackPattern;
+                // const url = `${Constance.API_HOST}/assess-beta/result/full/${rollupId}/${assessmentId}/phase/${phase}/attackPattern/${attackPattern}`;
+                const url = `${Constance.API_HOST}/assess-beta/result/full/${rollupId}/${assessmentId}/phase/${phase}`;
+                this.location.replaceState(url);
+            }),
+            switchMap(() => observableOf(new DonePushUrl()))
+        );
 
     @Effect()
     public updateAssesmentObject = this.actions$
-        .ofType(UPDATE_ASSESSMENT_OBJECT).pipe(
-        pluck('payload'),
-        filter((payload: Assessment) => payload && payload.id !== undefined),
-        switchMap((assessment: Assessment) => {
-            const id = assessment.id;
-            const o1$ = this.assessService
-                .genericPatch(`${Constance.X_UNFETTER_ASSESSMENT_URL}/${id}`, assessment)
-                .pipe(
-                    map((resp) => new LoadGroupData(id)),
-                    catchError((err) => {
-                        console.log(err);
-                        return observableEmpty();
-                    })
-                )
-            return o1$;
-        }));
+        .ofType(UPDATE_ASSESSMENT_OBJECT)
+        .pipe(
+            pluck('payload'),
+            filter((payload: Assessment) => payload && payload.id !== undefined),
+            switchMap((assessment: Assessment) => {
+                const id = assessment.id;
+                const type = assessment.determineAssessmentType();
+                let isCapability = false;
+                if (type === AssessmentEvalTypeEnum.CAPABILITIES) {
+                    isCapability = true;
+                }
+                const o1$ = this.assessService
+                    .genericPatch(`${Constance.X_UNFETTER_ASSESSMENT_URL}/${id}`, assessment)
+                    .pipe(
+                        map((resp) => new LoadGroupData({ id, isCapability })),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableEmpty();
+                        })
+                    )
+                return o1$;
+            })
+        );
 }

--- a/src/app/assess/v3/services/assess.service.ts
+++ b/src/app/assess/v3/services/assess.service.ts
@@ -200,14 +200,13 @@ export class AssessService {
      * @param {string} id
      * @return {Observable<RiskByAttack>}
      */
-    public getRiskPerAttackPattern(id: string, includeMeta = true): Observable<RiskByAttack> {
+    public getRiskPerAttackPattern(id: string, includeMeta = true, isCapability = false): Observable<RiskByAttack> {
         if (!id) {
             return observableEmpty();
         }
-        const url = `${this.assessBaseUrl}/${id}/risk-by-attack-pattern?metaproperties=${includeMeta}`;
+        const url = `${this.assessBaseUrl}/${id}/risk-by-attack-pattern?metaproperties=${includeMeta}&isCapability=${isCapability}`;
         return this.genericApi.getAs<RiskByAttack>(url);
     }
-
 
     /**
      * @description

--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -21,6 +21,7 @@ import { StixEnum } from 'stix/unfetter/stix.enum';
 import { Key } from 'ts-keycode-enum';
 import { GenericApi } from '../../../core/services/genericapi.service';
 import { heightCollapse } from '../../../global/animations/height-collapse';
+import { AngularHelper } from '../../../global/static/angular-helper';
 import { UserProfile } from '../../../models/user/user-profile';
 import { AppState } from '../../../root-store/app.reducers';
 import { Constance } from '../../../utils/constance';
@@ -948,8 +949,8 @@ export class WizardComponent extends Measurements
    * @param item
    * @returns {number}
    */
-  public trackByFn(index, item): number {
-    return item && item.id ? item.id : index;
+  public trackByFn(index: number, item: any): number {
+    return AngularHelper.genericTrackBy(index, item);
   }
 
   /**

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.html
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.html
@@ -61,11 +61,11 @@
                         <!-- Note that these actions are hard-wired at this time -->
                         <mat-cell *matCellDef="let row" class="master-list-actions {{cdefs.rowClass(row, acts)}}">
                             <div class="buttonGrp">
-                                <button mat-button (click)="onEdit(row, $event)">
-                                    <mat-icon>edit</mat-icon>
+                                <button mat-icon-button (click)="onEdit(row, $event)">
+                                    <mat-icon class="mat-24" aria-hidden="false" aria-label="edit">edit</mat-icon>
                                 </button>
-                                <button mat-button (click)="onDelete(row, $event)">
-                                    <mat-icon>delete</mat-icon>
+                                <button mat-icon-button (click)="onDelete(row, $event)">
+                                    <mat-icon class="mat-24" aria-hidden="false" aria-label="delete">delete</mat-icon>
                                 </button>
                             </div>
                         </mat-cell>

--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
@@ -123,4 +123,12 @@
         padding: 6px 0;
         padding-right: 6px;
     }
+
+    // mat-cell:last-child {
+    //     padding-right: 0px;
+    // }
+
+    .buttonGrp {
+        width: 100%;
+    }
 }

--- a/src/app/global/static/angular-helper.spec.ts
+++ b/src/app/global/static/angular-helper.spec.ts
@@ -1,0 +1,25 @@
+import { AngularHelper } from './angular-helper';
+
+describe('AngularHelper', () => {
+
+    let t: any[];
+    
+    beforeEach(() => {
+        t = [
+            { id: 1, name: 'a' },
+            { id: 2, name: 'b' },
+            { id: 3, name: 'c' },
+        ];
+    });
+
+    describe('genericTrackBy', () => {
+        it('should use an object id first if it exists', () => {
+            expect(AngularHelper.genericTrackByFn(-100, t[0])).toEqual(t[0].id);
+        });
+
+        it('should use the given index if and id does not exist', () => {
+            expect(AngularHelper.genericTrackByFn(-100, t[0])).toEqual(-100);
+        });
+    });
+
+});

--- a/src/app/global/static/angular-helper.ts
+++ b/src/app/global/static/angular-helper.ts
@@ -1,0 +1,15 @@
+
+export class AngularHelper {
+
+    /**
+     * @description angular track by list function, 
+     *  uses the items id iff (if and only if) it exists, 
+     *  otherwise uses the index
+     * @param {number} index
+     * @param { id: any } item
+     * @return {number}
+     */
+    public static genericTrackBy(index: number, item: { id: any }): number {
+        return (item && item.id) ? item.id : index;
+    }
+}


### PR DESCRIPTION
supports unfetter-discover/unfetter#1177
supports unfetter-discover/unfetter#1068

## problem
assessment beta (v3) needs to show assessed phases for capability baseline assessments
assessment v2 edit wizard did not load

## changes
* correctly load the v2 edit wizard, by not calling the effects 2x
* pass a `isCapability` to the backend `risk-by-attackpattern` endpoint to populate the assessed phases
* Improved unassessed list repsonse time
  * added `trackBy` for all the lists
  * instead of querying the backend for unassessed attack patterns, I used the ngrx `config` store

## test
pull this pr
_Edit test_
1. edit a v2 assessment, the page should load

__ Test unassessed list response time __
1. load results tab, click around the tactis and see the unassessed attack patterns list load faster
_Load assessed test_
1. create a beta assessment using a capability
2. load the capability in the results tab
3. verify there are assessed capabilities shown
see screen shot

![screen shot 2018-06-20 at 2 02 12 pm](https://user-images.githubusercontent.com/30807406/41676108-1e576f58-74b4-11e8-936c-e1b65c514745.png)

