### PR TITLE
Clicking publish now sets the published metaproperty to true via Save…

### DIFF
--- a/src/app/baseline/result/result-header/result-header.component.html
+++ b/src/app/baseline/result/result-header/result-header.component.html
@@ -15,7 +15,7 @@
     </div>
     <ng-template #notPublished>
       <div id="publishWrapper">
-        <button id="publishButton" mat-raised-button>PUBLISH</button>
+        <button (click)="publishBaseline()" id="publishButton" mat-raised-button>PUBLISH</button>
       </div>
     </ng-template>
   </div>

--- a/src/app/baseline/result/result-header/result-header.component.ts
+++ b/src/app/baseline/result/result-header/result-header.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { SummaryCalculationService } from '../summary/summary-calculation.service';
+import { Store } from '@ngrx/store';
+import * as assessReducers from '../../store/baseline.reducers';
+import { AssessmentSet } from 'stix/assess/v3/baseline/assessment-set';
+import { SaveBaseline } from '../../store/baseline.actions';
 
 @Component({
   selector: 'result-header',
@@ -18,9 +22,13 @@ export class ResultHeaderComponent implements OnInit {
   infoBarMsg: string;
   public editUrl: string;
 
+  @Input() currentBaseline: AssessmentSet;
+
   constructor(
-    public calculationService: SummaryCalculationService
+    public calculationService: SummaryCalculationService,
+    private wizardStore: Store<assessReducers.BaselineState>
   ) { }
+
 
   /**
    * @description on init
@@ -38,5 +46,15 @@ export class ResultHeaderComponent implements OnInit {
       this.infoBarMsg += ` ${this.percentCompleted}% of your baseline is complete.`;
       this.editUrl = `/baseline/wizard/edit/${this.baselineId}`;
     }
+
+    this.editUrl = `/baseline/wizard/edit/${this.baselineId}`;
+    this.infoBarMsg = 'Baselines is currently in beta. Some functionality does not work.'
+    this.percentCompleted = 2;
+    this.infoBarMsg += ` ${this.percentCompleted}% of your baseline is complete.`;
+  }
+
+  public publishBaseline() {
+    this.currentBaseline.metaProperties.published = true;
+    this.wizardStore.dispatch(new SaveBaseline(this.currentBaseline));
   }
 }

--- a/src/app/baseline/result/summary/summary.component.html
+++ b/src/app/baseline/result/summary/summary.component.html
@@ -31,7 +31,7 @@
     <mat-sidenav-content class="sidenavContentPolyfill320">
       <div class="main-panel">
         <!-- TODO replace true with published flag from metaproperties of baseline -->
-        <result-header [baselineId]="baselineId" [published]="calculationService.baseline.metaProperties.published ? calculationService.baseline.modified : undefined"></result-header>
+        <result-header [currentBaseline]="currentBaseline" [baselineId]="baselineId" [published]="calculationService.baseline.metaProperties.published ? calculationService.baseline.modified : undefined"></result-header>
         <summary-report></summary-report>
       </div>
     </mat-sidenav-content>

--- a/src/app/baseline/result/summary/summary.component.ts
+++ b/src/app/baseline/result/summary/summary.component.ts
@@ -33,6 +33,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
   baselineName: Observable<string>;
   blName: string;
   baselineId: string;
+  currentBaseline: AssessmentSet;
 
   dates: any[];
   summaries: AssessmentSet[];
@@ -247,6 +248,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
       distinctUntilChanged())
       .subscribe((baseline: AssessmentSet) => {
         if (baseline) {
+          this.currentBaseline = baseline;
           this.blName = baseline.name;
           this.baselineName = observableOf(this.blName);
         }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1148

To Test:
Create or use an existing base line and click publish. The button should disappear and should now says published. Click the drop down to add a new baseline. The status of this baseline should be marked as published. 