### PR TITLE
Hides sophistication breakdown and techniques charts when no valid da…

### DIFF
--- a/src/app/assess/v3/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/v3/result/summary/summary-calculation.service.spec.ts
@@ -332,28 +332,29 @@ describe('SummaryCalculationService', () => {
   }));
 
   it('should populate technique breakdown groupings given an array of asssesment objects', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
+    const DEFAULT_TECHNIQUE_BREAKDOWN = { 0: 0, 1: 0, 2: 0, 3: 0};
     service.summaryAggregation = null;
     service.populateTechniqueBreakdown(null);
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.populateTechniqueBreakdown([]);
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.populateTechniqueBreakdown(AssessmentObjectMockFactory.mockMany(1));
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: null, totalAttackPatternCountBySophisicationLevel: null };
     service.populateTechniqueBreakdown([]);
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.populateTechniqueBreakdown(AssessmentObjectMockFactory.mockMany(1));
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: null, attackPatternsByAssessedObject: [{ _id: null, attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
     service.populateTechniqueBreakdown([]);
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.populateTechniqueBreakdown(AssessmentObjectMockFactory.mockMany(1));
-    expect(service.techniqueBreakdown).toEqual({});
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.summaryAggregation = { assessedAttackPatternCountBySophisicationLevel: { index: null, count: null }, attackPatternsByAssessedObject: [{ _id: null, attackPatterns: null }], totalAttackPatternCountBySophisicationLevel: null };
     service.populateTechniqueBreakdown([]);
-    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.populateTechniqueBreakdown(AssessmentObjectMockFactory.mockMany(1));
-    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.summaryAggregation = {
       assessedAttackPatternCountBySophisicationLevel: { index: null, count: null },
       attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
@@ -361,13 +362,13 @@ describe('SummaryCalculationService', () => {
     const ao = AssessmentObjectMockFactory.mockWithRisk(.25);
     ao.stix = StixMockFactory.mockOne('an id');
     service.populateTechniqueBreakdown([ao]);
-    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
     service.summaryAggregation = {
       assessedAttackPatternCountBySophisicationLevel: { index: 0, count: 3 },
       attackPatternsByAssessedObject: [{ _id: 'an id', attackPatterns: [{ kill_chain_phases: [{ kill_chain_name: null, phase_name: 'happy camper' }] }] }], totalAttackPatternCountBySophisicationLevel: null
     } as SummaryAggregation;
     service.populateTechniqueBreakdown([ao]);
-    expect(service.techniqueBreakdown).toEqual({ 0: 0, 1: 0 });
+    expect(service.techniqueBreakdown).toEqual(DEFAULT_TECHNIQUE_BREAKDOWN);
 
   }));
 

--- a/src/app/assess/v3/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/v3/result/summary/summary-calculation.service.ts
@@ -31,8 +31,8 @@ export class SummaryCalculationService {
   techniqueBreakdownValue: any;
   assessmentObjects: AssessmentObject[];
   thresholdOptionsValue: ThresholdOption[];
-  // TODO temporary
   isCapabilityValue: boolean;
+  isValidSophisticationDataValue: boolean;
 
   constructor() {
     this.numericRisk = 0;
@@ -49,6 +49,7 @@ export class SummaryCalculationService {
     this.riskSub = new BehaviorSubject<number>(null);
     this.selectedRisk = 0.5;
     this.isCapability = false;
+    this.isValidSophisticationData = true;
   }
 
   public set numericRisk(newRisk: number) {
@@ -98,6 +99,10 @@ export class SummaryCalculationService {
     this.isCapabilityValue = newIsCapability;
   }
 
+  public set isValidSophisticationData(validData: boolean) {
+    this.isValidSophisticationDataValue = validData;
+  }
+
   public get numericRisk(): number {
     return this.numericRiskValue;
   }
@@ -143,6 +148,10 @@ export class SummaryCalculationService {
 
   public get isCapability(): boolean {
     return this.isCapabilityValue;
+  }
+
+  public get isValidSophisticationData(): boolean {
+    return this.isValidSophisticationDataValue
   }
 
   public getRiskText(): string {
@@ -292,7 +301,7 @@ export class SummaryCalculationService {
    */
   public populateTechniqueBreakdown(assessmentObjects: AssessmentObject[]): void {
 
-    this.techniqueBreakdown = {};
+    this.techniqueBreakdown = {0: 0, 1: 0, 2: 0, 3: 0};
     if (assessmentObjects && this.summaryAggregation && this.summaryAggregation.attackPatternsByAssessedObject && this.summaryAggregation.assessedAttackPatternCountBySophisicationLevel) {
       this.assessmentObjects = assessmentObjects;
       // Total assessed objects to calculated risk
@@ -316,7 +325,6 @@ export class SummaryCalculationService {
         }
         ++attackPatternSetMap[curAp['x_unfetter_sophistication_level']];
       });
-
       for (const prop in Object.keys(assessedRiskMapping)) {
         if (attackPatternSetMap[prop] === undefined) {
           this.techniqueBreakdown[prop] = 0;

--- a/src/app/assess/v3/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.html
+++ b/src/app/assess/v3/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.html
@@ -1,9 +1,12 @@
-<div id="sophisticationBreakdownComponent">
+<div *ngIf="summaryCalculationService.isValidSophisticationData; else noData"  id="sophisticationBreakdownComponent">
   <canvas baseChart
     [datasets]="barChartData" 
     [labels]="barChartLabels" 
-    [options]="barChartOptions" 
+    [options]="barChartOptions"
     [legend]="barChartLegend" 
     [chartType]="barChartType"
     [colors]="colors"></canvas>
 </div>
+<ng-template #noData>
+  <div>Sorry, none of the attack patterns in this assessment have been evaluated for an attacker's sophistication level.</div>
+</ng-template>

--- a/src/app/assess/v3/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
+++ b/src/app/assess/v3/result/summary/summary-report/sophistication-breakdown/sophistication-breakdown.component.ts
@@ -17,7 +17,7 @@ export class SophisticationBreakdownComponent implements OnInit {
   public barChartLegend: any;
   public readonly barChartType: string;
   public colors: any;
-  constructor(private summaryCalculationService: SummaryCalculationService) {
+  constructor(public summaryCalculationService: SummaryCalculationService) {
     this.barChartData = [
       {
         data: [],
@@ -85,16 +85,18 @@ export class SophisticationBreakdownComponent implements OnInit {
   public calculateData() {
     let assessedAttackPatternKeys = Object.keys(this.assessedAttackPatterns);
     let allAttackPatternKeys = Object.keys(this.allAttackPatterns);
-
     this.barChartData[0].data = [];
     this.barChartData[1].data = [];
+    let validData = false;
     for (let index = 0; index < allAttackPatternKeys.length; index++) {
       let assessed = 0;
       if (assessedAttackPatternKeys.includes(index.toString())) {
         assessed = this.assessedAttackPatterns[index];
+        validData = true;
       }
       this.barChartData[0].data.push(assessed);
       this.barChartData[1].data.push(this.allAttackPatterns[index] - assessed);
     }
+    this.summaryCalculationService.isValidSophisticationData = validData;
   }
 }

--- a/src/app/assess/v3/result/summary/summary-report/techniques-chart/techniques-chart.component.html
+++ b/src/app/assess/v3/result/summary/summary-report/techniques-chart/techniques-chart.component.html
@@ -1,4 +1,4 @@
-<div style="display: block">
+<div *ngIf="summaryCalculationService.isValidSophisticationData; else noData" style="display: block">
   <canvas baseChart 
     [datasets]="barChartData" 
     [labels]="barChartLabels" 
@@ -7,3 +7,7 @@
     [chartType]="barChartType"
     [colors]="colors"></canvas>
 </div>
+
+<ng-template #noData>
+  <div>Sorry, none of the techniques in this assessment have been evaluated for an attacker's sophistication level.</div>
+</ng-template>

--- a/src/app/assess/v3/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
+++ b/src/app/assess/v3/result/summary/summary-report/techniques-chart/techniques-chart.component.ts
@@ -64,7 +64,7 @@ export class TechniquesChartComponent implements OnInit {
   ];
   public colors: any[];
 
-  public constructor(private summaryCalculationService: SummaryCalculationService) { }
+  public constructor(public summaryCalculationService: SummaryCalculationService) { }
   /**
    * @description
    *  initialize this class member, calls render when finished


### PR DESCRIPTION
…ta is returned. Corrects issue with showing all sophistication levels for techniques chart.

Fixes unfetter-discover/unfetter#1084

To Test:
- Create an assessment using only attack patterns that do not have x-unfetter-sophistication-levels. (Anything from Ntctf, for example)
- Should see 'Sorry' messages in place of 'Sophistication Breakdown' and '% Techniques Detected by Skill' charts.
- Select/Create an assessment with some attack patterns that do have x-unfetter-sophistication-levels. (Using Mitre Attack framework, for example)
- Should see both middle charts populated with data.
- Should also see techniques by skill to the right of last level with data. For example, if Novice and Practitioner levels have data in the '% Techniques Detected by Skill' chart. And Expert and Innovator do not have data, the latter labels should still appear in the chart. 