### PR TITLE
Restores CSC tab content

### DIFF
--- a/src/app/assess/v2/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/v2/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -39,7 +39,7 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
     @Input()
     public assessedObjects: any[];
 
-    @Output('addAssessmentEvent')
+    @Output()
     public addAssessmentEvent = new EventEmitter<boolean>();
 
     public addAssessedObjectName: string = '';

--- a/src/app/assess/v2/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v2/result/full/group/assessments-group.component.ts
@@ -50,7 +50,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input()
   public assessmentGroup: Observable<FullAssessmentGroup>;
 
-  @Output('riskByAttackPatternChanged')
+  @Output()
   public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
 
   @ViewChildren('addAssessedObjectComponent')

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -39,7 +39,7 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
     @Input()
     public assessedObjects: any[];
 
-    @Output('addAssessmentEvent')
+    @Output()
     public addAssessmentEvent = new EventEmitter<boolean>();
 
     public addAssessedObjectName: string = '';

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -57,7 +57,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input()
   public unassessedPhases: string[];
 
-  @Output('riskByAttackPatternChanged')
+  @Output()
   public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
   
   @ViewChildren('addAssessedObjectComponent')

--- a/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.html
+++ b/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.html
@@ -48,7 +48,7 @@
                             </mat-tab>
 
                             <mat-tab label="Critical Security Controls (CSC)">
-                                <critical-security-controls (treeData)="treeData"></critical-security-controls>
+                                <critical-security-controls [treeData]="treeData"></critical-security-controls>
                             </mat-tab>
 
                         </mat-tab-group>

--- a/src/app/threat-dashboard/threat-report-editor/file-upload/file-upload.component.ts
+++ b/src/app/threat-dashboard/threat-report-editor/file-upload/file-upload.component.ts
@@ -16,10 +16,10 @@ export class FileUploadComponent implements OnInit {
   @ViewChild('fileUpload')
   public fileUploadEl: ElementRef;
 
-  @Output('fileParsedEvent')
+  @Output()
   public fileParsedEvent = new EventEmitter<any[]>();
 
-  @Output('fileUploadFailed')
+  @Output()
   public fileUploadFailed = new EventEmitter<string>();
 
   public success = false;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1114.

To test:
- Go to intrusion sets dashboard
- Click on an intrusion set on the left
- Wait for page to reload
- Click on `Critical Security Controls (CSC)` tab at the top
- Should show an expandable block for each intrusion set you clicked on. (It's okay if the expanded block is empty, depending on which intrusion sets you selected.)