### PR TITLE
show capability cards in group section of result tab

### DIFF
--- a/src/app/assess/v3/result/store/full-result.effects.ts
+++ b/src/app/assess/v3/result/store/full-result.effects.ts
@@ -10,7 +10,7 @@ import { Stix } from 'stix/unfetter/stix';
 import { Relationship } from '../../../../models';
 import { Constance } from '../../../../utils/constance';
 import { AssessService } from '../../services/assess.service';
-import { 
+import {
     DonePushUrl, FailedToLoad, FinishedLoading, LoadGroupData, LOAD_ASSESSMENTS_BY_ROLLUP_ID, LOAD_ASSESSMENT_BY_ID,
     LOAD_GROUP_ATTACK_PATTERN_RELATIONSHIPS, LOAD_GROUP_CURRENT_ATTACK_PATTERN, LOAD_GROUP_DATA, PUSH_URL, SetAssessment,
     SetAssessments, SetGroupAttackPatternRelationships, SetGroupCurrentAttackPattern, SetGroupData, UPDATE_ASSESSMENT_OBJECT
@@ -32,12 +32,14 @@ export class FullResultEffects {
             pluck('payload'),
             switchMap((rollupId: string) => {
                 return this.assessService
-                    .getByRollupId(rollupId).pipe(
+                    .getByRollupId(rollupId)
+                    .pipe(
                         mergeMap((data: Assessment[]) => [new SetAssessments(data), new FinishedLoading(true)]),
                         catchError((err) => {
                             console.log(err);
                             return observableOf(new FailedToLoad(true));
-                        }));
+                        })
+                    );
             })
         );
 
@@ -49,12 +51,14 @@ export class FullResultEffects {
             pluck('payload'),
             switchMap((id: string) => {
                 return this.assessService
-                    .getById(id).pipe(
+                    .getById(id)
+                    .pipe(
                         mergeMap((data: Assessment) => [new SetAssessment(data), new FinishedLoading(true)]),
                         catchError((err) => {
                             console.log(err);
                             return observableOf(new FailedToLoad(true));
-                        }));
+                        })
+                    );
             })
         );
 
@@ -68,18 +72,19 @@ export class FullResultEffects {
                 const getAssessedObjects$ = this.assessService.getAssessedObjects(loadData.id);
                 const isCapability = loadData.isCapability || false;
                 const getRiskByAttackPattern$ = this.assessService.getRiskPerAttackPattern(loadData.id, true, isCapability);
-                return observableForkJoin(getAssessedObjects$, getRiskByAttackPattern$).pipe(
-                    map(([assessedObjects, riskByAttackPattern]) => {
-                        riskByAttackPattern = riskByAttackPattern || new RiskByAttack();
-                        return new SetGroupData({ assessedObjects, riskByAttackPattern });
-                    }),
-                    catchError((err) => {
-                        console.log(err);
-                        return observableOf(new FailedToLoad(true));
-                    }));
+                return observableForkJoin(getAssessedObjects$, getRiskByAttackPattern$)
+                    .pipe(
+                        map(([assessedObjects, riskByAttackPattern]) => {
+                            riskByAttackPattern = riskByAttackPattern || new RiskByAttack();
+                            return new SetGroupData({ assessedObjects, riskByAttackPattern });
+                        }),
+                        catchError((err) => {
+                            console.log(err);
+                            return observableOf(new FailedToLoad(true));
+                        })
+                    );
             })
         );
-
 
     @Effect()
     public loadGroupCurrentAttackPattern = this.actions$
@@ -90,14 +95,16 @@ export class FullResultEffects {
             pluck('payload'),
             switchMap((attackPatternId: string) => {
                 return this.assessService
-                    .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}/${attackPatternId}`).pipe(
+                    .getAs<Stix>(`${Constance.ATTACK_PATTERN_URL}/${attackPatternId}`)
+                    .pipe(
                         map((data: Stix) => {
                             return new SetGroupCurrentAttackPattern({ currentAttackPattern: data });
                         }),
                         catchError((err) => {
                             console.log(err);
                             return observableOf(new FailedToLoad(true));
-                        }));
+                        })
+                    );
             })
         );
 
@@ -109,7 +116,8 @@ export class FullResultEffects {
             pluck('payload'),
             switchMap((attackPatternId: string) => {
                 return this.assessService
-                    .getAttackPatternRelationships(attackPatternId).pipe(
+                    .getAttackPatternRelationships(attackPatternId)
+                    .pipe(
                         mergeMap((relationships: Relationship[]) => {
                             return [
                                 new SetGroupAttackPatternRelationships(relationships),
@@ -119,7 +127,8 @@ export class FullResultEffects {
                         catchError((err) => {
                             console.log(err);
                             return observableOf(new FailedToLoad(true));
-                        }));
+                        })
+                    );
             }));
 
 

--- a/src/app/assess/v3/result/store/full-result.selectors.ts
+++ b/src/app/assess/v3/result/store/full-result.selectors.ts
@@ -5,6 +5,7 @@ import { ConfigState } from '../../../../root-store/config/config.reducers';
 import { Assessment } from 'stix/assess/v3/assessment';
 import { Dictionary } from 'stix/common/dictionary';
 import { TacticChain } from '../../../../global/components/tactics-pane/tactics.model';
+import { AssessmentEvalTypeEnum } from 'stix';
 
 const getConfigState = createFeatureSelector<ConfigState>('config');
 
@@ -45,6 +46,10 @@ export const getUnassessedPhasesForCurrentFramework = createSelector(
     getFullAssessment,
     getTacticsChains,
     (group: FullAssessmentGroup, assessment: Assessment, tacticsChains: Dictionary<TacticChain>) => {
+        if (assessment === undefined || tacticsChains === undefined) {
+            return group.unassessedPhases;
+        }
+
         const riskByAttackPattern = group.riskByAttackPattern;
         const assessedPhases = riskByAttackPattern.phases.map((phase) => phase._id);
         const assessedPhaseIdSet = new Set<string>(assessedPhases);
@@ -66,4 +71,9 @@ export const getUnassessedPhasesForCurrentFramework = createSelector(
             .map((phase) => phase.id);
         return curFrameworkUnassessedPhases;
     },
+);
+
+export const getAttackPatternRelationships = createSelector(
+    getGroupState,
+    (group: FullAssessmentGroup) => group.attackPatternRelationships,
 );


### PR DESCRIPTION
supports unfetter-discover/unfetter#1068

## problem
assessment beta result tab does not show cards in group section for inline edit

## changes
translated assessment beta capabilities to displayed objects.  keep the relationships query as is for mitigations and indicator assessments

## test
create a assessment beta w/ capabilities
view the capability assessment in the results tab
verify cards on the far right of the screen
verify the card has the correct value
change the value, verify the screen reflects the change (note the charts are not displaying or updating correctly at the moment) (refresh page to verify the change took hold)
edit the assessment in the wizard verify the values change across the results and wizard screens


See example of capability cards show in results tab
![screen shot 2018-06-26 at 2 28 32 pm](https://user-images.githubusercontent.com/30807406/41931848-cd987688-796e-11e8-90e9-fac722e75bc4.png)

