### PR TITLE
Baseline heatmap

### DIFF
--- a/src/app/assess/v3/result/full/full.component.html
+++ b/src/app/assess/v3/result/full/full.component.html
@@ -2,7 +2,7 @@
   <div *ngIf="(failedToLoad$|async) === false; else failedToLoadBlock" class="fadeIn">
     <mat-sidenav-container *ngIf="assessment$ | async as assessment">
       <mat-sidenav *ngIf="(assessmentGroup$ | async) as assessmentGroup" class="side-panel" mode="side" opened="true">
-        <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName|async }" collapsible="false" width="320">
+        <unfetter-side-panel class="side-panel" [item]="{ name: (assessmentName$ | async) }" collapsible="false" width="320">
 
           <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
           <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>

--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -39,7 +39,8 @@ export class FullComponent implements OnInit, OnDestroy {
   public assessment$: Observable<Assessment>;
   public assessmentGroup$: Observable<FullAssessmentGroup>;
   public assessmentId: string;
-  public assessmentName: Observable<string>;
+  public assessmentName$: Observable<string>;
+  public assessmentName: string;
   public attackPatternId: string;
   public categoryLookup$: Observable<Category[]>;
   public failedToLoad$: Observable<boolean>;
@@ -145,9 +146,12 @@ export class FullComponent implements OnInit, OnDestroy {
         },
         (err) => console.log(err));
 
-    this.assessmentName = this.store
+    this.assessmentName$ = this.store
       .select(getFullAssessmentName)
-      .pipe(distinctUntilChanged());
+      .pipe(
+        distinctUntilChanged(),
+        tap((name) => this.assessmentName = name)
+      );
 
     this.unassessedPhases$ = this.store
       .select(getUnassessedPhasesForCurrentFramework)
@@ -233,9 +237,14 @@ export class FullComponent implements OnInit, OnDestroy {
    * @description clicked currently viewed assessment, confirm delete
    * @return {void}
    */
-  public onDeleteCurrent(assessment: LastModifiedAssessment): void {
-    const id = this.rollupId;
-    this.confirmDelete({ name: assessment.name, rollupId: id });
+  public onDeleteCurrent(event: Event): void {
+    if (!event || (event instanceof UIEvent)) {
+      event.preventDefault();
+    }
+
+    const rollupId = this.rollupId;
+    const name = this.assessmentName;
+    this.confirmDelete({ name, rollupId });
   }
 
   /**

--- a/src/app/baseline/result/summary/summary-calculation.service.ts
+++ b/src/app/baseline/result/summary/summary-calculation.service.ts
@@ -13,7 +13,9 @@ import { Constance } from '../../../utils/constance';
 import { ThresholdOption } from '../../models/threshold-option';
 import { SummarySortHelper } from './summary-sort-helper';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class SummaryCalculationService {
   public readonly topNRisks: number;
   public readonly riskSub: BehaviorSubject<number>;

--- a/src/app/baseline/result/summary/summary-report/summary-report.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-report.component.html
@@ -12,7 +12,7 @@
     <div class="row">
       <div class="flex matchHeight">
         <div class="uf-mat-card card triple-card-width" id="chart-container" *ngIf="activeMainWell === 'heatmap'">
-            <summary-tactics [collapseSubject]="false"></summary-tactics>
+            <summary-tactics collapseSubject="false" [selectedAttackPatternIds]="summaryCalculationService.blAttackPatterns"></summary-tactics>
         </div>
       </div>
     </div>

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.html
@@ -1,11 +1,6 @@
 <div id="baseline-heat-map" class="uf-well">
     <div *ngIf="!collapseContents">
-        <tactics-pane #tactics [targets]="attackPatterns"
-                [title]="'Addressed Techniques'"
-                [subtitle]="'These are the techniques addressed by the capabilities in this baseline.'"
-                [heatmapOptions]="heatmapOptions"
-                [treemapOptions]="treemapOptions"
-                [carouselOptions]="carouselOptions"
-                [targets]="selectedTactics"></tactics-pane>
+        <tactics-pane #tactics [targets]="attackPatterns" [title]="'Addressed Techniques'" [subtitle]="'These are the techniques addressed by the capabilities in this baseline.'"
+            [heatmapOptions]="heatmapOptions" [treemapOptions]="treemapOptions" [carouselOptions]="carouselOptions"></tactics-pane>
     </div>
 </div>

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.html
@@ -5,6 +5,7 @@
                 [subtitle]="'These are the techniques addressed by the capabilities in this baseline.'"
                 [heatmapOptions]="heatmapOptions"
                 [treemapOptions]="treemapOptions"
-                [carouselOptions]="carouselOptions"></tactics-pane>
+                [carouselOptions]="carouselOptions"
+                [targets]="selectedTactics"></tactics-pane>
     </div>
 </div>

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
@@ -27,7 +27,7 @@ import * as configActions from '../../../../../root-store/config/config.actions'
 import * as userActions from '../../../../../root-store/users/user.actions';
 import { SummaryTacticsComponent } from './summary-tactics.component';
 
-describe('SummaryTacticsComponent', () => {
+fdescribe('SummaryTacticsComponent', () => {
 
     let fixture: ComponentFixture<SummaryTacticsComponent>;
     let component: SummaryTacticsComponent;
@@ -92,20 +92,6 @@ describe('SummaryTacticsComponent', () => {
         //     capabilities: new SimpleChange(null, component['capabilities'], false)
         // });
         expect(component).toBeTruthy();
-    });
-
-    it('should expand and collapse', () => {
-        expect(component.collapseContents).toBeFalsy();
-
-        component.collapseSubject = new BehaviorSubject(false);
-        // component.ngOnChanges(null);
-        expect(component.collapseContents).toBeFalsy();
-
-        component.collapseSubject.next(true);
-        expect(component.collapseContents).toBeTruthy()
-
-        component.collapseSubject.next(false);
-        expect(component.collapseContents).toBeFalsy();
     });
 
 });

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
@@ -27,7 +27,7 @@ import * as configActions from '../../../../../root-store/config/config.actions'
 import * as userActions from '../../../../../root-store/users/user.actions';
 import { SummaryTacticsComponent } from './summary-tactics.component';
 
-fdescribe('SummaryTacticsComponent', () => {
+describe('SummaryTacticsComponent', () => {
 
     let fixture: ComponentFixture<SummaryTacticsComponent>;
     let component: SummaryTacticsComponent;

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.spec.ts
@@ -1,40 +1,31 @@
-import { TestBed, ComponentFixture, async } from '@angular/core/testing';
-import { SimpleChange } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { StoreModule, Store } from '@ngrx/store';
-
+import { SimpleChange } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import {
-    MatButtonToggleModule,
-    MatCardModule,
-    MatIconModule,
-    MatOptionModule,
-    MatSelectModule,
-    MatToolbarModule,
-} from '@angular/material';
+import { MatButtonToggleModule, MatCardModule, MatIconModule, MatOptionModule, MatSelectModule, MatToolbarModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Store, StoreModule } from '@ngrx/store';
 import { MarkdownComponent } from 'ngx-markdown';
 import { Carousel } from 'primeng/primeng';
-
-import { SummaryTacticsComponent } from './summary-tactics.component';
-import { TacticsPaneComponent } from '../../../../../global/components/tactics-pane/tactics-pane.component';
-import { TacticsHeatmapComponent } from '../../../../../global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component';
-import { TacticsTreemapComponent } from '../../../../../global/components/tactics-pane/tactics-treemap/tactics-treemap.component';
-import { TacticsCarouselComponent } from '../../../../../global/components/tactics-pane/tactics-carousel/tactics-carousel.component';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { AuthService } from '../../../../../core/services/auth.service';
+import { HeatmapComponent } from '../../../../../global/components/heatmap/heatmap.component';
+import { MarkdownEditorComponent } from '../../../../../global/components/markdown-editor/markdown-editor.component';
 import { TacticsCarouselControlComponent } from '../../../../../global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component';
+import { TacticsCarouselComponent } from '../../../../../global/components/tactics-pane/tactics-carousel/tactics-carousel.component';
+import { TacticsControlService } from '../../../../../global/components/tactics-pane/tactics-control.service';
+import { TacticsHeatmapComponent } from '../../../../../global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component';
+import { TacticsPaneComponent } from '../../../../../global/components/tactics-pane/tactics-pane.component';
 import { TacticsTooltipComponent } from '../../../../../global/components/tactics-pane/tactics-tooltip/tactics-tooltip.component';
 import { TacticsTooltipService } from '../../../../../global/components/tactics-pane/tactics-tooltip/tactics-tooltip.service';
-import { TacticsControlService } from '../../../../../global/components/tactics-pane/tactics-control.service';
-import { HeatmapComponent } from '../../../../../global/components/heatmap/heatmap.component';
+import { TacticsTreemapComponent } from '../../../../../global/components/tactics-pane/tactics-treemap/tactics-treemap.component';
+import { mockTactics, mockUser } from '../../../../../global/components/tactics-pane/tactics.model.test';
 import { TreemapComponent } from '../../../../../global/components/treemap/treemap.component';
-import { MarkdownEditorComponent } from '../../../../../global/components/markdown-editor/markdown-editor.component';
 import { CapitalizePipe } from '../../../../../global/pipes/capitalize.pipe';
-import { mockUser, mockTactics } from '../../../../../global/components/tactics-pane/tactics.model.test';
+import { AppState, reducers } from '../../../../../root-store/app.reducers';
 import * as configActions from '../../../../../root-store/config/config.actions';
 import * as userActions from '../../../../../root-store/users/user.actions';
-import { reducers, AppState } from '../../../../../root-store/app.reducers';
-import { AuthService } from '../../../../../core/services/auth.service';
+import { SummaryTacticsComponent } from './summary-tactics.component';
 
 describe('SummaryTacticsComponent', () => {
 
@@ -97,9 +88,9 @@ describe('SummaryTacticsComponent', () => {
 
     it('should handle input data', () => {
         component['capabilities'] = [{id: 'C1'}];
-        component.ngOnChanges({
-            capabilities: new SimpleChange(null, component['capabilities'], false)
-        });
+        // component.ngOnChanges({
+        //     capabilities: new SimpleChange(null, component['capabilities'], false)
+        // });
         expect(component).toBeTruthy();
     });
 
@@ -107,7 +98,7 @@ describe('SummaryTacticsComponent', () => {
         expect(component.collapseContents).toBeFalsy();
 
         component.collapseSubject = new BehaviorSubject(false);
-        component.ngOnChanges(null);
+        // component.ngOnChanges(null);
         expect(component.collapseContents).toBeFalsy();
 
         component.collapseSubject.next(true);

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.ts
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.ts
@@ -1,11 +1,11 @@
 
-import { ChangeDetectorRef, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { map, pluck } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 import { HeatmapOptions } from '../../../../../global/components/heatmap/heatmap.data';
 import { CarouselOptions } from '../../../../../global/components/tactics-pane/tactics-carousel/carousel.data';
-import { Tactic } from '../../../../../global/components/tactics-pane/tactics.model';
+import { Tactic, TacticChain } from '../../../../../global/components/tactics-pane/tactics.model';
 import { TreemapOptions } from '../../../../../global/components/treemap/treemap.data';
 import { Dictionary } from '../../../../../models/json/dictionary';
 import { AppState } from '../../../../../root-store/app.reducers';
@@ -13,9 +13,10 @@ import { AppState } from '../../../../../root-store/app.reducers';
 @Component({
     selector: 'summary-tactics',
     templateUrl: './summary-tactics.component.html',
-    styleUrls: ['./summary-tactics.component.scss']
+    styleUrls: ['./summary-tactics.component.scss'],
+    changeDetection: ChangeDetectionStrategy.Default,
 })
-export class SummaryTacticsComponent implements OnInit, OnChanges {
+export class SummaryTacticsComponent implements OnInit {
 
     /**
      * @description 
@@ -28,20 +29,9 @@ export class SummaryTacticsComponent implements OnInit, OnChanges {
     @Input() public selectedAttackPatternIds: string[] = [];
 
     /**
-     * @description 
+     * @description attack patterns selected on heat map
      */
     public attackPatterns: Tactic[] = [];
-
-    /**
-     * @description tactics to highlight in heat map
-     */
-    public selectedTactics$: Observable<Tactic[]>;
-    public selectedTactics: Tactic[];
-
-    /**
-     * @description 
-     */
-    private capabilitiesToAttackPatternMap: any;
 
     /**
      * @description 
@@ -101,25 +91,24 @@ export class SummaryTacticsComponent implements OnInit, OnChanges {
     /**
      * @description 
      */
-    ngOnInit() {
-        // this.loadCapabilitiesMap();
-        // this.collapseContents = false;
+    ngOnInit(): void {
         const sub$ = this.appStore
             .select('config')
             .pipe(
-                pluck<any, Tactic[]>('tactics'),
-                map((tactics) => {
-                    const attackPatternSet = new Set<string>(this.selectedAttackPatternIds);
-                    return tactics.filter((tactic) => attackPatternSet.has(tactic.id))
-                }),
-                map((tactics) => {
-                    this.selectedTactics = tactics;
-                    this.changeDetectorRef.markForCheck();
-                    return tactics;
+                filter((config) => config.tactics !== undefined && config.tacticsChains !== undefined),
+                map((config) => {
+                    const tactics = config.tactics;
+                    let attackPatterns = this.attackPatternIdsToTactics(this.selectedAttackPatternIds, tactics);
+                    const chains = config.tacticsChains;
+                    attackPatterns = this.deriveAttackPatternFramework(attackPatterns, chains);
+                    return this.enhanceWithHeatMapOptions(attackPatterns);
                 })
             )
             .subscribe(
-                (tactics) => console.log(),
+                (attackPatterns) => {
+                    this.attackPatterns = attackPatterns;
+                    this.changeDetectorRef.markForCheck();
+                },
                 (err) => console.log(err),
                 () => {
                     if (sub$) {
@@ -130,89 +119,50 @@ export class SummaryTacticsComponent implements OnInit, OnChanges {
     }
 
     /**
-     * @description 
+     * @param  {string[]} attackPatternIds
+     * @param  {Tactic[]} tactics
+     * @returns Tactic
      */
-    ngOnChanges(changes: SimpleChanges) {
-        // if (changes && changes.capabilities) {
-        //     const indicators = this.groupCapabilitiesByAttackPatterns();
-        //     requestAnimationFrame(() => {
-        //         this.attackPatterns = [];
-        //         // this.attackPatterns = this.collectAttackPatterns(patterns, indicators);
-        //     });
-        // }
-
-        // if (this.collapseSubject) {
-        //     const collapseCard$ = this.collapseSubject.pipe(
-        //         finalize(() => collapseCard$ && collapseCard$.unsubscribe()))
-        //         .subscribe(
-        //             (collapseContents) => this.collapseContents = collapseContents,
-        //             (err) => console.log(err),
-        //     );
-        // }
+    public attackPatternIdsToTactics(attackPatternIds: string[], tactics: Tactic[]): Tactic[] {
+        const attackPatternSet = new Set<string>(attackPatternIds);
+        return tactics.filter((tactic) => attackPatternSet.has(tactic.id));
     }
 
     /**
-     * @description retrieve the capabilities-to-attack-patterns map from the ngrx store
+     * @param  {Tactic[]} attackPatterns
+     * @param  {Dictionary<TacticChain>} chains
+     * @returns Tactic
      */
-    private loadCapabilitiesMap() {
-        // const getCapabilityToAttackPatternMap$ = this.store
-        //     .select('indicatorSharing')
-        //     .pluck('indicatorToApMap')
-        //     .distinctUntilChanged()
-        //     .finally(() => {
-        //         if (getCapabilityToAttackPatternMap$) {
-        //             getCapabilityToAttackPatternMap$.unsubscribe();
-        //         }
-        //     })
-        //     .subscribe(
-        //         (capabilityToAttackPatternMap) => this.capabilitiesToAttackPatternMap = capabilityToAttackPatternMap,
-        //         (err) => console.log(err)
-        //     );
-    }
-
-    /**
-     * @description create a map of attack patterns and their capabilities (inverted capabilities-to-attack-patterns map)
-     */
-    private groupCapabilitiesByAttackPatterns() {
-        const capabilityIds: string[] = this.capabilities ? this.capabilities.map(capability => capability.id) : [];
-        const patternCapabilities: Dictionary<string[]> = {};
-        // Object.entries(this.capabilitiesToAttackPatternMap)
-        //   .filter(capability => capabilityIds.includes(capability[0]))
-        //   .forEach(([capability, patterns]: [string, any[]]) => {
-        //     if (patterns && patterns.length) {
-        //       patterns.forEach((p: any) => {
-        //         if (!patternCapabilities[p.name]) {
-        //           patternCapabilities[p.name] = [];
-        //         }
-        //         patternCapabilities[p.name].push(capability);
-        //       });
-        //     }
-        //   });
-        return patternCapabilities;
-    }
-
-    /**
-     * @description Build a list of all the attack patterns.
-     */
-    private collectAttackPatterns(patterns: any[], indicators: Dictionary<string[]>): Tactic[] {
-        const attackPatterns: Dictionary<Tactic> = {};
-        patterns.forEach((pattern) => {
-            const name = pattern.name;
-            if (name) {
-                let analytics = indicators[name];
-                if (analytics) {
-                    analytics = analytics.map(analytic => this.capabilities.find(a => a.id === analytic));
-                    attackPatterns[name] = Object.assign({}, {
-                        ...pattern,
-                        analytics: analytics,
-                        adds: {
-                            highlights: [{ value: analytics.length, color: { style: analytics.length > 0 } }]
-                        },
-                    });
-                }
-            }
+    public deriveAttackPatternFramework(attackPatterns: Tactic[], chains: Dictionary<TacticChain>): Tactic[] {
+        const phaseMatches = Object.keys(chains).filter((key) => {
+            const curChain = chains[key];
+            const isPhaseMatch = curChain.phases.find((tacticPhase) => {
+                const id = tacticPhase.id;
+                return attackPatterns.find((attackPattern) => {
+                    return attackPattern.phases.find((phase) => phase === id) !== undefined;
+                }) !== undefined;
+            });
+            return isPhaseMatch;
         });
-        return Object.values(attackPatterns);
+        const chainNameMatch = chains[phaseMatches[0]].id;
+        const enhancedAttackPatterns = attackPatterns
+            .map((attackPattern) => {
+                attackPattern.framework = chainNameMatch;
+                return attackPattern;
+            });
+        return enhancedAttackPatterns;
     }
 
+    /**
+     * @param  {Tactic[]} tactics
+     * @returns Tactic
+     */
+    public enhanceWithHeatMapOptions(tactics: Tactic[]): Tactic[] {
+        return tactics.map((tactic) => {
+            tactic.adds = {
+                highlights: [{ value: 2, color: { style: 'selected', bg: '#33a0b0', fg: 'white' } }]
+            };
+            return tactic;
+        });
+    }
 }

--- a/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.ts
+++ b/src/app/baseline/result/summary/summary-report/summary-tactics/summary-tactics.component.ts
@@ -75,11 +75,6 @@ export class SummaryTacticsComponent implements OnInit {
     public readonly carouselOptions: CarouselOptions = {
     };
 
-    /**
-     * @description 
-     */
-    @Input() public collapseSubject: BehaviorSubject<boolean>;
-
     public collapseContents: boolean;
 
     constructor(

--- a/src/app/global/components/heatmap/heatmap.component.spec.ts
+++ b/src/app/global/components/heatmap/heatmap.component.spec.ts
@@ -1,14 +1,12 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-
-import { OverlayModule } from '@angular/cdk/overlay';
 import * as d3 from 'd3';
-
+import { ResizeDirective } from '../../directives/resize.directive';
 import { HeatmapComponent } from './heatmap.component';
 import { HeatmapOptions } from './heatmap.data';
-import { ResizeDirective } from '../../directives/resize.directive';
 
 describe('HeatmapComponent', () => {
 

--- a/src/app/global/components/heatmap/heatmap.component.ts
+++ b/src/app/global/components/heatmap/heatmap.component.ts
@@ -1,26 +1,10 @@
-import {
-    Component,
-    Input,
-    Output,
-    OnInit,
-    AfterViewInit,
-    ViewChild,
-    ElementRef,
-    OnChanges,
-    SimpleChanges,
-    ChangeDetectorRef,
-    ChangeDetectionStrategy,
-    EventEmitter,
-} from '@angular/core';
-
-import * as CSSElementQueries from 'css-element-queries';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild, NgZone } from '@angular/core';
 import * as d3 from 'd3';
-
-import { HeatBatchData, HeatCellData, HeatmapOptions, DOMRect, DEFAULT_OPTIONS, } from './heatmap.data';
-import { HeatmapPane, HeatmapRenderer, } from './heatmap.renderer';
-import { HeatmapColumnRenderer } from './heatmap.renderer.columns';
+import { ResizeDirective, ResizeEvent } from '../../directives/resize.directive';
 import { TooltipEvent } from '../tactics-pane/tactics-tooltip/tactics-tooltip.service';
-import { ResizeEvent, ResizeDirective } from '../../directives/resize.directive';
+import { DEFAULT_OPTIONS, DOMRect, HeatBatchData, HeatmapOptions } from './heatmap.data';
+import { HeatmapPane, HeatmapRenderer } from './heatmap.renderer';
+import { HeatmapColumnRenderer } from './heatmap.renderer.columns';
 
 @Component({
     selector: 'unf-heatmap',
@@ -68,6 +52,7 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
 
     constructor(
         private changeDetector: ChangeDetectorRef,
+        private ngZone: NgZone,
     ) {
     }
 
@@ -77,15 +62,18 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
     ngOnInit(): void {
         this.options = HeatmapOptions.merge(this.options, DEFAULT_OPTIONS);
         this.helper.component = this;
+        this.helper.angularZone = this.ngZone;
     }
 
     /**
      * @description init this component after it gets some screen real estate
      */
     ngAfterViewInit(): void {
-        requestAnimationFrame(() => {
-            this.helper.createHeatmap();
-            this.changeDetector.detectChanges();
+        this.ngZone.runOutsideAngular(() => {
+            requestAnimationFrame(() => {
+                this.helper.createHeatmap();
+                // this.changeDetector.detectChanges();
+            });
         });
     }
 
@@ -95,8 +83,11 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
     ngOnChanges(changes: SimpleChanges) {
         if (changes && changes.data && !changes.data.firstChange) {
             console['debug'](`(${new Date().toISOString()}) heatmap data change detected`, changes.data);
-            this.changeDetector.markForCheck();
-            this.helper.createHeatmap();
+            // this.changeDetector.markForCheck();
+            // this.helper.createHeatmap();
+            this.ngZone.runOutsideAngular(() => {
+                this.helper.createHeatmap();
+            });
         }
     }
 
@@ -104,30 +95,34 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
      * @description handle changes to the viewport size
      */
     onResize(event?: ResizeEvent) {
-        if (this.resizeTimer) {
-            window.clearTimeout(this.resizeTimer);
-        }
-        this.resizeTimer = window.setTimeout(() => {
-            this.resizeTimer = null;
-            const node: any = d3.select(`${this.options.view.component} .heat-map`).node();
-            const rect: DOMRect = node ? node.getBoundingClientRect() : null;
-            if (!node || !rect || !rect.width || !rect.height) {
-                return;
-            } else if (!this.bounds || (this.bounds.width !== rect.width) || (this.bounds.height !== rect.height)) {
-                console['debug'](`(${new Date().toISOString()}) heatmap viewport change detected`);
-                this.bounds = rect;
-                this.redraw();
+        this.ngZone.runOutsideAngular(() => {
+            if (this.resizeTimer) {
+                window.clearTimeout(this.resizeTimer);
             }
-        }, 100);
+            this.resizeTimer = window.setTimeout(() => {
+                this.resizeTimer = null;
+                const node: any = d3.select(`${this.options.view.component} .heat-map`).node();
+                const rect: DOMRect = node ? node.getBoundingClientRect() : null;
+                if (!node || !rect || !rect.width || !rect.height) {
+                    return;
+                } else if (!this.bounds || (this.bounds.width !== rect.width) || (this.bounds.height !== rect.height)) {
+                    console['debug'](`(${new Date().toISOString()}) heatmap viewport change detected`);
+                    this.bounds = rect;
+                    this.redraw();
+                }
+            }, 100);
+        });
     }
 
     /**
      * @description Force a complete redraw of the heatmap.
      */
     public redraw() {
-        this.resizer.sensor.reset();
-        this.changeDetector.markForCheck();
-        this.helper.createHeatmap();
+        this.ngZone.runOutsideAngular(() => {
+            this.resizer.sensor.reset();
+            // this.changeDetector.markForCheck();
+            this.helper.createHeatmap();
+        });
     }
 
     /**

--- a/src/app/global/components/heatmap/heatmap.component.ts
+++ b/src/app/global/components/heatmap/heatmap.component.ts
@@ -70,10 +70,7 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
      */
     ngAfterViewInit(): void {
         this.ngZone.runOutsideAngular(() => {
-            requestAnimationFrame(() => {
-                this.helper.createHeatmap();
-                // this.changeDetector.detectChanges();
-            });
+            this.helper.createHeatmap();
         });
     }
 
@@ -83,8 +80,6 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
     ngOnChanges(changes: SimpleChanges) {
         if (changes && changes.data && !changes.data.firstChange) {
             console['debug'](`(${new Date().toISOString()}) heatmap data change detected`, changes.data);
-            // this.changeDetector.markForCheck();
-            // this.helper.createHeatmap();
             this.ngZone.runOutsideAngular(() => {
                 this.helper.createHeatmap();
             });
@@ -96,21 +91,15 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
      */
     onResize(event?: ResizeEvent) {
         this.ngZone.runOutsideAngular(() => {
-            if (this.resizeTimer) {
-                window.clearTimeout(this.resizeTimer);
+            const node: any = d3.select(`${this.options.view.component} .heat-map`).node();
+            const rect: DOMRect = node ? node.getBoundingClientRect() : null;
+            if (!node || !rect || !rect.width || !rect.height) {
+                return;
+            } else if (!this.bounds || (this.bounds.width !== rect.width) || (this.bounds.height !== rect.height)) {
+                console['debug'](`(${new Date().toISOString()}) heatmap viewport change detected`);
+                this.bounds = rect;
+                this.redraw();
             }
-            this.resizeTimer = window.setTimeout(() => {
-                this.resizeTimer = null;
-                const node: any = d3.select(`${this.options.view.component} .heat-map`).node();
-                const rect: DOMRect = node ? node.getBoundingClientRect() : null;
-                if (!node || !rect || !rect.width || !rect.height) {
-                    return;
-                } else if (!this.bounds || (this.bounds.width !== rect.width) || (this.bounds.height !== rect.height)) {
-                    console['debug'](`(${new Date().toISOString()}) heatmap viewport change detected`);
-                    this.bounds = rect;
-                    this.redraw();
-                }
-            }, 100);
         });
     }
 
@@ -120,7 +109,6 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
     public redraw() {
         this.ngZone.runOutsideAngular(() => {
             this.resizer.sensor.reset();
-            // this.changeDetector.markForCheck();
             this.helper.createHeatmap();
         });
     }

--- a/src/app/global/components/heatmap/heatmap.renderer.columns.ts
+++ b/src/app/global/components/heatmap/heatmap.renderer.columns.ts
@@ -31,9 +31,9 @@ export class HeatmapColumnRenderer extends HeatmapRenderer {
                 if (this.zoomOpts.zoomExtent) {
                     this.heatmap.workspace.zoom = d3.zoom().scaleExtent(this.zoomOpts.zoomExtent)
                         .on('zoom', () => {
-                            this.ngZone.runOutsideAngular(() => {
-                                this.onHeatmapZoom();
-                            })
+                            // this.ngZone.runOutsideAngular(() => {
+                            this.onHeatmapZoom();
+                            // })
                         });
                     this.heatmap.workspace.canvas.call(this.heatmap.workspace.zoom);
 
@@ -398,8 +398,8 @@ export class HeatmapColumnRenderer extends HeatmapRenderer {
         if (!isMini) {
             cell
                 .on('click', (p) => this.click.emit({ data: data, source: d3.event }))
-                .on('mouseover', () => this.ngZone.runOutsideAngular(() => this.onCellHover(data)))
-                .on('mouseout', () => this.ngZone.runOutsideAngular(() => this.offCellHover()));
+                .on('mouseover', () => this.onCellHover(data))
+                .on('mouseout', () => this.offCellHover());
         }
 
         const rect = cell
@@ -414,9 +414,9 @@ export class HeatmapColumnRenderer extends HeatmapRenderer {
             data.rect = rect;
             rect
                 .on('mouseover',
-                    (ev) => this.ngZone.runOutsideAngular(() => this.onRectHover(d3.event.target)))
+                    (ev) => this.onRectHover(d3.event.target))
                 .on('mouseout',
-                    (ev) => this.ngZone.runOutsideAngular(() => this.offRectHover(d3.event.target, color.bg as string)));
+                    (ev) => this.offRectHover(d3.event.target, color.bg as string));
         } else {
             data.mini = rect;
         }
@@ -624,7 +624,7 @@ export class HeatmapColumnRenderer extends HeatmapRenderer {
                             cell.rect.attr('fill', bg);
                         }
                         cell.rect.on('mouseout',
-                            (ev) => this.ngZone.runOutsideAngular(() => this.offRectHover(d3.event.target, bg)));
+                            (ev) => this.offRectHover(d3.event.target, bg));
                     }
                     if (cell.mini) {
                         if (bg.startsWith('.')) {

--- a/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
@@ -1,30 +1,21 @@
-import {
-    Component,
-    ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild } from '@angular/core';
 import { Store } from '@ngrx/store';
-
-import { TacticsView } from '../tactics-view';
-import { Tactic, TacticChain } from '../tactics.model';
-import { TacticsControlService } from '../tactics-control.service';
-import { TacticsTooltipService, TooltipEvent } from '../tactics-tooltip/tactics-tooltip.service';
-import { HeatmapComponent } from '../../heatmap/heatmap.component';
-import {
-    HeatBatchData,
-    HeatCellData,
-    HeatColor,
-    HeatmapOptions,
-    DEFAULT_OPTIONS,
-} from '../../heatmap/heatmap.data';
 import { Dictionary } from '../../../../models/json/dictionary';
 import { AppState } from '../../../../root-store/app.reducers';
+import { HeatmapComponent } from '../../heatmap/heatmap.component';
+import { DEFAULT_OPTIONS, HeatBatchData, HeatCellData, HeatColor, HeatmapOptions } from '../../heatmap/heatmap.data';
+import { TacticsControlService } from '../tactics-control.service';
+import { TacticsTooltipService } from '../tactics-tooltip/tactics-tooltip.service';
+import { TacticsView } from '../tactics-view';
+import { Tactic, TacticChain } from '../tactics.model';
+
 
 /**
  * @description Common data that can be found on attack patterns displayed in a heatmap cell.
  */
 export interface AttackPatternCell extends HeatCellData, Tactic {
     value: string,
-    values?: Array<{name: string, color: string}>,
+    values?: Array<{ name: string, color: string }>,
     text?: string, // the foreground, or text, color of an attack pattern cell
 }
 
@@ -32,6 +23,7 @@ export interface AttackPatternCell extends HeatCellData, Tactic {
     selector: 'tactics-heatmap',
     templateUrl: './tactics-heatmap.component.html',
     styleUrls: ['./tactics-heatmap.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, HeatmapOptions> {
 
@@ -42,13 +34,13 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
 
     @ViewChild(HeatmapComponent) private heatmap: HeatmapComponent;
 
-    private noColor: HeatColor = {bg: '#ccc', fg: 'black'};
+    private noColor: HeatColor = { bg: '#ccc', fg: 'black' };
     private readonly undefinedData = 'no-stix-data-defined';
     private readonly undefinedTactics = {
         title: 'No STIX Data Defined',
         value: this.undefinedData,
     };
-    private readonly undefinedColor: HeatColor = {bg: 'transparent', fg: 'transparent'};
+    private readonly undefinedColor: HeatColor = { bg: 'transparent', fg: 'transparent' };
 
     /**
      * @description 
@@ -101,14 +93,12 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
 
         // now convert the phases in the TacticChains into heat batches
         Object.values(data).forEach(batch => batch.cells.sort((ap1, ap2) => ap1.title.localeCompare(ap2.title)));
-        requestAnimationFrame(() => {
-            this.data = Object.values(data);
-            console['debug'](`(${new Date().toISOString()}) heatmap tactics`, this.data);
-            if (this.heatmap && this.heatmap.options && this.heatmap.options.color) {
-                this.heatmap.options.color.heatColors = heats;
-                console['debug'](`(${new Date().toISOString()}) heatmap heats`, this.heatmap.options.color.heatColors);
-            }
-        });
+        this.data = Object.values(data);
+        console['debug'](`(${new Date().toISOString()}) heatmap tactics`, this.data);
+        if (this.heatmap && this.heatmap.options && this.heatmap.options.color) {
+            this.heatmap.options.color.heatColors = heats;
+            console['debug'](`(${new Date().toISOString()}) heatmap heats`, this.heatmap.options.color.heatColors);
+        }
     }
 
     /**
@@ -132,7 +122,7 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
      * @description
      */
     private convertTacticChain(tactics: Dictionary<TacticChain>, chain: string,
-            data: Dictionary<HeatBatchData>, aps: any, heats: Dictionary<HeatColor>) {
+        data: Dictionary<HeatBatchData>, aps: any, heats: Dictionary<HeatColor>) {
         const framework = tactics[chain];
         if (framework) {
             framework.phases.forEach(phase => {
@@ -143,7 +133,7 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
                 };
 
                 if (!phase.tactics || !phase.tactics.length) {
-                    data[phase.id].cells.push({...this.undefinedTactics});
+                    data[phase.id].cells.push({ ...this.undefinedTactics });
                     if (!heats[this.undefinedData]) {
                         heats[this.undefinedData] = this.undefinedColor;
                     }
@@ -152,7 +142,7 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
                 phase.tactics.forEach(tactic => {
                     if (!aps[tactic.id]) {
                         // convert the tactic into a heat cell, colorize it if it is targeted
-                        const ap: AttackPatternCell = aps[tactic.id] = {...tactic, title: tactic.name, value: 'false'};
+                        const ap: AttackPatternCell = aps[tactic.id] = { ...tactic, title: tactic.name, value: 'false' };
                         const target = this.targets.find(t => t.id === tactic.id);
                         if (this.hasHighlights(target)) {
                             const colors = this.collectColors(target);

--- a/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
@@ -9,7 +9,6 @@ import { TacticsTooltipService } from '../tactics-tooltip/tactics-tooltip.servic
 import { TacticsView } from '../tactics-view';
 import { Tactic, TacticChain } from '../tactics.model';
 
-
 /**
  * @description Common data that can be found on attack patterns displayed in a heatmap cell.
  */
@@ -94,11 +93,13 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
         // now convert the phases in the TacticChains into heat batches
         Object.values(data).forEach(batch => batch.cells.sort((ap1, ap2) => ap1.title.localeCompare(ap2.title)));
         this.data = Object.values(data);
-        console['debug'](`(${new Date().toISOString()}) heatmap tactics`, this.data);
-        if (this.heatmap && this.heatmap.options && this.heatmap.options.color) {
-            this.heatmap.options.color.heatColors = heats;
-            console['debug'](`(${new Date().toISOString()}) heatmap heats`, this.heatmap.options.color.heatColors);
-        }
+        requestAnimationFrame(() => {
+            console['debug'](`(${new Date().toISOString()}) heatmap tactics`, this.data);
+            if (this.heatmap && this.heatmap.options && this.heatmap.options.color) {
+                this.heatmap.options.color.heatColors = heats;
+                console['debug'](`(${new Date().toISOString()}) heatmap heats`, this.heatmap.options.color.heatColors);
+            }
+        });
     }
 
     /**

--- a/src/app/global/components/tactics-pane/tactics-pane.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-pane.component.ts
@@ -65,7 +65,7 @@ export class TacticsPaneComponent implements OnInit, OnDestroy {
      * @description These input values are only the "preselected" attack patterns. If there is nothing preselected, it
      *              is perfectly okay to not provide this input.
      */
-    @Input() public targets: Tactic[] = [];
+    @Input() public targets: Tactic[];
 
     /**
      * @description Title to display in the component's header.

--- a/src/app/global/components/tactics-pane/tactics-pane.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-pane.component.ts
@@ -1,32 +1,20 @@
 
-import { of as observableOf,  BehaviorSubject ,  Observable ,  Subscription  } from 'rxjs';
-
-import { tap, map, take, distinctUntilChanged, pluck, filter } from 'rxjs/operators';
-import {
-    Component,
-    Input,
-    Output,
-    ViewChild,
-    OnInit,
-    OnDestroy,
-    EventEmitter,
-    SimpleChange,
-} from '@angular/core';
-import { Store } from '@ngrx/store';
-
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { MatButtonToggleChange } from '@angular/material';
-
-import { Tactic, TacticChain } from './tactics.model';
+import { Store } from '@ngrx/store';
+import { BehaviorSubject, Observable, of as observableOf, Subscription } from 'rxjs';
+import { distinctUntilChanged, filter, map, pluck, take, tap } from 'rxjs/operators';
+import { Dictionary } from '../../../models/json/dictionary';
+import { AppState } from '../../../root-store/app.reducers';
+import { HeatmapOptions } from '../heatmap/heatmap.data';
+import { TreemapOptions } from '../treemap/treemap.data';
 import { CarouselOptions } from './tactics-carousel/carousel.data';
 import { TacticsCarouselComponent } from './tactics-carousel/tactics-carousel.component';
 import { TacticsHeatmapComponent } from './tactics-heatmap/tactics-heatmap.component';
-import { TacticsTreemapComponent } from './tactics-treemap/tactics-treemap.component';
 import { TacticsTooltipComponent } from './tactics-tooltip/tactics-tooltip.component';
-import { TooltipEvent, TacticsTooltipService } from './tactics-tooltip/tactics-tooltip.service';
-import { HeatmapOptions } from '../heatmap/heatmap.data';
-import { TreemapOptions } from '../treemap/treemap.data';
-import { Dictionary } from '../../../models/json/dictionary';
-import { AppState } from '../../../root-store/app.reducers';
+import { TooltipEvent } from './tactics-tooltip/tactics-tooltip.service';
+import { TacticsTreemapComponent } from './tactics-treemap/tactics-treemap.component';
+import { Tactic, TacticChain } from './tactics.model';
 
 @Component({
     selector: 'tactics-pane',

--- a/src/app/global/components/treemap/treemap.component.html
+++ b/src/app/global/components/treemap/treemap.component.html
@@ -1,5 +1,5 @@
 <div class="center">
-    temporarily disable...
+    temporarily disabled...
 </div>
 <div #treemap class="col-xs-12 tree-map" (resize)="onResize($event)">
     <div #canvas class="tree-map-view"></div>


### PR DESCRIPTION
fixes unfetter-discover/unfetter#1143
show heat map selections in the baselines summary page

## changes
added selected attackpatterns to baselines summary
added assessment name to confirmation delete dialog
~changed heatmap to register event handlers outside angular for performance~ (removed due to spec failures)

## test
__delete confirmation dialog__
create an assessment 3, visit full or results tab, click the ellipsis menu, select delete, verify the assessment name is provided on the confirmation dialog

__show selected attack patterns__
create a baseline, select attack patterns, visit the baseline summary page, verify those patterns are selected

~__performance__~
~visit other pages w/ heatmap, verify the functionality works~
~does the heatmap seems to load faster and be more responsive?~

see screen shots

![screen shot 2018-07-05 at 11 42 07 am](https://user-images.githubusercontent.com/30807406/42333384-1dc8299e-806a-11e8-906f-83052cf90cc0.png)

![screen shot 2018-07-05 at 11 41 17 am](https://user-images.githubusercontent.com/30807406/42333390-225cbc5e-806a-11e8-8ff7-c6492be7502b.png)

