### PR TITLE
Allows final charts to be populated on summary for assessment beta.

### DIFF
--- a/src/app/assess/v3/result/store/summary.actions.ts
+++ b/src/app/assess/v3/result/store/summary.actions.ts
@@ -77,7 +77,7 @@ export class LoadSingleSummaryAggregationData implements Action {
     public readonly type = LOAD_SINGLE_SUMMARY_AGGREGATION_DATA;
 
     // individual assessment id
-    constructor(public payload: string) { }
+    constructor(public payload: { id: string, isCapability: boolean }) { }
 }
 
 export class LoadSummaryAggregationData implements Action {

--- a/src/app/assess/v3/result/store/summary.effects.ts
+++ b/src/app/assess/v3/result/store/summary.effects.ts
@@ -108,9 +108,10 @@ export class SummaryEffects {
         .ofType(LOAD_SINGLE_SUMMARY_AGGREGATION_DATA)
         .pipe(
             pluck('payload'),
-            switchMap((assessmentId: string) => {
+            switchMap((loadData: { id: string, isCapability: boolean }) => {
+                const isCapability = loadData.isCapability || false;
                 return this.assessService
-                    .getSummaryAggregation(assessmentId)
+                    .getSummaryAggregation(loadData.id, isCapability)
                     .pipe(
                         mergeMap((data: SummaryAggregation) => [new SetSummaryAggregationData([data]), new FinishedLoadingSummaryAggregationData(true)]),
                         catchError((err) => {

--- a/src/app/assess/v3/result/summary/summary.component.ts
+++ b/src/app/assess/v3/result/summary/summary.component.ts
@@ -42,7 +42,6 @@ export class SummaryComponent implements OnInit, OnDestroy {
   riskByAttack: RiskByAttack;
   riskByKillChain: RiskByKillChain;
   summaryAggregation: SummaryAggregation;
-  summaryAggregations: SummaryAggregation[];
   finishedLoading = false;
   finishedLoadingRBAP = false;
   finishedLoadingKCD = false;
@@ -133,7 +132,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
         }
         this.riskByAttackPatternStore.dispatch(new LoadSingleAssessmentRiskByAttackPatternData({id: this.assessmentId, isCapability: this.summaryCalculationService.isCapability}));
         this.store.dispatch(new LoadSingleRiskPerKillChainData(this.assessmentId));
-        this.store.dispatch(new LoadSingleSummaryAggregationData(this.assessmentId));
+        this.store.dispatch(new LoadSingleSummaryAggregationData({id: this.assessmentId, isCapability: this.summaryCalculationService.isCapability}));
       },
         (err) => console.log(err));
 
@@ -222,11 +221,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
       .subscribe((arr: SummaryAggregation[]) => {
         if (!arr || arr.length === 0) {
           this.summaryAggregation = undefined;
-          this.summaryAggregations = [];
           return;
         }
         this.summaryAggregation = { ...arr[0] };
-        this.summaryAggregations = [...arr];
       })
 
     const sub8$ = this.store

--- a/src/app/assess/v3/services/assess.service.ts
+++ b/src/app/assess/v3/services/assess.service.ts
@@ -238,12 +238,12 @@ export class AssessService {
      * @param {string} id
      * @return {Observable}
      */
-    public getSummaryAggregation(id: string): Observable<SummaryAggregation> {
+    public getSummaryAggregation(id: string, isCapability: boolean = false): Observable<SummaryAggregation> {
         if (!id) {
             return observableEmpty();
         }
 
-        const url = `${this.assessBaseUrl}/${id}/summary-aggregations`;
+        const url = `${this.assessBaseUrl}/${id}/summary-aggregations?isCapability=${isCapability}`;
         return this.genericApi.getAs<SummaryAggregation>(url);
     }
 


### PR DESCRIPTION
Supports unfetter-discover/discover#1084

To test:

- Insure that you have the corresponding unfetter-store PR: https://github.com/unfetter-discover/unfetter-store/pull/225
- In Assessments beta, open one of each type of assessment (Indicators, Mitigations, Capabilities).
- Insure that data is populated in each of the bottom 3 charts
- Note: known issue that will be addressed in another PR is that NTCTF assessments will not have data in the middle two charts. 