### PR TITLE
added notification service, changed notification processing to api

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -9,6 +9,7 @@ import { GenericApi } from './services/genericapi.service';
 import { UserPreferencesService } from './services/user-preferences.service';
 import { UsersService } from './services/users.service';
 import { WebsocketService } from './services/web-socket.service';
+import { NotificationsService } from './services/notifications.service';
 
 @NgModule({
 })
@@ -25,6 +26,7 @@ export class CoreModule {
                 UsersService,
                 UserPreferencesService,
                 WebsocketService,
+                NotificationsService,
                 HttpClientModule,
                 { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
             ],

--- a/src/app/core/services/notifications.service.ts
+++ b/src/app/core/services/notifications.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { GenericApi } from './genericapi.service';
+import { Constance } from '../../utils/constance';
+import { NotificationEmitTypes } from '../../root-store/notification/notification.model';
+
+@Injectable()
+export class NotificationsService {
+
+    public readonly notificationsUrl = Constance.NOTIFICATION_STORE_URL;
+    public readonly processUrl = `${Constance.NOTIFICATION_STORE_URL}/user-notifications/process`;
+
+    constructor(
+        private genericApi: GenericApi
+    ) { }
+
+    public getNotifications(): Observable<any> {
+        return this.genericApi.get(`${this.notificationsUrl}/user-notifications`);
+    }
+
+    public readNotification(notificationId: string): Observable<any> {
+        const url = `${this.processUrl}/${NotificationEmitTypes.READ_NOTIFICATION}/${notificationId}`
+        return this.genericApi.get(url);
+    }
+
+    public deleteNotification(notificationId: string): Observable<any> {
+        const url = `${this.processUrl}/${NotificationEmitTypes.DELETE_NOTIFICATION}/${notificationId}`
+        return this.genericApi.get(url);
+    }
+
+    public readAllNotifications(): Observable<any> {
+        const url = `${this.processUrl}/${NotificationEmitTypes.READ_ALL_NOTIFICATIONS}`
+        return this.genericApi.get(url);
+    }
+
+    public deleteAllNotifications(): Observable<any> {
+        const url = `${this.processUrl}/${NotificationEmitTypes.DELETE_ALL_NOTIFICATIONS}`
+        return this.genericApi.get(url);
+    }
+}

--- a/src/app/root-store/notification/notification.effects.ts
+++ b/src/app/root-store/notification/notification.effects.ts
@@ -1,18 +1,14 @@
 
 import { map, tap, mergeMap, switchMap } from 'rxjs/operators';
+import { of as observableOf } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Actions, Effect } from '@ngrx/effects';
-import { Observable } from 'rxjs';
-
-
-
-
 
 import * as notificationActions from '../../root-store/notification/notification.actions';
 import { WebsocketService } from '../../core/services/web-socket.service';
 import { WSMessageTypes } from '../../global/enums/ws-message-types.enum';
-import { GenericApi } from '../../core/services/genericapi.service';
-import { AppNotification, NotificationEmitTypes } from './notification.model';
+import { AppNotification } from './notification.model';
+import { NotificationsService } from '../../core/services/notifications.service';
 
 @Injectable()
 export class NotificationEffects {
@@ -29,7 +25,7 @@ export class NotificationEffects {
     @Effect()
     public notificationStore = this.actions$
         .ofType(notificationActions.FETCH_NOTIFICATION_STORE).pipe(
-        switchMap(() => this.genericApi.get('api/notification-store/user-notifications')),
+        switchMap(() => this.notificationsService.getNotifications()),
         tap((notifications) => console.log(notifications)),
         mergeMap((notifications: any[]) => [
             new notificationActions.SetNotifications(
@@ -44,53 +40,53 @@ export class NotificationEffects {
 
     @Effect()
     public readNotification = this.actions$
-        .ofType(notificationActions.EMIT_READ_NOTIFCATION).pipe(
-        tap((action: {type: string, payload: AppNotification}) => {
-            this.websocketService.sendMessage({
-                messageType: NotificationEmitTypes.READ_NOTIFICATION,
-                messageContent: action.payload._id
-            });
-        }),
-        map((action: { type: string, payload: AppNotification }) => {
-            const readNotification = action.payload;
-            readNotification.read = true;
-            return new notificationActions.UpdateNotification(readNotification);
-        }));
+        .ofType(notificationActions.EMIT_READ_NOTIFCATION)
+        .pipe(
+            switchMap((action: {type: string, payload: AppNotification}) => {
+                return this.notificationsService.readNotification(action.payload._id)
+                    .pipe(
+                        switchMap(() => observableOf(action))
+                    );
+            }),
+            map((action) => {
+                const readNotification = action.payload;
+                readNotification.read = true;
+                return new notificationActions.UpdateNotification(readNotification);
+            })
+        );
 
     @Effect()
     public deleteNotification = this.actions$
-        .ofType(notificationActions.EMIT_DELETE_NOTIFCATION).pipe(
-        tap((action: { type: string, payload: AppNotification }) => {
-            this.websocketService.sendMessage({
-                messageType: NotificationEmitTypes.DELETE_NOTIFICATION,
-                messageContent: action.payload
-            });
-        }),
-        map((action: { type: string, payload: string }) => new notificationActions.DeleteNotification(action.payload)));
+        .ofType(notificationActions.EMIT_DELETE_NOTIFCATION)
+        .pipe(
+            switchMap((action: { type: string, payload: string }) => {
+                return this.notificationsService.deleteNotification(action.payload)
+                    .pipe(
+                        switchMap(() => observableOf(action))
+                    );
+            }),
+            map((action) => new notificationActions.DeleteNotification(action.payload))
+        );
 
     @Effect()
     public readAllNotifications = this.actions$
-        .ofType(notificationActions.EMIT_READ_ALL_NOTIFCATIONS).pipe(
-        tap((action: { type: string, payload: AppNotification }) => {
-            this.websocketService.sendMessage({
-                messageType: NotificationEmitTypes.READ_ALL_NOTIFICATIONS
-            });
-        }),
-        map(() => new notificationActions.MarkAllAsRead()));
+        .ofType(notificationActions.EMIT_READ_ALL_NOTIFCATIONS)
+        .pipe(
+            switchMap(() => this.notificationsService.readAllNotifications()),
+            map(() => new notificationActions.MarkAllAsRead())
+        );
 
     @Effect()
     public deleteAllNotifications = this.actions$
-        .ofType(notificationActions.EMIT_DELETE_ALL_NOTIFCATIONS).pipe(
-        tap((action: { type: string, payload: AppNotification }) => {
-            this.websocketService.sendMessage({
-                messageType: NotificationEmitTypes.DELETE_ALL_NOTIFICATIONS
-            });
-        }),
-        map(() => new notificationActions.DeleteAllNotifications()));
+        .ofType(notificationActions.EMIT_DELETE_ALL_NOTIFCATIONS)
+        .pipe(
+            switchMap(() => this.notificationsService.deleteAllNotifications()),
+            map(() => new notificationActions.DeleteAllNotifications())
+        );
 
     constructor(
         private actions$: Actions,
         private websocketService: WebsocketService,
-        private genericApi: GenericApi
+        private notificationsService: NotificationsService
     ) { }
 }

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -110,6 +110,7 @@ export const Constance = {
   PROFILE_BY_ID_URL: 'api/auth/profile',
   REFRESH_TOKEN_URL: 'api/auth/refreshtoken',
   PUBLIC_CONFIG_URL: 'api/auth/public-config',
+  NOTIFICATION_STORE_URL: 'api/notification-store',
 
   CONFIG_URL: 'api/config',
   WEB_ANALYTICS_URL: 'api/web-analytics',


### PR DESCRIPTION
Requires `issue-986` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/215

Instructions:
- Confirm notifications work as expected (see below if you need help creating notifications) with the socket server connected
- Stop the socket server by commenting `startServer();` on line 18 of `unfetter-store/unfetter-socket-server/src/server/server.ts` (this may or may not require a stack restart
- Confirm Read, Delete, Mark all as Read, Delete All operations still work

To create test notifications:
- Method 1: Use 2nd user, create STIX objects in a shared group (other than unfetter open)
- Method 2:
- `docker exec -it unfetter-socket-server /bin/ash`
- `vi ./utils/test-user-notification.sh` => edit `userId` in the API call
- `./utils/test-user-notification.sh` to send a test notification

fixes unfetter-discover/unfetter#986