### PR TITLE
fix bug where results tab never loads

### DIFF
--- a/src/app/assess/v3/result/full/full.component.html
+++ b/src/app/assess/v3/result/full/full.component.html
@@ -59,7 +59,8 @@
         <div class="main-panel">
           <result-header [assessment]="assessment" [assessmentId]="assessmentId" [rollupId]="rollupId" [created]="assessment?.created"></result-header>
           <unf-assess-group #assessGroupMain [unassessedPhases]="unassessedPhases$ | async" [assessmentGroup]="assessmentGroup$" [activePhase]="phase"
-            [rollupId]="rollupId" [assessment]="assessment" (riskByAttackPatternChanged)="calculateRiskBreakdown($event)" [categoryLookup]="categoryLookup$">
+            [rollupId]="rollupId" [assessmentId]="assessmentId" [assessment]="assessment" [categoryLookup]="categoryLookup$"
+            (onRiskByAttackPatternChanged)="calculateRiskBreakdown($event)" (onAddedAssessmentObject)="requestGroupSectionDataLoad(assessment)">
           </unf-assess-group>
         </div>
       </mat-sidenav-content>

--- a/src/app/assess/v3/result/result-header/result-header.component.html
+++ b/src/app/assess/v3/result/result-header/result-header.component.html
@@ -1,7 +1,7 @@
 <div id="tabWrapper" class="flex flexColumn">
   <div class="flex flexRow">
     <div class="flex">
-      <uf-info-bar *ngIf="percentCompleted < 100" isWarningMsg="true" [message]="percentCompletedMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
+      <uf-info-bar *ngIf="percentCompletedMsg" isWarningMsg="true" [message]="percentCompletedMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>
   </div>
   <div class="flex1"></div>

--- a/src/app/assess/v3/result/result-header/result-header.component.ts
+++ b/src/app/assess/v3/result/result-header/result-header.component.ts
@@ -1,28 +1,28 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { Assessment } from 'stix/assess/v3/assessment';
 
 @Component({
   selector: 'result-header',
   templateUrl: './result-header.component.html',
-  styleUrls: ['./result-header.component.scss']
+  styleUrls: ['./result-header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.Default,
 })
 export class ResultHeaderComponent implements OnInit {
 
-  @Input()
-  rollupId: string;
-  @Input()
-  assessmentId: string;
-  @Input()
-  public created: Date;
-  @Input()
-  public assessment: Assessment;
-  public summaryLink: string;
-  public resultsLink: string;
-  public percentCompletedMsg: string;
+  @Input() public assessment: Assessment;
+  @Input() public assessmentId: string;
+  @Input() public created: Date;
+  @Input() public rollupId: string;
   public percentCompleted = 0;
-  protected totalIndicators = 45;
-  protected totalCoas = 249;
-  protected totalSensors = 7;
+  public percentCompletedMsg: string;
+  public resultsLink: string;
+  public summaryLink: string;
+
+  // TODO: grab dynamic count of coas and indicators
+  protected readonly TOTAL_COAS = 249;
+  protected readonly TOTAL_INDICATORS = 45;
+  protected readonly TOTAL_SENSORS = 7;
+
   protected editUrl: string;
 
   constructor() { }
@@ -37,7 +37,7 @@ export class ResultHeaderComponent implements OnInit {
     this.summaryLink = `${resultBase}/summary/${this.rollupId}/${this.assessmentId}`;
     this.resultsLink = `${resultBase}/full/${this.rollupId}/${this.assessmentId}`;
     const editBase = `${base}/wizard/edit/`;
-    this.editUrl = `${editBase}/${this.rollupId}`; 
+    this.editUrl = `${editBase}/${this.rollupId}`;
     // TODO: initialize the correct total questions, by calling the server, may need a count endpoint
     this.percentCompleted = this.calcPercentCompleted(this.assessment);
     this.percentCompletedMsg = `Assessments BETA, some features do not work!`
@@ -63,20 +63,20 @@ export class ResultHeaderComponent implements OnInit {
     let totalQuestions;
     switch (assessmentType.toString()) {
       case 'indicator': {
-        totalQuestions = this.totalIndicators;
+        totalQuestions = this.TOTAL_INDICATORS;
         break;
       }
       case 'course-of-action': {
-        totalQuestions = this.totalCoas;
+        totalQuestions = this.TOTAL_COAS;
         break;
       }
       case 'x-unfetter-sensor': {
-        totalQuestions = this.totalSensors;
+        totalQuestions = this.TOTAL_SENSORS;
         break;
       }
-      case 'x-unfetter-capability': 
+      case 'x-unfetter-capability':
       case 'x-unfetter-object-assessment': {
-        totalQuestions = this.totalSensors;
+        totalQuestions = this.TOTAL_SENSORS;
         break;
       }
       default: {
@@ -89,7 +89,7 @@ export class ResultHeaderComponent implements OnInit {
     const numAssessed = assessmentObjects.length;
     const percent = Math.round((numAssessed / totalQuestions) * 100);
     // console.log('calc % completed', percent);
-    return percent;
+    return (percent > 100) ? 100 : percent;
   }
 
 }

--- a/src/app/assess/v3/result/store/full-result.effects.ts
+++ b/src/app/assess/v3/result/store/full-result.effects.ts
@@ -53,7 +53,14 @@ export class FullResultEffects {
                 return this.assessService
                     .getById(id)
                     .pipe(
-                        mergeMap((data: Assessment) => [new SetAssessment(data), new FinishedLoading(true)]),
+                        mergeMap((assessment: Assessment) => {
+                            const assessmentType = assessment.determineAssessmentType();
+                            let isCapability = false;
+                            if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
+                              isCapability = true;
+                            }
+                            return [new SetAssessment(assessment), new LoadGroupData({ id, isCapability }), new FinishedLoading(true)]
+                        }),
                         catchError((err) => {
                             console.log(err);
                             return observableOf(new FailedToLoad(true));

--- a/src/app/assess/v3/result/store/full-result.selectors.ts
+++ b/src/app/assess/v3/result/store/full-result.selectors.ts
@@ -44,11 +44,32 @@ export const getUnassessedPhases = createSelector(
     },
 );
 
+export const getAllFinishedLoading = createSelector(
+    getFinishedLoadingAssessment,
+    getFinishedLoadingGroupData,
+    (finisedLoadingAssessment: boolean, finishedLoadingGroup: boolean) => {
+        return finisedLoadingAssessment && finishedLoadingGroup;
+    }
+);
+
+export const getFullAssessmentName = createSelector(
+    getFullAssessment,
+    (assessment: Assessment) => {
+        const assessmentType = (assessment !== undefined && assessment.determineAssessmentType) ?
+            assessment.determineAssessmentType() : 'Unknown';
+        return `${assessment.name} - ${assessmentType}`;
+    }
+);
+
 export const getUnassessedPhasesForCurrentFramework = createSelector(
     getGroupState,
     getFullAssessment,
     getTacticsChains,
     (group: FullAssessmentGroup, assessment: Assessment, tacticsChains: Dictionary<TacticChain>) => {
+        if (group.finishedLoadingGroupData === false) {
+            return [];
+        }
+
         if (assessment === undefined || tacticsChains === undefined) {
             return group.unassessedPhases;
         }

--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -42,8 +42,7 @@ type ButtonLabel = 'SAVE' | 'CONTINUE';
   styleUrls: ['./wizard.component.scss'],
   animations: [heightCollapse],
 })
-export class WizardComponent extends Measurements
-  implements OnInit, AfterViewInit, OnDestroy {
+export class WizardComponent extends Measurements implements OnInit, AfterViewInit, OnDestroy {
   @ViewChildren('question') public questions: QueryList<MatSelect>;
 
   public readonly CHART_BG_COLORS: any[];
@@ -502,11 +501,11 @@ export class WizardComponent extends Measurements
 
     // reset progress
     this.setSelectedRiskValue();
-    this.changeDetection.detectChanges();
     if (panelName !== 'summary') {
       this.updateChart();
     }
     this.updateRatioOfAnswerQuestions();
+    this.changeDetection.detectChanges();
   }
 
   /**


### PR DESCRIPTION
fix intermittent result tab loading bug

## changes
code clean up
put ngrx group load call in the parent component to reduce circular dependency between full and group components
removed some manual change detection checks


## test
visit a assessment beta result tab
click edit the assessment, hit the back button to the result tab, verify the page load and you do not see an infinite spinner
add some inline assessment objects from the speed dial, verify page updates
click around the page, ensure it updates


