### PR TITLE
Saves all assessment questions including unassessed questions

### DIFF
--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -1346,7 +1346,7 @@ export class WizardComponent extends Measurements
           assessmentsGroups: this.createAssessmentGroups(this[name]),
           tempModel: {},
         })
-        .map(group => this.collectAll(group))
+        .map(group => this.answerAll(group))
         .map(tempModel => this.generateXUnfetterAssessment(tempModel, this.meta))
         .filter(assessment => assessment.assessment_objects && assessment.assessment_objects.length);
       this.wizardStore.dispatch(new SaveAssessment(assessments));
@@ -1354,7 +1354,7 @@ export class WizardComponent extends Measurements
   }
 
   // for all unassessed questions, add an assessment object for each one
-  private collectAll(group): TempModel {
+  private answerAll(group): TempModel {
     const assessedIds = Object.keys(group.tempModel);
     group.assessmentsGroups
       .reduce((questions, grp) => [...questions, ...grp.assessments], [])


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1212.

Create a beta assessment, any category(ies), don't assess anything, just save.

On full results screen, you should see the unassessed items, and be able to edit them. They will have a risk of 100% and the value on the select box will be whatever the "0" value is.

If you edit the assessment, as with the previous wizard fix, all of the categories you selected will be visible, and all questions should appear.