### PR TITLE
array.includes polyfill

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -34,6 +34,9 @@ import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 
+// es7 array.includes
+import 'core-js/es7/array';
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -20,7 +20,6 @@
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
 import 'core-js/es6/symbol';
-import 'core-js/es6/object';
 import 'core-js/es6/function';
 import 'core-js/es6/parse-int';
 import 'core-js/es6/parse-float';
@@ -33,6 +32,10 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+
+// es6 and 7 object.includes
+import 'core-js/es6/object';
+import 'core-js/es7/object';
 
 // es7 array.includes
 import 'core-js/es7/array';

--- a/src/unf-polyfills.ts
+++ b/src/unf-polyfills.ts
@@ -1,58 +1,5 @@
 // UNFETTER polyfills
 
-// https://tc39.github.io/ecma262/#sec-array.prototype.includes
-if (!Array.prototype.includes) {
-    Object.defineProperty(Array.prototype, 'includes', {
-        value: (searchElement, fromIndex) => {
-            // 1. Let O be ? ToObject(this value).
-            if (this == null) {
-                throw new TypeError('"this" is null or not defined');
-            }
-            
-            const o = Object(this);
-            
-            // 2. Let len be ? ToLength(? Get(O, "length")).
-            // tslint:disable-next-line:no-bitwise
-            const len = o.length >>> 0;
-
-            // 3. If len is 0, return false.
-            if (len === 0) {
-                return false;
-            }
-
-            // 4. Let n be ? ToInteger(fromIndex).
-            //    (If fromIndex is undefined, this step produces the value 0.)
-            // tslint:disable-next-line:no-bitwise
-            const n = fromIndex | 0;
-
-            // 5. If n ≥ 0, then
-            //  a. Let k be n.
-            // 6. Else n < 0,
-            //  a. Let k be len + n.
-            //  b. If k < 0, let k be 0.
-            let k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
-
-            function sameValueZero(x, y) {
-                return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
-            }
-
-            // 7. Repeat, while k < len
-            while (k < len) {
-                // a. Let elementK be the result of ? Get(O, ! ToString(k)).
-                // b. If SameValueZero(searchElement, elementK) is true, return true.
-                // c. Increase k by 1. 
-                if (sameValueZero(o[k], searchElement)) {
-                    return true;
-                }
-                k++;
-            }
-
-            // 8. Return false
-            return false;
-        }
-    });
-}
-
 Object.keys = Object.keys || (obj => {
     const keys = [];
     for (const key in obj) {

--- a/src/unf-polyfills.ts
+++ b/src/unf-polyfills.ts
@@ -1,54 +1,5 @@
 // UNFETTER polyfills
 
-Object.keys = Object.keys || (obj => {
-    const keys = [];
-    for (const key in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, key)) {
-            keys.push(key);
-        }
-    }
-    return keys;
-});
-Object.values = Object.values || (obj => Object.keys(obj).map(key => obj[key]));
-if (!Object.entries) {
-    Object.entries = function(obj) {
-        const ownProps = Object.keys(obj);
-        let i = ownProps.length, resArray = new Array(i); // preallocate the Array
-        while (i--) {
-            resArray[i] = [ownProps[i], obj[ownProps[i]]];
-        }
-        return resArray;
-    }
-};
-
-if (typeof Object.assign !== 'function') {
-    // Must be writable: true, enumerable: false, configurable: true
-    Object.defineProperty(Object, 'assign', {
-        value: function assign(target, varArgs) { // .length of function is 2
-            'use strict';
-            if (target == null) { // TypeError if undefined or null
-                throw new TypeError('Cannot convert undefined or null to object');
-            }
-
-            const to = Object(target);
-            for (let index = 1; index < arguments.length; index++) {
-                const nextSource = arguments[index];
-                if (nextSource != null) { // Skip over if undefined or null
-                    for (const nextKey in nextSource) {
-                        // Avoid bugs when hasOwnProperty is shadowed
-                        if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                            to[nextKey] = nextSource[nextKey];
-                        }
-                    }
-                }
-            }
-            return to;
-        },
-        writable: true,
-        configurable: true
-    });
-}
-
 (window as any).global = window;
 
 // TODO find a better polyfill - This is to fix a problem with Angular 6 menus


### PR DESCRIPTION
fixes unfetter-discover/unfetter#1230

## problem
assessed attack patterns were duplicated in the unassessed attack patterns list. I think the polyfill was not working.

## changes
removed customer polyfill and replaced w/ core-js polyfill

## test
pull this feature branch
run deploy 'docker-compose -f docker-compose.yml -f docker-compose.deploy.yml up'
bring up an old browser like ff31, visit the assessment result tab
verify the `Demonstration Indicators` assessment and the `Discovery` phase looks like the screen shot attacked and not the screen shot in the issue
notice `Account Discovery` is only listed once

see screen shot 

![screen shot 2018-07-09 at 11 22 28 am](https://user-images.githubusercontent.com/30807406/42459809-75a53262-836a-11e8-8e6e-2cda4909de32.png)

