### PR TITLE
fix rendering and page refresh

### DIFF
--- a/src/app/assess/v3/result/full/full.component.html
+++ b/src/app/assess/v3/result/full/full.component.html
@@ -25,7 +25,7 @@
           </div>
           <div class="phases-list">
             <div class="phases-list-item cursor-pointer" *ngFor="let phase of assessmentGroup.riskByAttackPattern.phases; trackBy:trackByFn"
-              [ngClass]="{'highlightPhase': isCurrentPhase(phase._id)}" (click)="assessGroupMain.setPhase(phase._id); activePhase = phase._id">
+              [ngClass]="{'highlightPhase': isCurrentPhase(phase._id)}" (click)="activePhase = phase._id; assessGroupMain.setPhase(phase._id);">
               <div class="item-content flex">
                 <span class="phase-name flex-grow">
                   <b>{{phase._id | capitalize}}</b>
@@ -44,7 +44,7 @@
             <div class="header">Unassessed Tactics</div>
             <div class="unassessed-phases-list">
               <div class="unassessed-phases-list-item cursor-pointer" *ngFor="let phase of unassessedPhases; trackBy:trackByFn" [ngClass]="{'highlightPhase': isCurrentPhase(phase)}"
-                (click)="assessGroupMain.setPhase(phase); activePhase = phase">
+                (click)="activePhase = phase; assessGroupMain.setPhase(phase);">
                 <div class="item-content">
                   <span class="phase-name">
                     <b>{{phase | capitalize}}</b>

--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -1,4 +1,3 @@
-
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -22,7 +21,7 @@ import { AssessState } from '../../store/assess.reducers';
 import { getSortedCategories } from '../../store/assess.selectors';
 import { CleanAssessmentResultData, LoadAssessmentById, LoadGroupData } from '../store/full-result.actions';
 import { FullAssessmentResultState } from '../store/full-result.reducers';
-import { getFailedToLoadAssessment, getFinishedLoadingAssessment, getFullAssessment, getFullAssessmentName, getGroupState, getUnassessedPhasesForCurrentFramework, getAllFinishedLoading } from '../store/full-result.selectors';
+import { getAllFinishedLoading, getFailedToLoadAssessment, getFullAssessment, getFullAssessmentName, getGroupState, getUnassessedPhasesForCurrentFramework } from '../store/full-result.selectors';
 import { SummaryDataSource } from '../summary/summary.datasource';
 import { FullAssessmentGroup } from './group/models/full-assessment-group';
 
@@ -81,6 +80,7 @@ export class FullComponent implements OnInit, OnDestroy {
         this.rollupId = params.rollupId || '';
         this.assessmentId = params.assessmentId || '';
         this.phase = params.phase || '';
+        this.activePhase = this.activePhase || this.phase;
         this.attackPatternId = params.attackPatternId || '';
         const sub$ = this.appStore
           .select('users')
@@ -134,13 +134,13 @@ export class FullComponent implements OnInit, OnDestroy {
       .subscribe(
         (group: any) => {
           const riskByAttackPattern = group.riskByAttackPattern || {};
-          // active phase is either the current active phase,
+          // active phase is either the current active phase
           let activePhase = this.activePhase;
           if (!activePhase && riskByAttackPattern && riskByAttackPattern.phases.length > 0) {
-            //  the first assess attack pattern,
+            //  or use the first assessed phase
             activePhase = riskByAttackPattern.phases[0]._id;
           }
-          this.activePhase = activePhase;
+          this.activePhase = this.activePhase || activePhase;
           this.changeDetectorRef.markForCheck();
         },
         (err) => console.log(err));

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.html
@@ -184,11 +184,23 @@
               </div>
             </form>
           </div>
+          <div *ngSwitchDefault>
+            <div class="row">
+              <div class="col-md-12 mat-subheading-1">
+                The current assessment data are not compatible with this assessment viewer. Are you attempting to view an old version 2 assessment?
+              </div>
+            </div>
+            <div class="row">
+              <p class="text-right">
+                <button mat-button (click)="addAssessedObject = !addAssessedObject">CANCEL</button>
+              </p>
+            </div>
+          </div>
+
         </div>
       </mat-card-content>
     </mat-card>
   </div>
-  <!-- <unf-speed-dial [items]="speedDialItems" (itemClickedEmitter)="onSpeedDialClicked($event)" [(open)]="addAssessedObject"></unf-speed-dial> -->
   <div class="add-assessed-object-fab">
     <button mat-mini-fab color="primary" (click)="addAssessedObject = !addAssessedObject">
       <mat-icon class="mat-24">add</mat-icon>

--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -411,9 +411,6 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
             return EMPTY;
         }
 
-        // testing
-        // capability.id = '1243';
-        // return of([capability]);
         return this.assessService
             .genericPost(`api/v3/x-unfetter-capabilities`, capability)
             .pipe(
@@ -451,8 +448,8 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
         } as AssessedObject;
         const objectAssessment = {
             created_by_ref,
-            name: `${capability.name} Assessment`,
-            description: `${this.assessment.name} inline capabilty update`,
+            name: `${capability.name}`,
+            description: `${capability.description}`,
             object_ref: capability.id,
             assessed_objects: [
                 assessedObject,
@@ -460,9 +457,6 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
             type: StixEnum.OBJECT_ASSESSMENT,
         } as ObjectAssessment;
 
-        // testing
-        // objectAssessment.id = '123x';
-        // return of([objectAssessment]);
         return this.assessService
             .genericPost(`api/v3/x-unfetter-object-assessments`, objectAssessment)
             .pipe(

--- a/src/app/assess/v3/result/full/group/assessments-group.component.html
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.html
@@ -16,8 +16,7 @@
             <div *ngIf="unassessedAttackPatterns && unassessedAttackPatterns.length > 0">
                 <span class="fs-12">Unassessed Attack Patterns</span>
                 <div *ngFor="let unassessedAttackPattern of unassessedAttackPatterns; trackBy: trackByFn" class="ap-list-item cursor-pointer" (click)="setAttackPattern(unassessedAttackPattern.id)"
-                    [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)
-                }">
+                    [ngClass]="{'highlightAttackPattern': isCurrentAttackPattern(unassessedAttackPattern.id)}">
                     <span>{{ unassessedAttackPattern.name }}</span>
                 </div>
             </div>

--- a/src/app/assess/v3/result/full/group/assessments-group.component.scss
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.scss
@@ -48,9 +48,12 @@
 }
 
 .flex {
+    min-height: 100%;
+
     .flex-fixed {
         flex: 0 0 auto;
         width: 320px;
+        min-height: 100%;
 
         .phase-header {
             @include section-header();
@@ -64,6 +67,7 @@
 
 .main {
     font-size: 14px;
+    min-height: 100%;
     
     .fs-12 {
         font-size: 12px;
@@ -77,6 +81,7 @@
     }
     
     .phase-section {
+        min-height: calc(100vh - #{$navbar-height}px);
         @include space-top();
         background-color: $assessments-primary-lightest;
     }

--- a/src/app/assess/v3/result/summary/summary.component.ts
+++ b/src/app/assess/v3/result/summary/summary.component.ts
@@ -119,12 +119,12 @@ export class SummaryComponent implements OnInit, OnDestroy {
       .pipe(
         pluck('summaries'),
         distinctUntilChanged(),
-        filter((arr: Assessment[]) => arr && arr.length > 0 && arr[0] !== undefined)
+        filter((arr: Assessment[]) => arr && arr.length > 0 && arr[0] !== undefined && arr[0].determineAssessmentType !== undefined)
       )
       .subscribe((arr: Assessment[]) => {
         this.summaries = [...arr];
         this.summary = this.summaries[0] || new Assessment();
-        const assessmentType = this.summary.determineAssessmentType() || 'Unknown';
+        const assessmentType = this.summary.determineAssessmentType();
         if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
           this.summaryCalculationService.isCapability = true;
         } else {
@@ -244,10 +244,9 @@ export class SummaryComponent implements OnInit, OnDestroy {
       .pipe(
         pluck('summaries'),
         distinctUntilChanged(),
-        filter((summaries: Assessment[]) => summaries && summaries.length > 0),
+        filter((arr: Assessment[]) => arr && arr.length > 0 && arr[0] !== undefined && arr[0].determineAssessmentType !== undefined),
         map((summaries: Assessment[]) => {
           const assessmentType = summaries[0].determineAssessmentType();
-
           return `${summaries[0].name} - ${assessmentType}`;
         }),
         catchError((err, caught) => {


### PR DESCRIPTION
data timing issues with result tab and wizard

## problems
editing an assessment showed an empty wizard page sometimes
editing a sensor in a v3 viewer showed a bad fab button
selecting an unassessed phase did not auto select the first unassessed attack pattern
selecting some phases did not update the url

## changes
loaded the wizard and signaled finished loading after the capability information was loaded
selected the first unassessed attack pattern when needed
added default error message for fab

## test
create and assessment with v3

__wizard loads__
visit the result tab
view the capability, click "complete" or edit, verify the wizard loads, click the back button verify the 
results tab loads

__unassessed attack patterns__
visit the results tab
verify the first unassessed attack pattern is selected

__sensor fab__
view v2 sensor assessment under version 3 results tab viewer
verify an error message


![screen shot 2018-07-03 at 3 48 39 pm](https://user-images.githubusercontent.com/30807406/42243044-8eaaf5e0-7eff-11e8-9e4a-7e8094f82b3c.png)
![screen shot 2018-07-03 at 4 28 17 pm](https://user-images.githubusercontent.com/30807406/42243076-a57b2e0c-7eff-11e8-9ee9-e9fa4da6e840.png)
<img width="760" alt="screen shot 2018-07-03 at 4 28 49 pm" src="https://user-images.githubusercontent.com/30807406/42243119-ca3d0dfa-7eff-11e8-960d-1610eff95d84.png">
