### PR TITLE
Updated wording to baseline summary screen

### DIFF
--- a/src/app/baseline/result/summary/summary-report/summary-report.component.html
+++ b/src/app/baseline/result/summary/summary-report/summary-report.component.html
@@ -46,7 +46,7 @@
               Attack Patterns
             </div>
             <div class="card-row-data">
-              {{summaryCalculationService.blAttackPatterns.length}} out of {{summaryCalculationService.totalWeightings}}
+              {{summaryCalculationService.blAttackPatterns.length}} of {{summaryCalculationService.totalWeightings}}
             </div>
           </mat-card-content>
         </mat-card>


### PR DESCRIPTION
Changed wording to baseline summary screen denoting attack patterns included in the baseline. Changed from "x out of y" to "x of y" as suggested