### PR TITLE
Fixes unassessed assessments creation

### DIFF
--- a/src/app/assess/v3/store/assess.effects.ts
+++ b/src/app/assess/v3/store/assess.effects.ts
@@ -246,11 +246,11 @@ export class AssessEffects {
               url = `${url}/${assessment.id}`;
               return this.genericServiceApi
                 .patchAs<Assessment[]>(url, json).pipe(
-                  map<any[], Assessment[]>(RxjsHelpers.mapArrayAttributes));
+                  map<any[], Assessment[]>(RxjsHelpers.mapAttributes));
             } else {
               return this.genericServiceApi
                 .postAs<Assessment[]>(url, json).pipe(
-                  map<any[], Assessment[]>(RxjsHelpers.mapArrayAttributes));
+                  map<any[], Assessment[]>(RxjsHelpers.mapAttributes));
             }
           });
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1184.

Actions:
- Go to assessments beta page
- Create new assessment
- Select any or all categories, and Continue
- Jump to the Summary page (don't assess anything)
- Save

Previous behavior:
- UI saves assessments, one for each category, but each one lacks assessed objects. Master list dialog displays no category type for any of them. Editing shows empty assessment, no option for any categories.
- If, when you create, you assess at least one question, that category will appear properly in the master list dialog, and upon editing, but none of the other categories you originally selected will appear.

Fixed behavior:
- UI will save assessments, one assessed object that has no risk value for each category you selected, even though you made no evaluations.
- Master list dialog will display one row per category you selected.
- Editing the assessment will once again show all the categories, and allow you to edit each one. No loss of data.