### PR TITLE
Update baseline summary screen and wizard attack pattern chooser title

### DIFF
--- a/src/app/baseline/result/result-header/result-header.component.ts
+++ b/src/app/baseline/result/result-header/result-header.component.ts
@@ -39,9 +39,9 @@ export class ResultHeaderComponent implements OnInit {
     this.summaryLink = `${base}/summary/${this.baselineId}`;
     this.infoBarMsg = 'Baselines is currently in beta. Some functionality does not work.'
 
-    this.percentCompleted = this.calculationService.blCompleteWeightings;
+    this.percentCompleted = this.calculationService.blPercentComplete;
     if (this.percentCompleted < 100) {
-      this.infoBarMsg += ` ${this.percentCompleted.toFixed(3)}% of your baseline is complete.`;
+      this.infoBarMsg += ` ${this.percentCompleted.toFixed(2)}% of your baseline is complete.`;
       this.editUrl = `/baseline/wizard/edit/${this.baselineId}`;
     }
   }

--- a/src/app/baseline/result/summary/summary-calculation.service.ts
+++ b/src/app/baseline/result/summary/summary-calculation.service.ts
@@ -37,7 +37,7 @@ export class SummaryCalculationService {
   blGroups: string[] = [];
   blAttackPatterns: string[] = [];
   blCompleteAPs: number;
-  blCompleteWeightings: number;
+  blPercentComplete: number;
   allWeightings: number = 500;
   blWeightings: { protPct: 0, detPct: 0, respPct: 0 };
 
@@ -116,8 +116,8 @@ export class SummaryCalculationService {
     this.blCompleteAPs = blCompleteAPs;
   }
 
-  public set baselineIncompleteWeightings(blCompleteWeightings: number) {
-    this.blCompleteWeightings = blCompleteWeightings;
+  public set baselinePercentComplete(blPercentComplete: number) {
+    this.blPercentComplete = blPercentComplete;
   }
 
   public set baselineWeightings(blWeightings: { protPct, detPct, respPct }) {
@@ -187,8 +187,8 @@ export class SummaryCalculationService {
     return this.baselineIncompleteAPs;
   }
 
-  public get baselineIncompleteWeights(): number {
-    return this.baselineIncompleteWeightings;
+  public get baselinePercentComplete(): number {
+    return this.baselinePercentComplete;
   }
 
   public get baselineWeightings(): { protPct, detPct, respPct } {

--- a/src/app/baseline/result/summary/summary-report/summary-report.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-report.component.html
@@ -43,10 +43,10 @@
               {{summaryCalculationService.baseline.assessments.length}}
             </div>
             <div class="card-row-description third-row">
-              Attack Patterns Weighted
+              Attack Patterns
             </div>
             <div class="card-row-data">
-              {{summaryCalculationService.blAttackPatterns.length}}
+              {{summaryCalculationService.blAttackPatterns.length}} out of {{summaryCalculationService.totalWeightings}}
             </div>
           </mat-card-content>
         </mat-card>

--- a/src/app/baseline/result/summary/summary.component.ts
+++ b/src/app/baseline/result/summary/summary.component.ts
@@ -433,7 +433,7 @@ export class SummaryComponent implements OnInit, OnDestroy {
     this.calculationService.baseline = this.currentBaseline;
     this.calculationService.blAttackPatterns = this.blAttackPatterns;
     this.calculationService.blCompleteAPs = this.blCompleteAPs / (this.currentBaseline.assessments.length * this.attackPatternCount);
-    this.calculationService.blCompleteWeightings = ((this.blCompleteWeightings / (3 * this.currentBaseline.assessments.length * this.attackPatternCount)) / 100) * 100;
+    this.calculationService.blPercentComplete = (((this.blCompleteWeightings / (3 * this.currentBaseline.assessments.length * this.attackPatternCount)) / 100) * 100) * 100;
     this.calculationService.totalWeightings = this.attackPatternCount;
     this.calculationService.blGroups = this.blGroups;
     this.calculationService.blWeightings = this.blWeightings;

--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title>
     <div class="flex">
-        <span>Choose VPN Related Attack Patterns</span>
+        <span>Choose Related Attack Patterns</span>
         <span class="flex1"></span>
         <button mat-button (click)="clearSelections()">CLEAR</button>
         <button mat-button [mat-dialog-close]="false">CANCEL</button>


### PR DESCRIPTION
In the left-most card, removed 'Weighted' from 'Attack Patterns Weighted'
In the left-most card, changed number of attack patterns to the format x / y, where x is the number of attack patterns represented in the baseline and y is the total number of attack patterns in the kill chain
In the capability component (scoring step), removed the capability name VPN from the title of the AP selector