### PR TITLE
Fixed PDR score propagation and added % complete banner to BL summary

### DIFF
--- a/src/app/baseline/result/result-header/result-header.component.html
+++ b/src/app/baseline/result/result-header/result-header.component.html
@@ -1,7 +1,7 @@
 <div id="tabWrapper" class="flex flexColumn">
   <div class="flex flexRow">
     <div class="flex">
-      <uf-info-bar isWarningMsg="true" message="Baselines is currently in beta. Some functionality does not work."></uf-info-bar>
+      <uf-info-bar isWarningMsg="true" message="{{ infoBarMsg }}" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>
   </div>
   <div class="flex1"></div>

--- a/src/app/baseline/result/result-header/result-header.component.ts
+++ b/src/app/baseline/result/result-header/result-header.component.ts
@@ -16,7 +16,7 @@ export class ResultHeaderComponent implements OnInit {
   public summaryLink: string;
   infoBarMsg: string;
   percentCompleted: number;
-  protected editUrl: string;
+  public editUrl: string;
 
   constructor() { }
 

--- a/src/app/baseline/result/result-header/result-header.component.ts
+++ b/src/app/baseline/result/result-header/result-header.component.ts
@@ -14,6 +14,9 @@ export class ResultHeaderComponent implements OnInit {
   public published: Date;
 
   public summaryLink: string;
+  infoBarMsg: string;
+  percentCompleted: number;
+  protected editUrl: string;
 
   constructor() { }
 
@@ -24,6 +27,15 @@ export class ResultHeaderComponent implements OnInit {
   public ngOnInit(): void {
     const base = '/baseline/result/';
     this.summaryLink = `${base}/summary/${this.baselineId}`;
+
+
+   
+
+    this.editUrl = `/baseline/wizard/edit/${this.baselineId}`;
+    this.infoBarMsg = 'Baselines is currently in beta. Some functionality does not work.'
+    this.percentCompleted = 2;
+    this.infoBarMsg += ` ${this.percentCompleted}% of your baseline is complete.`;
+
   }
 
 }

--- a/src/app/baseline/result/summary/summary.component.html
+++ b/src/app/baseline/result/summary/summary.component.html
@@ -38,6 +38,12 @@
   </mat-sidenav-container>
 </div>
 
+<div class="flex flexRow">
+    <div class="flex">
+      <uf-info-bar *ngIf="percentCompleted < 100" isWarningMsg="true" [message]="percentCompletedMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
+    </div>
+  </div>
+
 <ng-template #loadingBlock>
   <loading-spinner></loading-spinner>
 </ng-template>

--- a/src/app/baseline/result/summary/summary.component.html
+++ b/src/app/baseline/result/summary/summary.component.html
@@ -38,11 +38,11 @@
   </mat-sidenav-container>
 </div>
 
-<div class="flex flexRow">
+<!-- <div class="flex flexRow">
     <div class="flex">
       <uf-info-bar *ngIf="percentCompleted < 100" isWarningMsg="true" [message]="percentCompletedMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>
-  </div>
+  </div> -->
 
 <ng-template #loadingBlock>
   <loading-spinner></loading-spinner>

--- a/src/app/baseline/wizard/capability/capability.component.spec.ts
+++ b/src/app/baseline/wizard/capability/capability.component.spec.ts
@@ -10,7 +10,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { StoreModule } from '@ngrx/store';
 import * as assessReducers from '../../store/baseline.reducers';
-
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('CapabilityComponent', () => {
   let component: CapabilityComponent;
@@ -31,11 +32,13 @@ describe('CapabilityComponent', () => {
     TestBed.configureTestingModule({
       declarations: [CapabilityComponent],
       imports: [
+        HttpClientTestingModule,
         NoopAnimationsModule,
         ...matModules,
         StoreModule.forRoot(assessReducers),
         ReactiveFormsModule,
-      ]
+      ],
+      providers: [GenericApi]
     })
       .compileComponents();
   }));


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1142
Fixes unfetter-discover/unfetter#1213

This PR contains code changes by @joe-dam and @mushinlogit.  It fixes the problem of replicating weighting changes across all attack patterns in the baseline.  This PR also enhances the beta message for the baselines summary page with a % complete and link to edit the baseline.

### To test:
1. Pull this branch
2. Display the baselines part of the app
3. Note beta banner with its % complete and `COMPLETE` link
4. Create a new baseline, and select `Network Firewall` and then pick multiple capabilities such as `PfSense` and `IPfirewall`
5. On the first capability screen (`PFSense`), note one of the weightings (any of them) and change that weighting to something else
6. Click `Continue`
7. Note that the value you changed on the next screen is back to what the default was before the value was changed on the previous screen
8.  Save the baseline and edit it
9. Verify the changed value is still set, and that that value for that attack pattern on other capabilities are not changed
 