### PR TITLE
redraw threat dashboard tree on window resize

### DIFF
--- a/docker-compose.build-ui.yml
+++ b/docker-compose.build-ui.yml
@@ -9,8 +9,8 @@ services:
       entrypoint:
       - npm
       - run
-      - build:prod:noclean:ff31
-      #- build:demo:noclean:ff31
+      # - build:prod:noclean:ff31
+      - build:demo:noclean:ff31
       # - build:prod:noclean
       # - build:demo:noclean
       volumes:

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.html
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.html
@@ -7,6 +7,7 @@
         </mat-select>
         <span class="carousel-button carousel-prev-button {{options.toolboxTheme}}"
                 [ngClass]="{'disabled': page === 0}" (click)="goPreviousPage($event)"></span>
+        <span>&nbsp;</span>
         <span class="carousel-button carousel-next-button {{options.toolboxTheme}}"
                 [ngClass]="{'disabled': page >= pages - 1}" (click)="goNextPage($event)"></span>
     </div>

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.scss
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.scss
@@ -58,7 +58,7 @@
                 max-width: 70px;
                 right: 70px;
                 border: 1px solid #d6d6d6;
-                border-radius: 3px 5px 5px 3px;
+                border-radius: 3px;
                 background: #fff;
                 color: #555;
                 font-size: 14px;

--- a/src/app/global/components/tactics-pane/tactics-pane.component.html
+++ b/src/app/global/components/tactics-pane/tactics-pane.component.html
@@ -17,9 +17,10 @@
             <mat-button-toggle value="carousel" matTooltip="Carousel View">
                 <mat-icon class="mat-24" aria-hidden="true" aria-label="view wide table">view_carousel</mat-icon>
             </mat-button-toggle>
-            <mat-button-toggle value="treemap" matTooltip="TreeMap View">
+            <!-- TODO Uncomment out treemap button when a new treemap library is integrated -->
+            <!-- <mat-button-toggle value="treemap" matTooltip="TreeMap View">
                 <mat-icon class="mat-24" aria-hidden="true" aria-label="view tree map">view_quilt</mat-icon>
-            </mat-button-toggle>
+            </mat-button-toggle> -->
             <mat-button-toggle value="heatmap" matTooltip="HeatMap View">
                 <mat-icon class="mat-24" aria-hidden="true" aria-label="view heat map">view_comfy</mat-icon>
             </mat-button-toggle>

--- a/src/app/global/components/tactics-pane/tactics-pane.component.scss
+++ b/src/app/global/components/tactics-pane/tactics-pane.component.scss
@@ -37,6 +37,10 @@ div.tactics-pane {
                 margin-right: 16px;
             }
 
+            .mat-button-toggle {
+                display: flex;
+            }
+
             .mat-button-toggle-group {
                 margin-top: -8px;
                 height: 48px;

--- a/src/app/threat-dashboard/collapsible-tree/collapsible-tree.component.ts
+++ b/src/app/threat-dashboard/collapsible-tree/collapsible-tree.component.ts
@@ -1,6 +1,8 @@
 
 import { Component, OnInit, OnChanges, Input, Output, EventEmitter, OnDestroy, Renderer2, ChangeDetectionStrategy } from '@angular/core';
 import * as d3 from 'd3';
+import { fromEvent } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
 
 @Component({
     selector: 'unf-collapsible-tree',
@@ -23,6 +25,15 @@ export class CollapsibleTreeComponent implements OnInit, OnDestroy, OnChanges {
      * @description initialize this component
      */
     public ngOnInit(): void {
+        fromEvent(window, 'resize')
+            .pipe(
+                debounceTime(500)
+            )
+            .subscribe((event) => {
+                d3.select(this.graphId).selectAll('*').remove();
+                this.cleanToolTips();
+                this.buildGraph('graph', 'graph-info');
+            });
     }
 
     /**

--- a/src/app/users/register/register.component.html
+++ b/src/app/users/register/register.component.html
@@ -26,8 +26,8 @@
             <mat-card *ngIf="form !== undefined" class="uf-mat-card">
 
                 <mat-card-header>
-                    <div mat-card-avatar *ngIf="userReturn.oauth.avatar_url !== undefined"
-                            class="avatar" [style.background]="'url(' + userReturn.oauth.avatar_url + ')'"></div>
+                    <div mat-card-avatar *ngIf="userReturn.avatar_url !== undefined"
+                            class="avatar" [style.background]="'url(' + userReturn.avatar_url + ')'"></div>
                     <mat-card-title>{{form.get('unfetterInformation').get('userName').value}}</mat-card-title>
                     <mat-card-subtitle>{{form.get('unfetterInformation').get('firstName').value}}&nbsp;{{form.get('unfetterInformation').get('lastName').value}}</mat-card-subtitle>
                 </mat-card-header>

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -11,6 +11,7 @@ import { AuthService } from '../../core/services/auth.service';
 import { Constance } from '../../utils/constance';
 import { ConfigService } from '../../core/services/config.service';
 import { cleanObjectProperties } from '../../global/static/clean-object-properties';
+import { UserHelpers } from '../../global/static/user-helpers';
 
 @Component({
     selector: 'register',
@@ -57,6 +58,7 @@ To get the most out of Unfetter, users should be in one or more organizations. A
                 .subscribe(
                     (user) => {
                         this.userReturn = user = user.attributes;
+                        this.userReturn.avatar_url = UserHelpers.getAvatarUrl(user);
                         
                         this.form = new FormGroup({
                             unfetterInformation: new FormGroup({


### PR DESCRIPTION
Instructions:
- Make browser fairly narrow
- threat dashboard => collapsible tree => open nodes until they go off the end
- Widen browser, ensure tree is redrawn, and can open properly (state wont be saved on resize)

fixes unfetter-discover/unfetter#1228