### PR TITLE
Issue 1147/bl mega menu

### DIFF
--- a/src/app/baseline/models/last-modified-baseline.ts
+++ b/src/app/baseline/models/last-modified-baseline.ts
@@ -4,5 +4,5 @@ import { LastModifiedStix } from '../global/models/last-modified-stix';
  * @description object returned from the last modified baselines 3.0 aggregate query
  */
 export class LastModifiedBaseline extends LastModifiedStix {
-    assessments: string[];
+    published: string;
 }

--- a/src/app/baseline/models/last-modified-baseline.ts
+++ b/src/app/baseline/models/last-modified-baseline.ts
@@ -4,5 +4,5 @@ import { LastModifiedStix } from '../global/models/last-modified-stix';
  * @description object returned from the last modified baselines 3.0 aggregate query
  */
 export class LastModifiedBaseline extends LastModifiedStix {
-
+    assessments: string[];
 }

--- a/src/app/baseline/result/store/summary.actions.ts
+++ b/src/app/baseline/result/store/summary.actions.ts
@@ -9,6 +9,7 @@ export const LOAD_SINGLE_SUMMARY_AGGREGATION_DATA = '[Baseline Summary] LOAD_SIN
 export const LOAD_SUMMARY_AGGREGATION_DATA = '[Baseline Summary] LOAD_SUMMARY_AGGREGATION_DATA';
 
 // For reducers
+export const SET_BASELINES = '[Baseline Summary] SET_BASELINES';
 export const SET_BASELINE = '[Baseline Summary] SET_BASELINE';
 export const SET_ATTACK_PATTERNS = '[Baseline Summary] SET_ATTACK_PATTERNS';
 export const SET_BASELINE_WEIGHTINGS = '[Baseline Summary] SET_BASELINE_WEIGHTINGS';
@@ -27,10 +28,16 @@ export class LoadBaselineData implements Action {
     constructor(public payload: string) { }
 }
 
+export class SetBaselines implements Action {
+    public readonly type = SET_BASELINES;
+
+    constructor(public payload: AssessmentSet[]) { }
+}
+
 export class SetBaseline implements Action {
     public readonly type = SET_BASELINE;
 
-    constructor(public payload: AssessmentSet[]) { }
+    constructor(public payload: AssessmentSet) { }
 }
 
 export class SetAttackPatterns implements Action {
@@ -90,6 +97,7 @@ export class CleanBaselineResultData {
 
 export type SummaryActions =
     CleanBaselineResultData |
+    SetBaselines |
     SetBaseline |
     SetAttackPatterns |
     SetBaselineWeightings |

--- a/src/app/baseline/result/store/summary.effects.ts
+++ b/src/app/baseline/result/store/summary.effects.ts
@@ -27,8 +27,7 @@ export class SummaryEffects {
           pluck('payload'),
           switchMap((baselineId: string) => {
             // Get all baselines and save them as well as the one which is current
-            return this.baselineService
-              .fetchBaselines(true)
+            return this.baselineService.fetchBaselines(true)
               .pipe(
                 mergeMap((data: AssessmentSet[]) => {
                   const baseline = data.find((bl) => bl.id === baselineId);
@@ -46,8 +45,8 @@ export class SummaryEffects {
         .ofType(SET_BASELINE)
         .pipe(
             pluck('payload'),
-            switchMap((assessmentSets: AssessmentSet[]) => {
-                return this.baselineService.fetchObjectAssessmentsByAssessmentSet(assessmentSets[0]);
+            switchMap((baseline: AssessmentSet) => {
+                return this.baselineService.fetchObjectAssessmentsByAssessmentSet(baseline);
             }),
             mergeMap((objAssessments: ObjectAssessment[]) => {
                 // Pull out unique list of attack patterns represented in all of these object assessments
@@ -65,9 +64,9 @@ export class SummaryEffects {
                         // Collect weighting summaries for P, D, and R
                         apTotal++;
                         aoObj.questions.map((question) => {
-                            protWeightings += (question.name === 'protect') ? 1 : 0;
-                            detWeightings += (question.name === 'detect') ? 1 : 0;
-                            respWeightings += (question.name === 'respond') ? 1 : 0;
+                            protWeightings += (question.name === 'protect' && question.score !== 'N') ? 1 : 0;
+                            detWeightings += (question.name === 'detect' && question.score !== 'N') ? 1 : 0;
+                            respWeightings += (question.name === 'respond' && question.score !== 'N') ? 1 : 0;
                         })
                     })
 

--- a/src/app/baseline/result/store/summary.reducers.ts
+++ b/src/app/baseline/result/store/summary.reducers.ts
@@ -3,7 +3,8 @@ import { SummaryAggregation } from '../../../models/assess/summary-aggregation';
 import * as summaryActions from './summary.actions';
 
 export interface SummaryState {
-    baseline: AssessmentSet[];
+    baselines: AssessmentSet[];
+    baseline: AssessmentSet;
     blAttackPatterns: string[];
     blWeightings: {};
     blGroups: string[];
@@ -15,7 +16,8 @@ export interface SummaryState {
 
 const genState = (state?: Partial<SummaryState>) => {
     const tmp = {
-        baseline: new Array<AssessmentSet>(),
+        baselines: new Array<AssessmentSet>(),
+        baseline: new AssessmentSet(),
         blAttackPatterns: new Array<string>(),
         blWeightings: { protPct: 0, detPct: 0, respPct: 0 },
         blGroups: new Array<string>(),
@@ -39,10 +41,15 @@ export function summaryReducer(state = initialState, action: summaryActions.Summ
             return genState({
                 ...state,
             });
+        case summaryActions.SET_BASELINES:
+            return genState({
+                ...state,
+                baselines: [...action.payload],
+            });
         case summaryActions.SET_BASELINE:
             return genState({
                 ...state,
-                baseline: [...action.payload],
+                baseline: action.payload,
             });
         case summaryActions.SET_ATTACK_PATTERNS:
             return genState({

--- a/src/app/baseline/result/summary/summary.component.ts
+++ b/src/app/baseline/result/summary/summary.component.ts
@@ -58,9 +58,16 @@ export class SummaryComponent implements OnInit, OnDestroy {
         }
         return author ? author.name : 'Unknown';
       })
-      .addColumn('framework', 'Type', 'master-list-extra', false, (value) => value || 'ATT&CK')
-      .addColumn('industry', 'Industry', 'master-list-extra', false, (value) => value || 'Local')
-      .addColumn('created', 'Status', 'master-list-extra', false, (created) => created || 'not published')
+      // TODO: must change baselines in some way to save framework in place when it was created
+      //       once that is done, add this back in and update
+      // .addColumn('framework', 'Type', 'master-list-extra', false, (value) => value || 'ATT&CK')
+      // TODO: until there is an industry specification for a baseline, don't show this column
+      //       could borrow from specific user who created the baseline, but the user could
+      //       have more than one industry in its identity
+      // .addColumn('industry', 'Industry', 'master-list-extra', false, (value) => value || 'Local')
+      .addColumn('published', 'Status', 'master-list-extra', false, (published) => {
+        return published ? 'Published' : 'Not Published'
+      })
     ,
     displayRoute: this.baseAssessUrl + '/result/summary',
     modifyRoute: this.baseAssessUrl + '/wizard/edit',
@@ -223,7 +230,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
         // this.transformSummary()
       }, (err) => console.log(err));
 
-    const sub8$ = this.store
+    const sub3$ = this.store
       .select('summary').pipe(
       pluck('finishedLoadingSummaryAggregationData'),
       distinctUntilChanged())
@@ -234,16 +241,18 @@ export class SummaryComponent implements OnInit, OnDestroy {
         // }
       }, (err) => console.log(err));
 
-    const sub9$ = this.store
+    const sub4$ = this.store
       .select('summary').pipe(
       pluck('baseline'),
       distinctUntilChanged())
       .subscribe((baseline: AssessmentSet) => {
-        this.blName = baseline.name;
-        this.baselineName = observableOf(this.blName);
+        if (baseline) {
+          this.blName = baseline.name;
+          this.baselineName = observableOf(this.blName);
+        }
       }, (err) => console.log(err));
 
-    this.subscriptions.push(sub1$, sub2$, sub8$, sub9$);
+    this.subscriptions.push(sub1$, sub2$, sub3$, sub4$);
   }
 
 

--- a/src/app/baseline/result/summary/summary.component.ts
+++ b/src/app/baseline/result/summary/summary.component.ts
@@ -45,7 +45,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
     columns: new MasterListDialogTableHeaders('modified', 'Date Modified')
       .addColumn('id', '# of Capabilities', 'master-list-capabilities', false, (id) => {
         if (id && this.summaries) {
-          const baseline = this.summaries.filter((baseline) => baseline.id === id);
+          const baseline = this.summaries.filter((bl) => bl.id === id);
           return baseline[0].assessments.length.toString();
         } else {
           return '0';

--- a/src/app/baseline/result/summary/summary.datasource.ts
+++ b/src/app/baseline/result/summary/summary.datasource.ts
@@ -17,7 +17,7 @@ export class SummaryDataSource extends DataSource<Partial<LastModifiedBaseline>>
     protected dataChange = new BehaviorSubject(undefined);
 
     constructor(
-        protected assessService: BaselineService,
+        protected baselineService: BaselineService,
         protected creatorId?: string,
     ) {
         super();
@@ -33,7 +33,7 @@ export class SummaryDataSource extends DataSource<Partial<LastModifiedBaseline>>
             switchMap(() => {
                 const val = this.filterChange.getValue();
                 const filterVal = val.trim().toLowerCase() || '';
-                const baselines$ = this.assessService.getLatestAssessments();
+                const baselines$ = this.baselineService.getLatestAssessments();
                 if (!filterVal || filterVal.length === 0) {
                     return baselines$;
                 }

--- a/src/app/baseline/services/baseline.service.ts
+++ b/src/app/baseline/services/baseline.service.ts
@@ -145,17 +145,6 @@ export class BaselineService {
      *  fetch all assessment sets (aka baselines) from the server that this user can see
      *      given the rules of the security filter
      * @param {boolean} includeMeta - true to include metaProperties metadata
-     * @returns {Observable<AssessmentSet[]>}
-     */
-    public fetchAssessmentSets(includeMeta = true): Observable<AssessmentSet[]> {
-        return this.fetchBaselines(includeMeta);
-    }
-
-    /**
-     * @description
-     *  fetch all assessment sets (aka baselines) from the server that this user can see
-     *      given the rules of the security filter
-     * @param {boolean} includeMeta - true to include metaProperties metadata
      * @return {Observable<AssessmentSet[]>}
      */
     public fetchBaselines(includeMeta = true): Observable<AssessmentSet[]> {


### PR DESCRIPTION
Requires unfetter-discover/unfetter-store#222
Fixes unfetter-discover/unfetter#1147

Capability and Status (i.e. published) columns in the baselines master list are now reporting correct data.  The `Industry` and `Framework` columns have been removed for now, as they do not have values which can be derived on a baseline by baseline basis.

### To test:
1. Pull this branch
2. Display mega menu (dropdown arrow next to open baseline name)
3. Notice Capability and Status column report correct values
4. Create some baselines with any combination of groups and capabilities
5. Display the baselines mega menu and note correct counts of capabilities and correct published status
