### PR TITLE
Fix summary back button to go to last capability instead of last capability-group

### DIFF
--- a/src/app/baseline/result/summary/summary-report/summary-report.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-report.component.html
@@ -43,10 +43,10 @@
               {{summaryCalculationService.baseline.assessments.length}}
             </div>
             <div class="card-row-description third-row">
-              Attack Patterns Weighted
+              Attack Patterns
             </div>
             <div class="card-row-data">
-              {{summaryCalculationService.blAttackPatterns.length}}
+              {{summaryCalculationService.blAttackPatterns.length}} out of {{summaryCalculationService.totalWeightings}}
             </div>
           </mat-card-content>
         </mat-card>

--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title>
     <div class="flex">
-        <span>Choose VPN Related Attack Patterns</span>
+        <span>Choose Related Attack Patterns</span>
         <span class="flex1"></span>
         <button mat-button (click)="clearSelections()">CLEAR</button>
         <button mat-button [mat-dialog-close]="false">CANCEL</button>

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -309,8 +309,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
     if (group) {
       // Adjust page based on given group
-      this.page = this.navigations.find(navigation => navigation.id === group.id).page;
-
       this.wizardStore.dispatch(new SetCurrentBaselineGroup(group));
     } else {
       // If Group Setup or Summary, indicate as such


### PR DESCRIPTION
Appears that this line is not needed and removing it fixes this issue.

Fixes unfetter-discover/unfetter#1259

To test
  - Create a baseline 
  - Make sure you can navigate as usual
  - Once you get to the summary page, press the back button -> you should now be directed to the last capability to score and not the last group.
  - Repeat for editing a baseline