### PR TITLE
streamlined avatar urls

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -20,10 +20,10 @@
     </a>
   </mat-menu>
 
-  <span *ngIf="user$ | async as user" class="flex flexItemsCenter">   
+  <span *ngIf="authService.loggedIn() && user$ | async as user" class="flex flexItemsCenter">   
 
     <span id="appMenuWrapper">
-      <button mat-icon-button class="navButton" *ngIf="authService.loggedIn()" (click)="showAppMenu = !showAppMenu">
+      <button mat-icon-button class="navButton" (click)="showAppMenu = !showAppMenu">
         <mat-icon class="mat-24">apps</mat-icon>
       </button>
       <div id="appMenuTriangle" *ngIf="showAppMenu" @fadeInOut>&nbsp;</div>
@@ -63,11 +63,11 @@
       </div>
     </span>
 
-    <span id="notificationContainer" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
+    <span id="notificationContainer" class="navButton" *ngIf="!demoMode">
       <notification-window></notification-window>
     </span>
 
-    <span id="accountWrapper" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
+    <span id="accountWrapper" class="navButton" *ngIf="!demoMode">
       <div class="cursor-pointer" (click)="showAccountMenu = !showAccountMenu">
         <img *ngIf="user.avatar_url" id="avatar" class="smallAvatar" src="{{ user.avatar_url }}" alt="User">
         <button mat-icon-button *ngIf="!user.avatar_url" id="accountBtn">

--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -20,86 +20,89 @@
     </a>
   </mat-menu>
 
-  <span id="appMenuWrapper">
-    <button mat-icon-button class="navButton" *ngIf="authService.loggedIn()" (click)="showAppMenu = !showAppMenu">
-      <mat-icon class="mat-24">apps</mat-icon>
-    </button>
-    <div id="appMenuTriangle" *ngIf="showAppMenu" @fadeInOut>&nbsp;</div>
-    <div *ngIf="showAppMenu && authService.loggedIn()" id="appMenuWindow" class="uf-nav-popup" @fadeInOut>
-      <div id="appList" class="flex">
-        <span *ngFor="let appItem of appList" class="appLinkWrapper">
-          <a routerLink="./{{ appItem.url }}" class="appLink" (click)="showAppMenu = false">
-            <img src="{{ appItem.icon }}" class="appItemImg">
-            <div class="appItemText">{{ appItem.title }}</div>
-          </a>
-        </span>
-        <span class="appLinkWrapper">
-          <a href="{{ swaggerUrl }}?token={{ encodedToken }}&RUN_MODE={{ runMode }}" target=_blank class="appLink">
-            <img src="{{ apiDocsIcon }}" class="appItemImg">
-            <div class="appItemText">API Explorer</div>
-          </a>
-        </span>
-        <span class="appLinkWrapper" *ngIf="authService.isAdmin() || runMode === 'DEMO'">
-          <a routerLink="./stix/attack-patterns" class="appLink" (click)="showAppMenu = false">
-            <img src="{{ stixIcon }}" class="appItemImg">
-            <div class="appItemText">STIX</div>
-          </a>
-        </span>
-        <span class="appLinkWrapper" *ngIf="authService.isOrgLeader()">
-          <a routerLink="./organizations" class="appLink" (click)="showAppMenu = false">
-            <img src="{{ orgLeaderIcon }}" class="appItemImg">
-            <div class="appItemText">Organizations</div>
-          </a>
-        </span>
-        <span class="appLinkWrapper" *ngIf="authService.isAdmin()">
-          <a routerLink="./admin" class="appLink" (click)="showAppMenu = false">
-            <img src="{{ adminIcon }}" class="appItemImg">
-            <div class="appItemText">Admin</div>
-          </a>
-        </span>
-      </div>      
-    </div>
-  </span>
+  <span *ngIf="user$ | async as user" class="flex flexItemsCenter">   
 
-  <span id="notificationContainer" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
-    <notification-window></notification-window>
-  </span>
-
-  <span id="accountWrapper" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
-    <div class="cursor-pointer" *ngFor="let avatar of [getAvatar(user$ | async)]"
-        (click)="showAccountMenu = !showAccountMenu">
-      <img *ngIf="avatar" id="avatar" class="smallAvatar" src="{{avatar}}" alt="User">
-      <button mat-icon-button *ngIf="!avatar" id="accountBtn">
-        <mat-icon class="mat-24">account_circle</mat-icon>
+    <span id="appMenuWrapper">
+      <button mat-icon-button class="navButton" *ngIf="authService.loggedIn()" (click)="showAppMenu = !showAppMenu">
+        <mat-icon class="mat-24">apps</mat-icon>
       </button>
-      <i class="material-icons" id="accountCaret">arrow_drop_down</i>
-    </div>    
-    <div *ngIf="showAccountMenu" id="accountMenuTriangle" @fadeInOut>&nbsp;</div>
-    <div *ngIf="showAccountMenu" id="accountMenuWindow" class="uf-nav-popup" @fadeInOut>    
-      <div *ngIf="(user$ | async).userProfile !== null">
-        <strong>{{ (user$ | async).userProfile.userName }}</strong>
+      <div id="appMenuTriangle" *ngIf="showAppMenu" @fadeInOut>&nbsp;</div>
+      <div *ngIf="showAppMenu && authService.loggedIn()" id="appMenuWindow" class="uf-nav-popup" @fadeInOut>
+        <div id="appList" class="flex">
+          <span *ngFor="let appItem of appList" class="appLinkWrapper">
+            <a routerLink="./{{ appItem.url }}" class="appLink" (click)="showAppMenu = false">
+              <img src="{{ appItem.icon }}" class="appItemImg">
+              <div class="appItemText">{{ appItem.title }}</div>
+            </a>
+          </span>
+          <span class="appLinkWrapper">
+            <a href="{{ swaggerUrl }}?token={{ encodedToken }}&RUN_MODE={{ runMode }}" target=_blank class="appLink">
+              <img src="{{ apiDocsIcon }}" class="appItemImg">
+              <div class="appItemText">API Explorer</div>
+            </a>
+          </span>
+          <span class="appLinkWrapper" *ngIf="authService.isAdmin() || runMode === 'DEMO'">
+            <a routerLink="./stix/attack-patterns" class="appLink" (click)="showAppMenu = false">
+              <img src="{{ stixIcon }}" class="appItemImg">
+              <div class="appItemText">STIX</div>
+            </a>
+          </span>
+          <span class="appLinkWrapper" *ngIf="authService.isOrgLeader()">
+            <a routerLink="./organizations" class="appLink" (click)="showAppMenu = false">
+              <img src="{{ orgLeaderIcon }}" class="appItemImg">
+              <div class="appItemText">Organizations</div>
+            </a>
+          </span>
+          <span class="appLinkWrapper" *ngIf="authService.isAdmin()">
+            <a routerLink="./admin" class="appLink" (click)="showAppMenu = false">
+              <img src="{{ adminIcon }}" class="appItemImg">
+              <div class="appItemText">Admin</div>
+            </a>
+          </span>
+        </div>      
       </div>
-      <hr>
-      <div class="accountMenuLine">
-        <a routerLink="/users/settings" class="flexImportant flexItemsCenter">
-          <i class="material-icons">settings</i>
-          <span>&nbsp;&nbsp;Settings</span>
-        </a>
-      </div>
-      <div class="accountMenuLine">
-        <a routerLink="/users/profile/{{(user$ | async).userProfile._id}}" class="flexImportant flexItemsCenter">
-          <i class="material-icons">person_outline</i>
-          <span>&nbsp;&nbsp;Profile</span>
-        </a>
-      </div>
-      <hr>
-      <div class="accountMenuLine">
-        <a (click)="authService.logOut(); logoutStore()" class="flexImportant flexItemsCenter">
-          <i class="material-icons">exit_to_app</i>
-          <span>&nbsp;&nbsp;Sign Out</span>
-        </a>
-      </div>     
-    </div>
+    </span>
 
-  </span>  
+    <span id="notificationContainer" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
+      <notification-window></notification-window>
+    </span>
+
+    <span id="accountWrapper" class="navButton" *ngIf="!demoMode && authService.loggedIn()">
+      <div class="cursor-pointer" (click)="showAccountMenu = !showAccountMenu">
+        <img *ngIf="user.avatar_url" id="avatar" class="smallAvatar" src="{{ user.avatar_url }}" alt="User">
+        <button mat-icon-button *ngIf="!user.avatar_url" id="accountBtn">
+          <mat-icon class="mat-24">account_circle</mat-icon>
+        </button>
+        <i class="material-icons" id="accountCaret">arrow_drop_down</i>
+      </div>    
+      <div *ngIf="showAccountMenu" id="accountMenuTriangle" @fadeInOut>&nbsp;</div>
+      <div *ngIf="showAccountMenu" id="accountMenuWindow" class="uf-nav-popup" @fadeInOut>    
+        <div *ngIf="user.userProfile !== null">
+          <strong>{{ user.userProfile.userName }}</strong>
+        </div>
+        <hr>
+        <div class="accountMenuLine">
+          <a routerLink="/users/settings" class="flexImportant flexItemsCenter">
+            <i class="material-icons">settings</i>
+            <span>&nbsp;&nbsp;Settings</span>
+          </a>
+        </div>
+        <div class="accountMenuLine">
+          <a routerLink="/users/profile/{{ user.userProfile._id }}" class="flexImportant flexItemsCenter">
+            <i class="material-icons">person_outline</i>
+            <span>&nbsp;&nbsp;Profile</span>
+          </a>
+        </div>
+        <hr>
+        <div class="accountMenuLine">
+          <a (click)="authService.logOut(); logoutStore()" class="flexImportant flexItemsCenter">
+            <i class="material-icons">exit_to_app</i>
+            <span>&nbsp;&nbsp;Sign Out</span>
+          </a>
+        </div>     
+      </div>
+    </span> 
+
+  </span>
+
 </mat-toolbar>

--- a/src/app/global/components/header-navigation/header-navigation.component.ts
+++ b/src/app/global/components/header-navigation/header-navigation.component.ts
@@ -113,16 +113,6 @@ export class HeaderNavigationComponent {
     return this._authServices;
   }
 
-  public getAvatar(user): string {
-    if (user && user.userProfile && user.userProfile.oauth) {
-      const oauth = user.userProfile.oauth;
-      if (user.userProfile[oauth] && user.userProfile[oauth].avatar_url) {
-        return user.userProfile[oauth].avatar_url;
-      }
-    }
-    return null;
-  }
-
   @HostListener('document:click', ['$event']) public clickedOutside(event) {
     if (this.showAppMenu && this.el.nativeElement.querySelector('#appMenuWrapper') && !this.el.nativeElement.querySelector('#appMenuWrapper').contains(event.target)) {
       this.showAppMenu = false;

--- a/src/app/global/static/user-helpers.spec.ts
+++ b/src/app/global/static/user-helpers.spec.ts
@@ -1,0 +1,41 @@
+import { UserHelpers } from './user-helpers';
+
+describe('UserHelpers', () => {
+
+    describe('getAvatarUrl', () => {
+        const mockUrl = 'fake.com/img1';
+        it('should return github avatar', () => {
+            const mockUser = {
+                oauth: 'github',
+                github: {
+                    avatar_url: mockUrl
+                }
+            };
+            expect(UserHelpers.getAvatarUrl(mockUser)).toBe(mockUrl);
+        });
+
+        it('should return gitlab avatar', () => {
+            const mockUser = {
+                oauth: 'gitlab',
+                gitlab: {
+                    avatar_url: mockUrl
+                }
+            };
+            expect(UserHelpers.getAvatarUrl(mockUser)).toBe(mockUrl);
+        });
+
+        it('should return legacy github avatar', () => {
+            const mockUser = {
+                github: {
+                    avatar_url: mockUrl
+                }
+            };
+            expect(UserHelpers.getAvatarUrl(mockUser)).toBe(mockUrl);
+        });
+
+        it('should return null if not github or gitlab url', () => {
+            const mockUser = {};
+            expect(UserHelpers.getAvatarUrl(mockUser)).toBeFalsy();
+        });
+    });
+});

--- a/src/app/global/static/user-helpers.ts
+++ b/src/app/global/static/user-helpers.ts
@@ -1,0 +1,15 @@
+export class UserHelpers {
+    public static getAvatarUrl(user): string {
+        if (user && user.oauth) {
+            const oauth = user.oauth;
+            if (user[oauth] && user[oauth].avatar_url) {
+                return user[oauth].avatar_url;
+            }
+        }
+        // Support for legacy user model, can be deleted in the future
+        if (user.github && user.github.avatar_url) {
+            return user.github.avatar_url;
+        }
+        return null;
+    }
+}

--- a/src/app/models/user/user-profile.ts
+++ b/src/app/models/user/user-profile.ts
@@ -21,5 +21,6 @@ export class UserProfile {
     public approved = false;
     public registered: boolean;
     public preferences?: UserPreferences;
+    public avatar_url?: string;
     organizations: OrganizationIdentity[] = [];
 }

--- a/src/app/root-store/users/users.reducers.spec.ts
+++ b/src/app/root-store/users/users.reducers.spec.ts
@@ -12,7 +12,8 @@ describe('usersReducer', () => {
             token: '1234',
             authenticated: false,
             approved: false,
-            role: 'STANDARD_USER'
+            role: 'STANDARD_USER',
+            avatar_url: '1234.com/img1'
         };
     });
 
@@ -23,16 +24,25 @@ describe('usersReducer', () => {
     it('should login user', () => {
         const payload = { 
             userData: { 
-                ...mockState
+                ...mockState,
+                oauth: 'github',
+                github: {
+                    avatar_url: mockState.avatar_url
+                }
             }, 
             token: mockState.token 
         };
         const expected = {
             ...mockState,
             userProfile: {
-                ...mockState
+                ...mockState,
+                oauth: 'github',
+                github: {
+                    avatar_url: mockState.avatar_url
+                }
             },
-            authenticated: true
+            authenticated: true,
+            avatar_url: mockState.avatar_url
         };
         expect(usersReducer(undefined, new userActions.LoginUser(payload))).toEqual(expected);
     });

--- a/src/app/root-store/users/users.reducers.ts
+++ b/src/app/root-store/users/users.reducers.ts
@@ -7,7 +7,8 @@ export interface UserState {
     token: string,
     authenticated: boolean,
     approved: boolean,
-    role: string
+    role: string,
+    avatar_url: string
 }
 
 export const initialState: UserState = {
@@ -15,7 +16,8 @@ export const initialState: UserState = {
     token: null,
     authenticated: false,
     approved: false,
-    role: null
+    role: null,
+    avatar_url: null
 }
 
 export function usersReducer(state = initialState, action: userActions.UserActions) {

--- a/src/app/root-store/users/users.reducers.ts
+++ b/src/app/root-store/users/users.reducers.ts
@@ -1,5 +1,6 @@
 import * as userActions from './user.actions';
 import { UserProfile } from '../../models/user/user-profile';
+import { UserHelpers } from '../../global/static/user-helpers';
 
 export interface UserState {
     userProfile: UserProfile,
@@ -20,13 +21,15 @@ export const initialState: UserState = {
 export function usersReducer(state = initialState, action: userActions.UserActions) {
     switch (action.type) {
         case userActions.LOGIN_USER:
+            const avatar_url = UserHelpers.getAvatarUrl(action.payload.userData);
             return {
                 ...state,
                 userProfile: action.payload.userData,
                 token: action.payload.token,
                 role: action.payload.userData.role,
                 approved: action.payload.userData.approved,
-                authenticated: true
+                authenticated: true,
+                avatar_url
             };
         case userActions.UPDATE_USER_DATA:
             return {

--- a/src/app/users/profile/profile.component.html
+++ b/src/app/users/profile/profile.component.html
@@ -10,8 +10,8 @@
         <div class="col-xs-12 col-lg-6 col-lg-offset-3">
             <mat-card>
                 <mat-card-header>
-                    <div mat-card-avatar *ngIf="user.oauth.avatar_url !== undefined"
-                            class="avatar" [style.background]="'url(' + user.oauth.avatar_url + ')'"></div>
+                    <div mat-card-avatar *ngIf="user.avatar_url !== undefined"
+                            class="avatar" [style.background]="'url(' + user.avatar_url + ')'"></div>
                     <mat-card-title class="mt-5">{{user.userName}}</mat-card-title>
                     <mat-card-subtitle>{{user.firstName}}&nbsp;{{user.lastName}}</mat-card-subtitle>
                 </mat-card-header>

--- a/src/app/users/profile/profile.component.ts
+++ b/src/app/users/profile/profile.component.ts
@@ -9,6 +9,7 @@ import { UsersService } from '../../core/services/users.service';
 import { RxjsHelpers } from '../../global/static/rxjs-helpers';
 import { UserProfile } from '../../models/user/user-profile';
 import { ProfileOrg } from './profile-org';
+import { UserHelpers } from '../../global/static/user-helpers';
 
 @Component({
     selector: 'profile',
@@ -37,6 +38,7 @@ export class ProfileComponent implements OnInit {
                     map(RxjsHelpers.mapArrayAttributes))
                     .subscribe(([userResults, allOrgs]) => {
                         this.user = userResults;
+                        this.user.avatar_url = UserHelpers.getAvatarUrl(this.user);
 
                         this.organizations = this.user.organizations
                             .filter((org) => org.approved)

--- a/src/app/users/settings/settings.component.html
+++ b/src/app/users/settings/settings.component.html
@@ -10,8 +10,8 @@
         <div class="col-xs-12 col-lg-6 col-lg-offset-3">
             <mat-card>
                 <mat-card-header>
-                    <div mat-card-avatar *ngIf="user.oauth.avatar_url !== undefined"
-                            class="avatar" [style.background]="'url(' + user.oauth.avatar_url + ')'"></div>
+                    <div mat-card-avatar *ngIf="user.avatar_url !== undefined"
+                            class="avatar" [style.background]="'url(' + user.avatar_url + ')'"></div>
                     <mat-card-title class="mt-5">{{user.userName}}</mat-card-title>
                     <mat-card-subtitle>{{user.firstName}}&nbsp;{{user.lastName}}</mat-card-subtitle>
                 </mat-card-header>

--- a/src/app/users/settings/settings.component.ts
+++ b/src/app/users/settings/settings.component.ts
@@ -13,6 +13,7 @@ import { AppState } from '../../root-store/app.reducers';
 import { FetchConfig } from '../../root-store/config/config.actions';
 import { Constance } from '../../utils/constance';
 import { KillchainConfigEntry } from './killchain-config-entry';
+import { UserHelpers } from '../../global/static/user-helpers';
 
 @Component({
     selector: 'settings',
@@ -49,6 +50,7 @@ export class SettingsComponent implements OnInit {
         ).subscribe(
             (results: any) => {
                 this.user = results[0].attributes;
+                this.user.avatar_url = UserHelpers.getAvatarUrl(this.user);
                 const allOrgs = results[1].map((org) => org.attributes);
                 this.approvedOrganizations = this.user.organizations
                     .filter((org) => org.approved)


### PR DESCRIPTION
Requires `issue-1206` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/220

Verify avatar displays correctly for both GitHub and GitLab users in the following conditions:
- Account dropdown
- User settings
- User profile
- Analytic Exchange comments (requires creation of new comments, old comments of gitlab users wont work)

fixes unfetter-discover/unfetter#1206