### PR TITLE
Attack patterns shared between baseline capability and heatmap

### DIFF
--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.ts
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.ts
@@ -82,15 +82,11 @@ export class AttackPatternChooserComponent implements OnInit {
 
     ngOnInit() {
         if (this.data && this.data.active) {
-            (this.data.active as Observable<AttackPattern[]>).pipe(
-                distinctUntilChanged())
-                .subscribe(
-                    (patterns) => {
-                        // @todo We need to convert whatever is provided to us into Tactic objects,
-                        //       and set their value to a heat property ('inactive' or 'selected').
-                    },
-                    (err) => console.log(`(${new Date().toISOString}) Attack Pattern Chooser preselects error`, err),
-                )
+            this.attackPatterns = this.data.active.map(ap => ({
+                ...ap,
+                phases: [],
+                adds: { highlights: [{ color: { style: 'active', } }], }
+            }));
         }
     }
 

--- a/src/app/baseline/wizard/capability/capability.component.html
+++ b/src/app/baseline/wizard/capability/capability.component.html
@@ -7,7 +7,7 @@
         </mat-card-title>
       </div>
       <div class="col-lg-1">
-        <button mat-icon-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(true)">
+        <button mat-icon-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(dataSource.data)">
           <mat-icon class="mat-24" aria-hidden="true" aria-label="view heat map">view_comfy</mat-icon>
           {{ attackMatrix }}
         </button>
@@ -30,7 +30,7 @@
       </div>
       <div class="row margin-bottom">
         <div class="col-sm-12">
-            <button mat-raised-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(true)">
+            <button mat-raised-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(dataSource.data)">
               {{ openAttackMatrix }}
             </button>
         </div>

--- a/src/app/baseline/wizard/capability/capability.component.ts
+++ b/src/app/baseline/wizard/capability/capability.component.ts
@@ -32,7 +32,7 @@ export class CapabilityComponent implements OnInit {
 
 
   @Output()
-  public onToggleHeatMap = new EventEmitter<boolean>();
+  public onToggleHeatMap = new EventEmitter<any>();
   public currentCapability: Capability;
   public currentCapabilityName: string;
   public currentCapabilityDescription: string;

--- a/src/app/baseline/wizard/wizard.component.html
+++ b/src/app/baseline/wizard/wizard.component.html
@@ -51,7 +51,8 @@
     <div [ngSwitch]="openedSidePanel">
       <unf-baseline-wizard-group *ngSwitchCase="'categories'"></unf-baseline-wizard-group>
       <unf-baseline-wizard-capability-selector *ngSwitchCase="'capability-selector'"></unf-baseline-wizard-capability-selector>
-      <unf-baseline-wizard-capability *ngSwitchCase="'capabilities'" (onToggleHeatMap)="toggleHeatMap()"></unf-baseline-wizard-capability>
+      <unf-baseline-wizard-capability #capabilityPane
+          *ngSwitchCase="'capabilities'" (onToggleHeatMap)="toggleHeatMap($event)"></unf-baseline-wizard-capability>
       <div *ngSwitchCase="'capability'">
         <p>This is the attack pattern selection and capability scoring panel.</p>
       </div>


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1205.

Note when testing that default baseline data tends to use the NCTCF framework. You should be able to use other frameworks, but the initial data won't appear on the heatmap if you do.

- Pulling up the attack pattern chooser (heatmap, not the select) on a capability should now highlight the attack patterns currently on the capability (assuming you are on the same framework as the capability).

- You can select/deselect attack patterns, and click submit. The capability should update with the new selections.