### PR TITLE
Result group dial

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -145,7 +145,7 @@ describe(`App`, () => {
             { path: 'admin', title: 'admin', theme: Themes.DEFAULT },
             { path: 'assessments', title: 'assessments', theme: Themes.ASSESSMENTS },
             { path: 'assess', title: 'assessments', theme: Themes.ASSESSMENTS },
-            { path: 'assess-beta', title: 'assessments', theme: Themes.ASSESSMENTS },
+            { path: 'assess-beta', title: 'assessments beta', theme: Themes.ASSESSMENTS },
             { path: 'baseline', title: 'Baselines', theme: Themes.ASSESSMENTS },
             { path: 'events', title: 'events', theme: Themes.EVENTS },
             { path: 'home', title: 'home', theme: Themes.DEFAULT },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -90,7 +90,7 @@ export class AppComponent implements OnInit {
         } else if (url === 'baseline') {
           this.title = 'Baselines';
         } else if (url === 'assess-beta') {
-            this.title = 'assessments';
+            this.title = 'assessments beta';
         } else {
           this.title = url;
         }

--- a/src/app/assess/v3/layout/assess-layout.component.html
+++ b/src/app/assess/v3/layout/assess-layout.component.html
@@ -43,7 +43,7 @@
     <div class="container fadeIn">
       <div class="row mt-15">
         <div class="col-xs-10 col-xs-offset-1">
-          <error-card errorTitle="Assessment create" errorBody="Failed to load. Check your network."></error-card>
+          <error-card errorTitle="Assessment create" errorBody="Failed to load. Check the network and URL."></error-card>
         </div>
       </div>
     </div>

--- a/src/app/assess/v3/layout/assess-layout.component.html
+++ b/src/app/assess/v3/layout/assess-layout.component.html
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<ng-template #failedToLoadBlock>
+<!-- <ng-template #failedToLoadBlock>
   <div class="center">
     <div class="flex-cols center">
       <span class="center empty">
@@ -37,4 +37,14 @@
       </span>
     </div>
   </div>
-</ng-template>
+</ng-template> -->
+
+<ng-template #failedToLoadBlock>
+    <div class="container fadeIn">
+      <div class="row mt-15">
+        <div class="col-xs-10 col-xs-offset-1">
+          <error-card errorTitle="Assessment create" errorBody="Failed to load. Check your network."></error-card>
+        </div>
+      </div>
+    </div>
+  </ng-template>

--- a/src/app/assess/v3/result/full/full.component.html
+++ b/src/app/assess/v3/result/full/full.component.html
@@ -1,83 +1,81 @@
-<div *ngIf="(finishedLoading|async) === true; else loadingBlock" class="fadeIn">
-  <mat-sidenav-container *ngIf="assessment | async as assessment; else notFound">
-    <mat-sidenav *ngIf="(assessmentGroup$ | async) as assessmentGroup" class="side-panel" mode="side" opened="true" >
-      <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
+<ng-container *ngIf="(finishedLoading$|async) === true; else loadingBlock">
+  <div *ngIf="(failedToLoad$|async) === false; else failedToLoadBlock" class="fadeIn">
+    <mat-sidenav-container *ngIf="assessment$ | async as assessment">
+      <mat-sidenav *ngIf="(assessmentGroup$ | async) as assessmentGroup" class="side-panel" mode="side" opened="true">
+        <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
 
-        <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
-        <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>
-        <sidepanel-option-item label="Delete" icon="delete" (click)="onDeleteCurrent($event)"></sidepanel-option-item>
+          <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
+          <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>
+          <sidepanel-option-item label="Delete" icon="delete" (click)="onDeleteCurrent($event)"></sidepanel-option-item>
 
-        <master-list-dialog-trigger title="Assessments" width="750px" height="400px" [dataSource]="masterListOptions.dataSource"
-          [columns]="masterListOptions.columns" (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
-          (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
-      </unfetter-side-panel>
-      <div *ngIf="assessmentGroup.riskByAttackPattern" class="side-panel-risks">
-        <div class="risk-header-wrapper">
-          <div class="flex risk-header">
-            <span class="flex-grow">
-              Tactic
-            </span>
-            <span class="align-right">
-              Risk Level
-            </span>
-          </div>
-        </div>
-        <div class="phases-list">
-          <div class="phases-list-item cursor-pointer" 
-            *ngFor="let phase of assessmentGroup.riskByAttackPattern.phases; trackBy:trackByFn"
-            [ngClass]="{'highlightPhase': isCurrentPhase(phase._id)}"
-            (click)="assessGroupMain.setPhase(phase._id); activePhase = phase._id">
-            <div class="item-content flex">
-              <span class="phase-name flex-grow">
-                <b>{{phase._id | capitalize}}</b>
+          <master-list-dialog-trigger title="Assessments" width="750px" height="400px" [dataSource]="masterListOptions.dataSource"
+            [columns]="masterListOptions.columns" (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
+            (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
+        </unfetter-side-panel>
+        <div *ngIf="assessmentGroup.riskByAttackPattern" class="side-panel-risks">
+          <div class="risk-header-wrapper">
+            <div class="flex risk-header">
+              <span class="flex-grow">
+                Tactic
               </span>
-              <span class="align-right">{{assessGroupMain.getRiskByPhase(phase._id) | percent:'2.1-1'}}</span>
-            </div>
-            <div class="item-content">Attack Patterns {{ phase.attackPatterns.length }}/{{ assessGroupMain.getNumAttackPatterns(phase._id) }}</div>
-            <div class="item-content" *ngIf="riskBreakdown">
-              <risk-breakdown [riskBreakdown]="riskBreakdown[phase._id]"></risk-breakdown>
+              <span class="align-right">
+                Risk Level
+              </span>
             </div>
           </div>
-        </div>
-        <div class="divider-wrapper">
-        </div>
-        <div *ngIf="unassessedPhases$ | async as unassessedPhases">
-          <div class="header">Unassessed Tactics</div>
-          <div class="unassessed-phases-list">
-            <div class="unassessed-phases-list-item cursor-pointer" 
-              *ngFor="let phase of unassessedPhases; trackBy:trackByFn"
-              [ngClass]="{'highlightPhase': isCurrentPhase(phase)}"
-              (click)="assessGroupMain.setPhase(phase); activePhase = phase">
-              <div class="item-content">
-                <span class="phase-name">
-                  <b>{{phase | capitalize}}</b>
+          <div class="phases-list">
+            <div class="phases-list-item cursor-pointer" *ngFor="let phase of assessmentGroup.riskByAttackPattern.phases; trackBy:trackByFn"
+              [ngClass]="{'highlightPhase': isCurrentPhase(phase._id)}" (click)="assessGroupMain.setPhase(phase._id); activePhase = phase._id">
+              <div class="item-content flex">
+                <span class="phase-name flex-grow">
+                  <b>{{phase._id | capitalize}}</b>
                 </span>
+                <span class="align-right">{{assessGroupMain.getRiskByPhase(phase._id) | percent:'2.1-1'}}</span>
+              </div>
+              <div class="item-content">Attack Patterns {{ phase.attackPatterns.length }}/{{ assessGroupMain.getNumAttackPatterns(phase._id) }}</div>
+              <div class="item-content" *ngIf="riskBreakdown">
+                <risk-breakdown [riskBreakdown]="riskBreakdown[phase._id]"></risk-breakdown>
+              </div>
+            </div>
+          </div>
+          <div class="divider-wrapper">
+          </div>
+          <div *ngIf="unassessedPhases$ | async as unassessedPhases">
+            <div class="header">Unassessed Tactics</div>
+            <div class="unassessed-phases-list">
+              <div class="unassessed-phases-list-item cursor-pointer" *ngFor="let phase of unassessedPhases; trackBy:trackByFn" [ngClass]="{'highlightPhase': isCurrentPhase(phase)}"
+                (click)="assessGroupMain.setPhase(phase); activePhase = phase">
+                <div class="item-content">
+                  <span class="phase-name">
+                    <b>{{phase | capitalize}}</b>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </mat-sidenav>
-    <mat-sidenav-content class="sidenavContentPolyfill320">
-      <div class="main-panel">
-        <result-header [assessment]="assessment" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="assessment?.created"></result-header>
-        <unf-assess-group #assessGroupMain [unassessedPhases]="unassessedPhases$ | async" [assessmentGroup]="assessmentGroup$" [activePhase]="phase" 
-          [rollupId]="rollupId" [assessment]="assessment" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)">
-        </unf-assess-group>
-      </div>
-    </mat-sidenav-content>
-  </mat-sidenav-container>
-</div>
+      </mat-sidenav>
+      <mat-sidenav-content class="sidenavContentPolyfill320">
+        <div class="main-panel">
+          <result-header [assessment]="assessment" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="assessment?.created"></result-header>
+          <unf-assess-group #assessGroupMain [unassessedPhases]="unassessedPhases$ | async" [assessmentGroup]="assessmentGroup$" [activePhase]="phase"
+            [rollupId]="rollupId" [assessment]="assessment" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)" [categoryLookup]="categoryLookup$">
+          </unf-assess-group>
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
+  </div>
+</ng-container>
 
 <ng-template #loadingBlock>
-  <loading-spinner></loading-spinner>
+  <loading-spinner class="fadeIn"></loading-spinner>
 </ng-template>
 
-<ng-template #notFound>
-  <div class="container">
+<ng-template #failedToLoadBlock>
+  <div class="container fadeIn">
     <div class="row mt-15">
       <div class="col-xs-10 col-xs-offset-1">
-        <error-card errorTitle="Assessment Not Found" errorBody="404: The request URL was not found in the application."></error-card>
+        <error-card errorTitle="Assessment Failed To Load" errorBody="This Assessment was not found. Check the URL, or verify the Assessment is published and visible to your organization."></error-card>
       </div>
     </div>
   </div>

--- a/src/app/assess/v3/result/full/full.component.html
+++ b/src/app/assess/v3/result/full/full.component.html
@@ -75,7 +75,7 @@
   <div class="container fadeIn">
     <div class="row mt-15">
       <div class="col-xs-10 col-xs-offset-1">
-        <error-card errorTitle="Assessment Failed To Load" errorBody="This Assessment was not found. Check the URL, or verify the Assessment is published and visible to your organization."></error-card>
+        <error-card errorTitle="Assessment Failed To Load" errorBody="This Assessment failed to load. Check the network, URL, and verify the assessment is visible to your organization."></error-card>
       </div>
     </div>
   </div>

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
@@ -2,8 +2,13 @@
   <hr>
 
   <div *ngIf="addAssessedObject">
-    <mat-card class="mat-elevation-z18" id="addAssessedObjectCard">
+    <mat-card class="mat-elevation-z18 fadeIn" id="addAssessedObjectCard">
       <mat-card-title>Add {{ addAssessedObjectName }}</mat-card-title>
+      <mat-card-subtitle *ngIf="errMsg && errMsg.length > 0">
+        <span class="errMsg">
+          {{ errMsg }}
+        </span>
+      </mat-card-subtitle>
       <mat-card-content *ngIf="addAssessedType">
 
         <div [ngSwitch]="addAssessedType">
@@ -23,23 +28,23 @@
             <div class="row">
               <div class="col-md-12">
                 <mat-form-field class="full-width">
-                  <input matInput placeholder="Name" required [(ngModel)]="indicator.name" value="{{indicator.name}}" />
-                </mat-form-field>
-              </div>
-            </div>            
-            <div class="row">
-              <div class="col-md-12">
-                <mat-form-field class="full-width">
-                  <textarea matInput placeholder="Pattern" required [(ngModel)]="indicator.pattern" value="{{indicator.pattern}}"></textarea>
+                  <input matInput placeholder="Name" required [(ngModel)]="indicator.name" value="{{indicator.name}}" autocomplete="off" />
                 </mat-form-field>
               </div>
             </div>
             <div class="row">
-                <div class="col-md-12">
-                    <mat-form-field class="full-width">
-                        <textarea matInput placeholder="Description" [(ngModel)]="indicator.description" value="{{indicator.description}}"></textarea>
-                    </mat-form-field>
-                </div>
+              <div class="col-md-12">
+                <mat-form-field class="full-width">
+                  <textarea matInput placeholder="Pattern" required [(ngModel)]="indicator.pattern" value="{{indicator.pattern}}" autocomplete="off"></textarea>
+                </mat-form-field>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-md-12">
+                <mat-form-field class="full-width">
+                  <textarea matInput placeholder="Description" [(ngModel)]="indicator.description" value="{{indicator.description}}" autocomplete="off"></textarea>
+                </mat-form-field>
+              </div>
             </div>
 
             <div class="row">
@@ -50,7 +55,6 @@
               </p>
             </div>
           </div>
-          <!-- End indicator-->
 
           <div *ngSwitchCase="'course-of-action'">
             <div class="row">
@@ -67,14 +71,15 @@
             <div class="row">
               <div class="col-md-12">
                 <mat-form-field class="full-width">
-                  <input matInput placeholder="Name" required [(ngModel)]="courseOfAction.name" value="{{courseOfAction.name}}">
+                  <input matInput placeholder="Name" required [(ngModel)]="courseOfAction.name" value="{{courseOfAction.name}}" autocomplete="off">
                 </mat-form-field>
               </div>
             </div>
             <div class="row">
               <div class="col-md-12">
                 <mat-form-field class="full-width">
-                  <textarea matInput placeholder="Description" [(ngModel)]="courseOfAction.description" value="{{courseOfAction.description}}"></textarea>
+                  <textarea matInput placeholder="Description" [(ngModel)]="courseOfAction.description" value="{{courseOfAction.description}}"
+                    autocomplete="off"></textarea>
                 </mat-form-field>
               </div>
             </div>
@@ -86,43 +91,77 @@
               </p>
             </div>
           </div>
-          <!-- End COA -->
 
-          <div *ngSwitchCase="'x-unfetter-sensor'">
-            <div class="row">
-              <div *ngFor="let measurement of xUnfetterSensor.questions" class="col-xs-12">
-                <mat-form-field class="full-width">
-                  <mat-select [(ngModel)]="measurement.risk" class="full-width matSelectBotMargin" placeholder="{{ measurement.name }}">
-                    <mat-option *ngFor="let option of measurement.options" [value]="option.risk">
-                      {{ option.name }}
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
+          <div *ngSwitchCase="'x-unfetter-capability'">
+            <form [formGroup]="capabilityFormGroup" autocomplete="off">
+              <!-- <div class="row">
+                <div *ngFor="let measurement of xUnfetterCapability.questions" class="col-xs-12">
+                  <mat-form-field class="full-width">
+                    <mat-select [(ngModel)]="measurement.risk" class="full-width matSelectBotMargin" placeholder="{{ measurement.name }}">
+                      <mat-option *ngFor="let option of measurement.options" [value]="option.risk">
+                        {{ option.name }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="col-md-12">
-                <mat-form-field class="full-width">
-                  <input matInput placeholder="Name" required [(ngModel)]="xUnfetterSensor.name" value="{{xUnfetterSensor.name}}" />
-                </mat-form-field>
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <input matInput placeholder="Name" required [(ngModel)]="xUnfetterCapability.name" value="{{xUnfetterCapability.name}}" autocomplete="off">
+                  </mat-form-field>
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="col-md-12">
-                <mat-form-field class="full-width">
-                  <textarea matInput placeholder="Description" [(ngModel)]="xUnfetterSensor.description" value="{{xUnfetterSensor.description}}"></textarea>
-                </mat-form-field>
+            -->
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <textarea matInput placeholder="Description" formControlName="description"></textarea>
+                  </mat-form-field>
+                </div>
+              </div> 
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <mat-select formControlName="protectWeight" placeholder="protect">
+                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                        {{ weight.longForm }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <p class="text-right">
-                <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL</button>
-                <button color="accent" mat-raised-button [disabled]="!xUnfetterSensor.name" (click)="createAssessedObject(xUnfetterSensor, currentAttackPattern)">SAVE</button>
-              </p>
-            </div>
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <mat-select formControlName="detectWeight" placeholder="detect">
+                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                        {{ weight.longForm }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <mat-select formControlName="respondWeight" placeholder="respond">
+                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                        {{ weight.longForm }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row">
+                <p class="text-right">
+                  <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL</button>
+                  <!-- <button color="accent" mat-raised-button [disabled]="!xUnfetterCapability.name" (click)="createAssessedObject(xUnfetterCapability, currentAttackPattern)">SAVE</button> -->
+                  <button color="accent" mat-raised-button [disabled]="!capabilityFormGroup" (click)="applyNewCapability(capabilityFormGroup?.value, $event)">SAVE</button>
+                </p>
+              </div>
+            </form>
           </div>
-          <!-- End sensor -->
-
         </div>
       </mat-card-content>
     </mat-card>

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
@@ -51,7 +51,7 @@
               <p class="text-right">
                 <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL
                 </button>
-                <button mat-raised-button color="accent" [disabled]="!indicator.name || !indicator.pattern" (click)="createAssessedObject(indicator, currentAttackPattern)">SAVE</button>
+                <button mat-raised-button color="accent" [disabled]="!indicator.name || !indicator.pattern" (click)="onCreateAssessedObject(indicator, currentAttackPattern, $event)">SAVE</button>
               </p>
             </div>
           </div>
@@ -87,44 +87,51 @@
             <div class="row">
               <p class="text-right">
                 <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL</button>
-                <button color="accent" mat-raised-button [disabled]="!courseOfAction.name" (click)="createAssessedObject(courseOfAction, currentAttackPattern)">SAVE</button>
+                <button color="accent" mat-raised-button [disabled]="!courseOfAction.name" (click)="onCreateAssessedObject(courseOfAction, currentAttackPattern, $event)">SAVE</button>
               </p>
             </div>
           </div>
 
           <div *ngSwitchCase="'x-unfetter-capability'">
             <form [formGroup]="capabilityFormGroup" autocomplete="off">
-              <!-- <div class="row">
-                <div *ngFor="let measurement of xUnfetterCapability.questions" class="col-xs-12">
-                  <mat-form-field class="full-width">
-                    <mat-select [(ngModel)]="measurement.risk" class="full-width matSelectBotMargin" placeholder="{{ measurement.name }}">
-                      <mat-option *ngFor="let option of measurement.options" [value]="option.risk">
-                        {{ option.name }}
-                      </mat-option>
-                    </mat-select>
-                  </mat-form-field>
+              <div class="row errMsg" *ngIf="capabilityFormGroup.get('assessmentRisk').touched && capabilityFormGroup.get('assessmentRisk').errors as riskErrs">
+                {{ riskErrs | json }}
+              </div>
+              <div class="row">
+                <div class="col-md-12 mat-subheading-1">
+                  Capability
                 </div>
               </div>
               <div class="row">
                 <div class="col-md-12">
                   <mat-form-field class="full-width">
-                    <input matInput placeholder="Name" required [(ngModel)]="xUnfetterCapability.name" value="{{xUnfetterCapability.name}}" autocomplete="off">
+                    <input matInput placeholder="Name" formControlName="name" required>
                   </mat-form-field>
                 </div>
               </div>
-            -->
               <div class="row">
                 <div class="col-md-12">
                   <mat-form-field class="full-width">
                     <textarea matInput placeholder="Description" formControlName="description"></textarea>
                   </mat-form-field>
                 </div>
-              </div> 
+              </div>
               <div class="row">
                 <div class="col-md-12">
                   <mat-form-field class="full-width">
-                    <mat-select formControlName="protectWeight" placeholder="protect">
-                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                    <mat-select formControlName="category" placeholder="Category">
+                      <mat-option *ngFor="let category of categoryLookup; trackBy: trackByFn" [value]="category">
+                        {{ category.name }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-12">
+                  <mat-form-field class="full-width">
+                    <mat-select formControlName="protectWeight" placeholder="Protect">
+                      <mat-option *ngFor="let weight of capabilitySelectWeightings; trackBy: trackByFn" [value]="weight.shortForm">
                         {{ weight.longForm }}
                       </mat-option>
                     </mat-select>
@@ -134,8 +141,8 @@
               <div class="row">
                 <div class="col-md-12">
                   <mat-form-field class="full-width">
-                    <mat-select formControlName="detectWeight" placeholder="detect">
-                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                    <mat-select formControlName="detectWeight" placeholder="Detect">
+                      <mat-option *ngFor="let weight of capabilitySelectWeightings; trackBy: trackByFn" [value]="weight.shortForm">
                         {{ weight.longForm }}
                       </mat-option>
                     </mat-select>
@@ -145,9 +152,25 @@
               <div class="row">
                 <div class="col-md-12">
                   <mat-form-field class="full-width">
-                    <mat-select formControlName="respondWeight" placeholder="respond">
-                      <mat-option *ngFor="let weight of selectWeightings" [value]="weight">
+                    <mat-select formControlName="respondWeight" placeholder="Respond">
+                      <mat-option *ngFor="let weight of capabilitySelectWeightings; trackBy: trackByFn" [value]="weight.shortForm">
                         {{ weight.longForm }}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-12 mat-subheading-1">
+                  Score Assessment
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-xs-12">
+                  <mat-form-field class="full-width">
+                    <mat-select formControlName="assessmentRisk" class="full-width matSelectBotMargin" placeholder="Coverage">
+                      <mat-option *ngFor="let option of capabiltyAssessmentSelectOptions" [value]="option.risk">
+                        {{ option.name }}
                       </mat-option>
                     </mat-select>
                   </mat-form-field>
@@ -156,8 +179,7 @@
               <div class="row">
                 <p class="text-right">
                   <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL</button>
-                  <!-- <button color="accent" mat-raised-button [disabled]="!xUnfetterCapability.name" (click)="createAssessedObject(xUnfetterCapability, currentAttackPattern)">SAVE</button> -->
-                  <button color="accent" mat-raised-button [disabled]="!capabilityFormGroup" (click)="applyNewCapability(capabilityFormGroup?.value, $event)">SAVE</button>
+                  <button color="accent" mat-raised-button [disabled]="capabilityFormGroup.invalid" (click)="onCapabilitySave(capabilityFormGroup?.value, $event)">SAVE</button>
                 </p>
               </div>
             </form>
@@ -166,5 +188,5 @@
       </mat-card-content>
     </mat-card>
   </div>
-  <unf-speed-dial [items]="speedDialItems" (itemClickedEmitter)="speedDialClicked($event)" [(open)]="addAssessedObject"></unf-speed-dial>
+  <unf-speed-dial [items]="speedDialItems" (itemClickedEmitter)="onSpeedDialClicked($event)" [(open)]="addAssessedObject"></unf-speed-dial>
 </div>

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.scss
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.scss
@@ -1,7 +1,13 @@
+@import '../../../../../../../styles/_variables';
+
 #addAssessedObjectCard {
     position: fixed;
     bottom: 26px;
     right: 100px;
     width: 400px;
     z-index: 500;
+}
+
+.errMsg {
+    color: $warn-color;
 }

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { EMPTY, Observable, of, Subscription } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, first } from 'rxjs/operators';
 import { AssessedObject, ObjectAssessment } from 'stix';
 import { Capability } from 'stix/assess/v3/baseline/capability';
 import { Category } from 'stix/assess/v3/baseline/category';
@@ -264,10 +264,14 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
 
         const sub$ = saveCapability$
             .pipe(
+                // grab first capability on list
+                first(),
                 // save the capability to assessment link
                 switchMap((savedCapability) => {
                     return this.generateSaveObjectAssessmentObservable(formValues, savedCapability);
                 }),
+                // grab first object assessent on list
+                first(),
                 // TODO: should we save the new object assessment into the baseline?
                 // save the object as part of the parent assessment
                 switchMap((objectAssessment) => {
@@ -405,11 +409,11 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
 
         // testing
         // capability.id = '1243';
-        // return of(capability);
+        // return of([capability]);
         return this.assessService
             .genericPost(`api/v3/x-unfetter-capabilities`, capability)
             .pipe(
-                map((assessments) => assessments.map(RxjsHelpers.mapAttributes))
+                map((capabilities) => capabilities.map(RxjsHelpers.mapAttributes)[0])
             );
     }
 
@@ -454,11 +458,11 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
 
         // testing
         // objectAssessment.id = '123x';
-        // return of(objectAssessment);
+        // return of([objectAssessment]);
         return this.assessService
             .genericPost(`api/v3/x-unfetter-object-assessments`, objectAssessment)
             .pipe(
-                map((assessments) => assessments.map(RxjsHelpers.mapAttributes))
+                map((objectAssessments) => objectAssessments.map(RxjsHelpers.mapAttributes)[0])
             );
     }
 

--- a/src/app/assess/v3/result/full/group/add-assessed-object/select-option.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/select-option.ts
@@ -1,0 +1,8 @@
+export class SelectOption {
+    constructor(
+        public name: string,
+        public risk: number = -1,
+    ) {
+
+    }
+}

--- a/src/app/assess/v3/result/full/group/add-assessed-object/weighting.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/weighting.ts
@@ -1,0 +1,7 @@
+import { QuestionAnswerEnum } from 'stix/assess/v3/baseline/question-answer.enum';
+
+export class Weighting {
+    constructor(public longForm: string, public shortForm: QuestionAnswerEnum) {
+
+    }
+}

--- a/src/app/assess/v3/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.html
@@ -71,7 +71,8 @@
             <div class="assessment-objects">
                 <unf-add-assessed-object #addAssessedObjectComponent *ngIf="assessment && canAddAssessedObjects" [assessment]="assessment" [addAssessedObject]="addAssessedObject"
                     [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [displayedAssessedObjects]="displayedAssessedObjects"
-                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment() : 0">
+                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment() : 0"
+                    [categoryLookup]="categoryLookup | async">
                 </unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">

--- a/src/app/assess/v3/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.html
@@ -70,9 +70,9 @@
 
             <div class="assessment-objects">
                 <unf-add-assessed-object #addAssessedObjectComponent *ngIf="assessment && canAddAssessedObjects" [assessment]="assessment" [addAssessedObject]="addAssessedObject"
-                    [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [indicator]="indicator"
-                    [courseOfAction]="courseOfAction" [xUnfetterSensor]="xUnfetterSensor" [displayedAssessedObjects]="displayedAssessedObjects"
-                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment() : 0"></unf-add-assessed-object>
+                    [addAssessedType]="addAssessedType" [currentAttackPattern]="currentAttackPattern" [displayedAssessedObjects]="displayedAssessedObjects"
+                    [assessedObjects]="assessedObjects" (addAssessmentEvent)="$event ? onAddAssessment() : 0">
+                </unf-add-assessed-object>
 
                 <div *ngIf="displayedAssessedObjects && displayedAssessedObjects.length">
                     <div *ngFor="let assessedObj of displayedAssessedObjects | sortByField: 'risk'; trackBy: trackByFn">

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -1,4 +1,3 @@
-
 import { AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output, QueryList, ViewChildren } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
@@ -11,6 +10,7 @@ import { AssessmentQuestion } from 'stix/assess/v2/assessment-question';
 import { RiskByAttack } from 'stix/assess/v2/risk-by-attack';
 import { Assessment } from 'stix/assess/v3/assessment';
 import { AssessmentEvalTypeEnum } from 'stix/assess/v3/assessment-eval-type.enum';
+import { Category } from 'stix/assess/v3/baseline/category';
 import { AttackPattern } from 'stix/unfetter/attack-pattern';
 import { Stix } from 'stix/unfetter/stix';
 import { AuthService } from '../../../../../core/services/auth.service';
@@ -35,34 +35,18 @@ import { FullAssessmentGroup } from './models/full-assessment-group';
   // changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
+  @Input() public activePhase: string;
+  @Input() public assessment: Assessment;
+  @Input() public assessmentGroup: Observable<FullAssessmentGroup>;
+  @Input() public assessmentId: string;
+  @Input() public categoryLookup: Observable<Category[]>;
+  @Input() public initialAttackPatternId: string;
+  @Input() public rollupId: string;
+  @Input() public unassessedPhases: string[];
+  @Output() public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
+  @ViewChildren('addAssessedObjectComponent') public addAssessedObjectComponents: QueryList<AddAssessedObjectComponent>;
 
-  @Input()
-  public assessment: Assessment;
-
-  @Input()
-  public assessmentId: string;
-
-  @Input()
-  public rollupId: string;
-
-  @Input()
-  public activePhase: string;
-
-  @Input()
-  public initialAttackPatternId: string;
-
-  @Input()
-  public assessmentGroup: Observable<FullAssessmentGroup>;
-  @Input()
-  public unassessedPhases: string[];
-
-  @Output()
-  public riskByAttackPatternChanged = new EventEmitter<RiskByAttack>();
-
-  @ViewChildren('addAssessedObjectComponent')
-  public addAssessedObjectComponents: QueryList<AddAssessedObjectComponent>;
   public addAssessedObjectComponent: AddAssessedObjectComponent;
-
   public addAssessedObject: boolean;
   public addAssessedType: string;
   public assessedObjects: AssessmentObject[];
@@ -72,6 +56,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public displayedAssessedObjects: DisplayedAssessmentObject[];
   public riskByAttackPattern: RiskByAttack;
   public unassessedAttackPatterns: AttackPattern[];
+
 
   private readonly subscriptions: Subscription[] = [];
 

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -22,7 +22,6 @@ import { StixPermissions } from '../../../../../global/static/stix-permissions';
 import { Relationship } from '../../../../../models';
 import { AppState } from '../../../../../root-store/app.reducers';
 import { Constance } from '../../../../../utils/constance';
-import { AssessService } from '../../../services/assess.service';
 import { LoadGroupAttackPatternRelationships, LoadGroupCurrentAttackPattern, LoadGroupData, PushUrl, UpdateAssessmentObject } from '../../store/full-result.actions';
 import { FullAssessmentResultState } from '../../store/full-result.reducers';
 import { AddAssessedObjectComponent } from './add-assessed-object/add-assessed-object.component';
@@ -69,19 +68,15 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
   public assessedObjects: AssessmentObject[];
   public attackPatternsByPhase: AssessAttackPatternMeta[];
   public canAddAssessedObjects: boolean = false;
-  public courseOfAction: any;
   public currentAttackPattern: AttackPattern;
   public displayedAssessedObjects: DisplayedAssessmentObject[];
-  public indicator: any;
   public riskByAttackPattern: RiskByAttack;
   public unassessedAttackPatterns: AttackPattern[];
-  public xUnfetterSensor: any;
 
   private readonly subscriptions: Subscription[] = [];
 
   constructor(
     private appStore: Store<AppState>,
-    private assessService: AssessService,
     private authService: AuthService,
     private changeDetector: ChangeDetectorRef,
     private store: Store<FullAssessmentResultState>,

--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -189,9 +189,10 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     const sub3$ = this.assessmentGroup
       .pipe(
         filter((group: FullAssessmentGroup) => {
-          return group.finishedLoadingGroupData === true
-            && this.displayedAssessedObjects !== undefined
-            && this.currentAttackPattern !== undefined
+          const hasAttackPattern = this.currentAttackPattern !== undefined && this.currentAttackPattern.id !== undefined;
+          const hasDisplayObject = this.displayedAssessedObjects !== undefined;
+          const isFinishedLoading = group.finishedLoadingGroupData !== undefined && group.finishedLoadingGroupData === true;
+          return (isFinishedLoading && hasDisplayObject && hasAttackPattern);
         })
       )
       .subscribe(

--- a/src/app/assess/v3/result/result.module.ts
+++ b/src/app/assess/v3/result/result.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule, MatProgressSpinnerModule, MatSelectModule, MatSliderModule, MatTableModule, MatTabsModule } from '@angular/material';
 import { RouterModule } from '@angular/router';
 import { EffectsModule } from '@ngrx/effects';
@@ -47,6 +47,7 @@ const moduleComponents = [
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     RouterModule,
     ...materialModules,
     GlobalModule,

--- a/src/app/assess/v3/result/store/full-result.actions.ts
+++ b/src/app/assess/v3/result/store/full-result.actions.ts
@@ -16,7 +16,7 @@ export const UPDATE_ASSESSMENT_OBJECT = '[Assess Result Group] UPDATE_ASSESSMENT
 // For reducers
 export const CLEAN_ASSESSMENT_RESULT_DATA = '[Assess Result Group] CLEAN_ASSESSMENT_RESULT_DATA';
 export const DONE_PUSH_URL = '[Assess Result] DONE_PUSH_URL';
-export const FAILED_TO_LOAD = '[Assess Result Group] FAILED_TO_LOAD';
+export const FAILED_TO_LOAD = '[Assess Result] FAILED_TO_LOAD';
 export const FINISHED_LOADING = '[Assess Result] FINISHED_LOADING';
 export const PUSH_URL = '[Assess Result] PUSH_URL';
 export const RELOAD_AFTER_UPDATE_ASSESSMENT_OBJECT = '[Assess Result Group] RELOAD_AFTER_UPDATE_ASSESSMENT_OBJECT';

--- a/src/app/assess/v3/result/store/full-result.reducers.spec.ts
+++ b/src/app/assess/v3/result/store/full-result.reducers.spec.ts
@@ -32,7 +32,7 @@ describe('assessment v3 - full result reducer spec', () => {
     it('should track failed to load', () => {
         const state = fullAssessmentResultReducer(initialState, new actions.FailedToLoad(true));
         expect(state).toBeDefined();
-        expect(state.finishedLoading).toBe(false);
+        expect(state.finishedLoading).toBe(true);
         expect(state.failedToLoad).toBe(true);
     });
 

--- a/src/app/assess/v3/result/store/full-result.reducers.ts
+++ b/src/app/assess/v3/result/store/full-result.reducers.ts
@@ -84,7 +84,7 @@ export function fullAssessmentResultReducer(state = initialState, action: FullAs
         case fullAssessmentResultActions.FAILED_TO_LOAD:
             return {
                 ...state,
-                finishedLoading: !action.payload,
+                finishedLoading: true,
                 failedToLoad: action.payload,
             };
         case fullAssessmentResultActions.SET_GROUP_DATA:

--- a/src/app/assess/v3/result/store/full-result.selectors.spec.ts
+++ b/src/app/assess/v3/result/store/full-result.selectors.spec.ts
@@ -1,7 +1,7 @@
 import { FullAssessmentResultState, genState } from './full-result.reducers';
 import { getFailedToLoadAssessment, getFinishedLoadingAssessment, getTacticsChains } from './full-result.selectors';
 
-fdescribe('assessment v3 - full result selectors spec', () => {
+describe('assessment v3 - full result selectors spec', () => {
 
     let state: { 'fullAssessment': FullAssessmentResultState };
     let configState;

--- a/src/app/assess/v3/result/store/full-result.selectors.spec.ts
+++ b/src/app/assess/v3/result/store/full-result.selectors.spec.ts
@@ -1,19 +1,48 @@
-import { getTacticsChains } from './full-result.selectors';
+import { FullAssessmentResultState, genState } from './full-result.reducers';
+import { getFailedToLoadAssessment, getFinishedLoadingAssessment, getTacticsChains } from './full-result.selectors';
 
-describe('assessment v3 - full result selectors spec', () => {
+fdescribe('assessment v3 - full result selectors spec', () => {
 
-    let appState;
+    let state: { 'fullAssessment': FullAssessmentResultState };
+    let configState;
 
     beforeEach(() => {
-        appState = {
+        state = { 'fullAssessment': genState() };
+        configState = {
             config: {
                 tacticsChains: genTacticsChains(),
             }
         }
     });
 
+    it('should return a failed to load false', () => {
+        const el = getFailedToLoadAssessment(state);
+        expect(el).toBeDefined();
+        expect(el).toBeFalsy();
+    });
+
+    it('should return a failed to load true', () => {
+        state.fullAssessment.failedToLoad = true;
+        const el = getFailedToLoadAssessment(state);
+        expect(el).toBeDefined();
+        expect(el).toBeTruthy();
+    });
+
+    it('should return a finished loading false', () => {
+        const el = getFinishedLoadingAssessment(state);
+        expect(el).toBeDefined();
+        expect(el).toBeFalsy();
+    });
+
+    it('should return a finished loading true', () => {
+        state.fullAssessment.finishedLoading = true;
+        const el = getFinishedLoadingAssessment(state);
+        expect(el).toBeDefined();
+        expect(el).toBeTruthy();
+    });
+
     it('getTacticsChains should return config tacticsChains', () => {
-        const el = getTacticsChains(appState);
+        const el = getTacticsChains(configState);
         expect(el).toBeTruthy();
         const id = 'mitre-attack';
         const attack = el[id];

--- a/src/app/assess/v3/result/store/full-result.selectors.ts
+++ b/src/app/assess/v3/result/store/full-result.selectors.ts
@@ -1,11 +1,10 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { FullAssessmentGroup } from '../full/group/models/full-assessment-group';
-import { FullAssessmentResultState } from './full-result.reducers';
-import { ConfigState } from '../../../../root-store/config/config.reducers';
 import { Assessment } from 'stix/assess/v3/assessment';
 import { Dictionary } from 'stix/common/dictionary';
 import { TacticChain } from '../../../../global/components/tactics-pane/tactics.model';
-import { AssessmentEvalTypeEnum } from 'stix';
+import { ConfigState } from '../../../../root-store/config/config.reducers';
+import { FullAssessmentGroup } from '../full/group/models/full-assessment-group';
+import { FullAssessmentResultState } from './full-result.reducers';
 
 const getConfigState = createFeatureSelector<ConfigState>('config');
 
@@ -18,6 +17,10 @@ export const getFullAssessmentState = createFeatureSelector<FullAssessmentResult
 export const getFinishedLoadingAssessment = createSelector(
     getFullAssessmentState,
     (state) => state.finishedLoading);
+
+export const getFailedToLoadAssessment = createSelector(
+    getFullAssessmentState,
+    (state) => state.failedToLoad);
 
 export const getGroupState = createSelector(
     getFullAssessmentState,

--- a/src/app/assess/v3/store/assess.reducers.ts
+++ b/src/app/assess/v3/store/assess.reducers.ts
@@ -24,7 +24,7 @@ export interface AssessState {
     showSummary: boolean;
 };
 
-const genAssessState = (state?: Partial<AssessState>) => {
+export const genAssessState = (state?: Partial<AssessState>) => {
     const tmp = {
         assessment: new Assessment(),
         backButton: false,

--- a/src/app/assess/v3/store/assess.selectors.spec.ts
+++ b/src/app/assess/v3/store/assess.selectors.spec.ts
@@ -1,0 +1,87 @@
+import { Capability } from 'stix/assess/v3/baseline/capability';
+import { CapabilityMockFactory } from 'stix/assess/v3/baseline/capability.mock';
+import { Category } from 'stix/assess/v3/baseline/category';
+import { CategoryMockFactory } from 'stix/assess/v3/baseline/category.mock';
+import { AssessState, genAssessState } from './assess.reducers';
+import { getCapabilities, getCategories, getFinishedLoading, getSortedCapabilities, getSortedCategories } from './assess.selectors';
+
+describe('assessment v3 - assess selectors spec', () => {
+
+    let storeState: { 'assessment': AssessState };
+
+    beforeEach(() => {
+        const categories = genTestCategories();
+        const capabilities = genTestCapabilities();
+        const state = genAssessState();
+        state.categories = categories;
+        state.capabilities = capabilities;
+        storeState = { 'assessment': state };
+    });
+
+    it('getFinishedLoading should return false', () => {
+        const finishedLoading = getFinishedLoading(storeState);
+        expect(finishedLoading).toBeDefined();
+        expect(finishedLoading).toBeFalsy();
+    });
+
+    it('getFinishedLoading should return true', () => {
+        storeState.assessment.finishedLoading = true;
+        const finishedLoading = getFinishedLoading(storeState);
+        expect(finishedLoading).toBeTruthy();
+    });
+
+    it('getCapabilities should return', () => {
+        const expected = storeState.assessment.capabilities;
+        const capabilities = getCapabilities(storeState);
+        expect(capabilities).toBeTruthy();
+        expect(Array.isArray(capabilities)).toBeTruthy();
+        expect(capabilities).toEqual(expected);
+    });
+
+    it('getSortedCapabilities should return', () => {
+        // unsort
+        storeState.assessment.capabilities[0].name = 'z';
+        storeState.assessment.capabilities[1].name = 'a';
+        const capabilities = getSortedCapabilities(storeState);
+        expect(capabilities).toBeTruthy();
+        expect(Array.isArray(capabilities)).toBeTruthy();
+        expect(ensureSorted(capabilities)).toBeTruthy();
+    });
+
+    it('getCategories should return', () => {
+        const expected = storeState.assessment.categories;
+        const categories = getCategories(storeState);
+        expect(categories).toBeTruthy();
+        expect(Array.isArray(categories)).toBeTruthy();
+        expect(categories).toEqual(expected);
+    });
+
+    it('getSortedCategories should return', () => {
+        // unsort
+        storeState.assessment.categories[0].name = 'z';
+        storeState.assessment.categories[1].name = 'a';
+        const categories = getSortedCategories(storeState);
+        expect(categories).toBeTruthy();
+        expect(Array.isArray(categories)).toBeTruthy();
+        expect(ensureSorted(categories)).toBeTruthy();
+    });
+
+    function ensureSorted(arr: any[]): boolean {
+        let prev = arr[0];
+        const allDesc = arr.every((cur) => {
+            const isDesc = prev.name <= cur.name;
+            prev = cur;
+            return isDesc;
+        });
+        return allDesc;
+    }
+
+    function genTestCategories(): Category[] {
+        return CategoryMockFactory.mockMany(5);
+    }
+
+    function genTestCapabilities(): Capability[] {
+        return CapabilityMockFactory.mockMany(5);
+    }
+
+});

--- a/src/app/assess/v3/store/assess.selectors.ts
+++ b/src/app/assess/v3/store/assess.selectors.ts
@@ -82,7 +82,17 @@ export const getCapabilities = createSelector(
     (state) => state.capabilities,
 );
 
+export const getSortedCapabilities = createSelector(
+    getCapabilities,
+    (capabilities) => capabilities.sort(SortHelper.sortDescByField('name'))
+);
+
 export const getCategories = createSelector(
     getAssessState,
     (state) => state.categories,
+);
+
+export const getSortedCategories = createSelector(
+    getCategories,
+    (categories) => categories.sort(SortHelper.sortDescByField('name')),
 );

--- a/src/app/baseline/services/baseline.service.ts
+++ b/src/app/baseline/services/baseline.service.ts
@@ -123,8 +123,10 @@ export class BaselineService {
         const url = filter ?
             `${this.categoryBaseUrl}?${encodeURI(filter)}` : this.categoryBaseUrl;
         return this.genericApi
-            .getAs<JsonApiData<Category>[]>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<JsonApiData<Category>[]>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -136,8 +138,10 @@ export class BaselineService {
         const url = filter ?
             `${this.capabilityBaseUrl}?${encodeURI(filter)}` : this.capabilityBaseUrl;
         return this.genericApi
-            .getAs<JsonApiData<Capability>[]>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<JsonApiData<Capability>[]>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -150,8 +154,10 @@ export class BaselineService {
     public fetchBaselines(includeMeta = true): Observable<AssessmentSet[]> {
         const url = `${Constance.X_UNFETTER_ASSESSMENT_SETS_URL}?metaproperties=${includeMeta}`;
         return this.genericApi
-            .getAs<JsonApiData<AssessmentSet[]>>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<JsonApiData<AssessmentSet[]>>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -162,8 +168,10 @@ export class BaselineService {
     public getById(id: string, includeMeta = true): Observable<AssessmentSet> {
         const url = `${this.baselineBaseUrl}/${id}?metaproperties=${includeMeta}`;
         return this.genericApi
-            .getAs<JsonApiData<AssessmentSet>>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<JsonApiData<AssessmentSet>>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -174,8 +182,10 @@ export class BaselineService {
     public fetchAssessmentSet(id: string, includeMeta = true): Observable<AssessmentSet> {
         const url = `${Constance.X_UNFETTER_ASSESSMENT_SETS_URL}/${id}?metaproperties=${includeMeta}`;
         return this.genericApi
-            .getAs<JsonApiData<AssessmentSet>>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<JsonApiData<AssessmentSet>>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -226,8 +236,10 @@ export class BaselineService {
 
         const url = `${this.capabilityBaseUrl}/${capId}`;
         return this.genericApi
-            .getAs<Capability>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<Capability>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -242,8 +254,10 @@ export class BaselineService {
 
         const url = `${this.categoryBaseUrl}/${catId}`;
         return this.genericApi
-            .getAs<Category>(url).pipe(
-                map(RxjsHelpers.mapAttributes));
+            .getAs<Category>(url)
+            .pipe(
+                map(RxjsHelpers.mapAttributes)
+            );
     }
 
     /**
@@ -258,8 +272,10 @@ export class BaselineService {
         const urlBase = this.objectAssessmentsBaseUrl;
         const observables = ids.map((id) => {
             return this.genericApi
-                .getAs<JsonApiData<ObjectAssessment>>(`${this.baselineBaseUrl}/${id}`).pipe(
-                    map<JsonApiData<ObjectAssessment>, ObjectAssessment>(RxjsHelpers.mapAttributes));
+                .getAs<JsonApiData<ObjectAssessment>>(`${this.baselineBaseUrl}/${id}`)
+                .pipe(
+                    map<JsonApiData<ObjectAssessment>, ObjectAssessment>(RxjsHelpers.mapAttributes)
+                );
         });
 
         return observableForkJoin(...observables);

--- a/src/app/global/components/speed-dial/speed-dial.component.html
+++ b/src/app/global/components/speed-dial/speed-dial.component.html
@@ -7,7 +7,7 @@
                         <mat-icon class="mat-24">{{item.matIcon}}</mat-icon>
                     </ng-container>
                     <ng-template #svgIcon>
-                        <img class="stix-icon" style="height: 23px;" src="{{item.svgIconPath}}">
+                        <img class="stix-icon" style="height: 23px;" src="{{item.svgIconName}}">
                     </ng-template>
                 </button>
             </ng-container>

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -518,6 +518,15 @@ export const Constance = {
         'most critical systems covered',
         'all critical systems covered'
       ]
+    },
+    'x-unfetter-capability': {
+      coverage: [
+        'no coverage',
+        'some coverage',
+        'half coverage',
+        'most critical systems covered',
+        'all critical systems covered'
+      ]
     }
   },
   DIALOG_WIDTH_MEDIUM: '800px',


### PR DESCRIPTION
fixes unfetter-discover/unfetter#1068

## feature
assessment beta, result tab speed dial, can now save a new capability inline

## changes
added capability awareness to the forms
use angular reactive forms for capability
added failed to load error handling
added error message on form submit

## test
pull this feature
create an assessment w/ capability
visit result tab

__Capability Case__
select the capability assessment from the master list
select the speed dial
select capability 
fill out form
verify it saves
save another capability, but optionally block the request in chrome, verify a red generic error message

__Mitigations Case__
select the mitigation assessment from the master list
select the speed dial
select mitigation 
fill out form
verify it saves

__Indicators Case__
select the indicators assessment from the master list
select the speed dial
select indicator 
fill out form
verify it saves

__Assessment failed to load__
mangle the assessment id in the url, refresh the browser, verify the error message


see screen shots

![screen shot 2018-06-29 at 3 59 04 pm](https://user-images.githubusercontent.com/30807406/42112642-0a5958e2-7bd8-11e8-871a-d848cc738eaa.png)

![screen shot 2018-06-29 at 4 00 03 pm](https://user-images.githubusercontent.com/30807406/42112648-0e4e74d2-7bd8-11e8-8079-54490fcf8094.png)


![screen shot 2018-06-29 at 4 03 24 pm](https://user-images.githubusercontent.com/30807406/42112653-116c0044-7bd8-11e8-94e8-5a58d887e577.png)

