### PR TITLE
Correct % complete

### DIFF
--- a/src/app/baseline/result/result-header/result-header.component.ts
+++ b/src/app/baseline/result/result-header/result-header.component.ts
@@ -39,9 +39,9 @@ export class ResultHeaderComponent implements OnInit {
     this.summaryLink = `${base}/summary/${this.baselineId}`;
     this.infoBarMsg = 'Baselines is currently in beta. Some functionality does not work.'
 
-    this.percentCompleted = this.calculationService.blCompleteWeightings;
+    this.percentCompleted = this.calculationService.blPercentComplete;
     if (this.percentCompleted < 100) {
-      this.infoBarMsg += ` ${this.percentCompleted.toFixed(3)}% of your baseline is complete.`;
+      this.infoBarMsg += ` ${this.percentCompleted.toFixed(2)}% of your baseline is complete.`;
       this.editUrl = `/baseline/wizard/edit/${this.baselineId}`;
     }
   }

--- a/src/app/baseline/result/summary/summary-calculation.service.ts
+++ b/src/app/baseline/result/summary/summary-calculation.service.ts
@@ -37,7 +37,7 @@ export class SummaryCalculationService {
   blGroups: string[] = [];
   blAttackPatterns: string[] = [];
   blCompleteAPs: number;
-  blCompleteWeightings: number;
+  blPercentComplete: number;
   allWeightings: number = 500;
   blWeightings: { protPct: 0, detPct: 0, respPct: 0 };
 
@@ -116,8 +116,8 @@ export class SummaryCalculationService {
     this.blCompleteAPs = blCompleteAPs;
   }
 
-  public set baselineIncompleteWeightings(blCompleteWeightings: number) {
-    this.blCompleteWeightings = blCompleteWeightings;
+  public set baselinePercentComplete(blPercentComplete: number) {
+    this.blPercentComplete = blPercentComplete;
   }
 
   public set baselineWeightings(blWeightings: { protPct, detPct, respPct }) {
@@ -187,8 +187,8 @@ export class SummaryCalculationService {
     return this.baselineIncompleteAPs;
   }
 
-  public get baselineIncompleteWeights(): number {
-    return this.baselineIncompleteWeightings;
+  public get baselinePercentComplete(): number {
+    return this.baselinePercentComplete;
   }
 
   public get baselineWeightings(): { protPct, detPct, respPct } {

--- a/src/app/baseline/result/summary/summary.component.ts
+++ b/src/app/baseline/result/summary/summary.component.ts
@@ -433,7 +433,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
     this.calculationService.baseline = this.currentBaseline;
     this.calculationService.blAttackPatterns = this.blAttackPatterns;
     this.calculationService.blCompleteAPs = this.blCompleteAPs / (this.currentBaseline.assessments.length * this.attackPatternCount);
-    this.calculationService.blCompleteWeightings = ((this.blCompleteWeightings / (3 * this.currentBaseline.assessments.length * this.attackPatternCount)) / 100) * 100;
+    this.calculationService.blPercentComplete = (((this.blCompleteWeightings / (3 * this.currentBaseline.assessments.length * this.attackPatternCount)) / 100) * 100) * 100;
     this.calculationService.totalWeightings = this.attackPatternCount;
     this.calculationService.blGroups = this.blGroups;
     this.calculationService.blWeightings = this.blWeightings;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1258

Percent complete was being displayed as a raw percentage.  Now it is displayed correctly with 2 decimal places.

### To test:
1. Pull this branch
2. Navigate to Baselines
3. Note percent complete
4. Click `Complete` button and count number of answers in the baseline (i.e. non-empty selections for the protect, detect, and respond questions)
5. Divide number of non-empty answers by product of number of AP in the KC (e.g. 243 for NTCTF), number of capabilities in the baseline, and 3 (i.e. 1 answer each for P, D, and R).  This result (multiplied by 100) should be the percentage displayed in the info bar.