### PR TITLE
added height to master list title so it displays properly in old brow…

### DIFF
--- a/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
+++ b/src/app/global/components/master-list-dialog/master-list-dialog.component.scss
@@ -4,6 +4,8 @@
     padding: 0;
 
     .mat-dialog-title {
+        // FF31 fix
+        height: 49px;
         margin-bottom: 0px;
 
         h2.lead {


### PR DESCRIPTION
…sers

Open assessments and baselines master lists in both ff31 and chrome, confirm it displays as expected.

fixes unfetter-discover/unfetter#1229