### PR TITLE
Issue 1207

### DIFF
--- a/src/app/core/services/genericapi.service.ts
+++ b/src/app/core/services/genericapi.service.ts
@@ -221,7 +221,14 @@ export class GenericApi {
                 );
     }
 
-    public uploadAttachments(files: FileList, progressCallback?: (number) => void): Observable<[{attributes: GridFSFile}]> {
+    /**
+     * @param  {FileList} files
+     * @param  {(number)=>void} progressCallback?
+     * @returns Observable<[GridFSFile]>
+     * @description This is the observable to upload a list of files to the upload/files route.
+     * The optional callback will assist in driving progress bars.
+     */
+    public uploadAttachments(files: FileList, progressCallback?: (number) => void): Observable<GridFSFile[]> {
         const formData: FormData = new FormData();
         Object.values(files).forEach((file) => formData.append('attachments', file));
         const req = new HttpRequest('POST', `${Constance.UPLOAD_URL}/files`, formData, {

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -82,6 +82,7 @@ import { DataSourcesComponent } from './components/data-sources/data-sources.com
 import { MarkdownEditorComponent } from './components/markdown-editor/markdown-editor.component';
 import { SelectionListComponent } from './components/selection-list/selection-list.component';
 import { ErrorPageComponent } from './components/error-page/error-page.component';
+import { ReadableBytesPipe } from './pipes/readable-bytes.pipe';
 
 const matModules = [
     MatAutocompleteModule,
@@ -155,6 +156,7 @@ const unfetterComponents = [
     MarkdownEditorComponent,
     SelectionListComponent,
     ErrorPageComponent,
+    ReadableBytesPipe
 ];
 
 @NgModule({

--- a/src/app/global/models/grid-fs-file.ts
+++ b/src/app/global/models/grid-fs-file.ts
@@ -1,0 +1,8 @@
+export interface GridFSFile {
+    _id: string,
+    length: number,
+    chunkSize: number,
+    uploadDate: string,
+    filename: string,
+    contentType: string
+}

--- a/src/app/global/pipes/readable-bytes.pipe.spec.ts
+++ b/src/app/global/pipes/readable-bytes.pipe.spec.ts
@@ -1,0 +1,32 @@
+import { ReadableBytesPipe } from './readable-bytes.pipe';
+
+describe('ReadableBytesPipe', () => {
+    const pipe = new ReadableBytesPipe();
+
+    it('should convert Bytes', () => {
+        expect(pipe.transform(3)).toBe('3 Bytes');
+    });
+
+    it('should convert KiloBytes', () => {
+        expect(pipe.transform(2048)).toBe('2.0 KB');
+        expect(pipe.transform(2560)).toBe('2.5 KB');
+    });
+
+    it('should convert MegaBytes', () => {
+        expect(pipe.transform(1048576)).toBe('1.0 MB');
+        // Rounded
+        expect(pipe.transform(1887436)).toBe('1.8 MB');
+    });
+
+    it('should convert GigaBytes', () => {
+        expect(pipe.transform(1073741824)).toBe('1.0 GB');
+        // Rounded
+        expect(pipe.transform(1288490188)).toBe('1.2 GB');
+    });
+
+    it('should convert TeraBytes', () => {
+        expect(pipe.transform(1099511627776)).toBe('1.0 TB');
+        // Rounded
+        expect(pipe.transform(1209462790553)).toBe('1.1 TB');
+    });
+});

--- a/src/app/global/pipes/readable-bytes.pipe.ts
+++ b/src/app/global/pipes/readable-bytes.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'readableBytes' })
+export class ReadableBytesPipe implements PipeTransform {
+
+    public transform(bytes: number): string {
+        const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+        const i = Math.floor(Math.log(bytes) / Math.log(1024));
+        if (i === 0) {
+            return `${bytes} ${sizes[i]}`
+        };
+        return `${(bytes / (1024 ** i)).toFixed(1)} ${sizes[i]}`;
+    }
+}

--- a/src/app/global/pipes/readable-bytes.pipe.ts
+++ b/src/app/global/pipes/readable-bytes.pipe.ts
@@ -1,5 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+/**
+ * @description Converts a number of bytes into a human readable string.
+ *  It will round to the neared KB, MB, GB, or TB if > 1024 bytes
+ */
 @Pipe({ name: 'readableBytes' })
 export class ReadableBytesPipe implements PipeTransform {
 

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -181,6 +181,15 @@
                     <add-label-reactive [parentForm]="form" [stixType]="'indicator'"></add-label-reactive>
                 </div>
 
+                <div *ngIf="!editMode">
+                    <h5>File Attachments</h5>
+                    <div class="uf-well">
+                        <p>
+                            <input type="file" name="attachments" id="attachments" (change)="fileInputChange($event)" multiple>
+                        </p>
+                    </div>
+                </div>
+
                 <div class="mt-6">
                     <button mat-raised-button matStepperNext type="button" color="primary">CONTINUE</button>
                     <button mat-button matStepperPrevious type="button">BACK</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -234,6 +234,10 @@
             
         </mat-vertical-stepper>
 
+        <div *ngIf="uploadProgress > 0">
+            <label>Uploading Files...</label>
+            <mat-progress-bar mode="determinate" [value]="uploadProgress"></mat-progress-bar>
+        </div>
         <p class="text-right mt-6">
             <button mat-button mat-dialog-close (click)="resetForm($event); dialogRef.close(false);">CANCEL</button>
             <button mat-raised-button color="primary" [disabled]="form.status !== 'VALID'" type="submit">SAVE</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -236,7 +236,8 @@
 
         <div *ngIf="uploadProgress > 0">
             <label>Uploading Files...</label>
-            <mat-progress-bar mode="determinate" [value]="uploadProgress"></mat-progress-bar>
+            <mat-progress-bar mode="determinate" [value]="uploadProgress" *ngIf="uploadProgress < 100"></mat-progress-bar>
+            <mat-progress-bar mode="indeterminate" *ngIf="uploadProgress === 100"></mat-progress-bar>
         </div>
         <div *ngIf="submitErrorMsg" class="uf-well-warn">
             <h5>An Error Occured</h5>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -238,6 +238,10 @@
             <label>Uploading Files...</label>
             <mat-progress-bar mode="determinate" [value]="uploadProgress"></mat-progress-bar>
         </div>
+        <div *ngIf="submitErrorMsg" class="uf-well-warn">
+            <h5>An Error Occured</h5>
+            <p>{{ submitErrorMsg }}</p>
+        </div>
         <p class="text-right mt-6">
             <button mat-button mat-dialog-close (click)="resetForm($event); dialogRef.close(false);">CANCEL</button>
             <button mat-raised-button color="primary" [disabled]="form.status !== 'VALID'" type="submit">SAVE</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.spec.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.spec.ts
@@ -10,6 +10,7 @@ import { IndicatorSharingService } from '../indicator-sharing.service';
 import { of as observableOf, Observable } from 'rxjs';
 import { AuthService } from '../../core/services/auth.service';
 import { take } from 'rxjs/operators';
+import { GenericApi } from '../../core/services/genericapi.service';
 
 describe('AddIndicatorComponent', () => {
     let component: AddIndicatorComponent;
@@ -89,6 +90,17 @@ describe('AddIndicatorComponent', () => {
         }
     };
 
+    const mockGenericApi = {
+        uploadAttachments: (files, cb) => {
+            return observableOf([
+                {
+                    _id: '1234',
+                    filename: 'bob.txt'
+                }
+            ]);
+        }
+    };
+
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
@@ -120,6 +132,10 @@ describe('AddIndicatorComponent', () => {
                 {
                     provide: AuthService,
                     useValue: mockAuthService
+                },
+                {
+                    provide: GenericApi,
+                    useValue: mockGenericApi
                 }
             ]
         })

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
@@ -41,6 +41,7 @@ export class AddIndicatorComponent implements OnInit {
     public patternObjs: PatternHandlerPatternObject[] = [];
     public patternObjSubject: Subject<PatternHandlerPatternObject[]> = new Subject();
     public editMode: boolean = false;
+    public files: FileList;
 
     @ViewChild('associatedDataStep') 
     public associatedDataStep: MatStep;
@@ -220,6 +221,16 @@ export class AddIndicatorComponent implements OnInit {
                 );
         }
 
+    }
+
+    public fileInputChange(event) {
+        console.log('$$$$', event);
+        this.files = event.target.files;
+        console.log('@@@@@', this.files);
+        for (const idx in this.files) {
+            console.log('$$$$', this.files[idx]);
+        }
+        console.log(Object.values(this.files));
     }
 
     public stepperChanged(event: StepperSelectionEvent) {

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -219,6 +219,30 @@
           </div>
         </mat-tab>
 
+        <mat-tab label="Attachments" *ngIf="indicator.metaProperties && indicator.metaProperties.attachments">
+          <br>
+          <table class="uf-table">
+            <thead>
+              <tr>
+                <th>Filename</th>
+                <th>Size</th>
+                <th>Download</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let attachment of indicator.metaProperties.attachments">
+                <td>{{ attachment.filename }}</td>
+                <td>{{ attachment.length }}</td>
+                <td>
+                  <div class="mat-icon-button-cell-wrapper">
+                    <a href="{{ generateAttachmentLink(attachment) }}" mat-icon-button><i class="material-icons mat-24">cloud_download</i></a>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </mat-tab>
+
       </mat-tab-group>
 
       <div class="mt-20 overFlowHidden" @heightCollapse *ngIf="showCommentTextArea">

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -232,7 +232,7 @@
             <tbody>
               <tr *ngFor="let attachment of indicator.metaProperties.attachments">
                 <td>{{ attachment.filename }}</td>
-                <td>{{ attachment.length }}</td>
+                <td>{{ attachment.length | readableBytes }}</td>
                 <td>
                   <div class="mat-icon-button-cell-wrapper">
                     <a href="{{ generateAttachmentLink(attachment) }}" mat-icon-button><i class="material-icons mat-24">cloud_download</i></a>

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
@@ -19,11 +19,11 @@ import { mockConfigService } from '../../testing/mock-config-service';
 import { ConfigService } from '../../core/services/config.service';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { of as observableOf, Observable } from 'rxjs';
+import { ReadableBytesPipe } from '../../global/pipes/readable-bytes.pipe';
 
 describe('IndicatorCardComponent', () => {
     let component: IndicatorCardComponent;
     let fixture: ComponentFixture<IndicatorCardComponent>;
-    let store;
 
     const mockIndicator = {
         name: 'test indicator',
@@ -126,6 +126,7 @@ describe('IndicatorCardComponent', () => {
                 TimeAgoPipe,
                 CapitalizePipe,
                 ChipLinksComponent,
+                ReadableBytesPipe,
             ],
             imports: [
                 MatButtonModule,

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit, AfterViewInit, ViewChild, ElementRef, Renderer2, Output, EventEmitter, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
-import { trigger, state, transition, style, animate, query } from '@angular/animations';
 import { Observable ,  Subscription ,  BehaviorSubject } from 'rxjs';
 import { MatTooltip } from '@angular/material';
 
@@ -96,21 +95,21 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
             }
         }
 
-        if (this.collapseAllCardsSubject) {            
+        if (this.collapseAllCardsSubject) {
             this.collapseCard$ = this.collapseAllCardsSubject
-            .subscribe(
-                (collapseContents) => {
-                    this.collapseContents = collapseContents;
-                },
-                (err) => {
-                    console.log(err);
-                },
-                () => {
-                    if (this.collapseCard$) {
-                        this.collapseCard$.unsubscribe();
+                .subscribe(
+                    (collapseContents) => {
+                        this.collapseContents = collapseContents;
+                    },
+                    (err) => {
+                        console.log(err);
+                    },
+                    () => {
+                        if (this.collapseCard$) {
+                            this.collapseCard$.unsubscribe();
+                        }
                     }
-                }
-            );
+                );
         }
     }
 
@@ -321,6 +320,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
                 },
                 (err) => {
                     this.flashMessage('Unable to generate download.');
+                    console.log(err);
                 },
                 () => {
                     downloadData$.unsubscribe();

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
@@ -13,7 +13,8 @@ import { generateStixRelationship } from '../../global/static/stix-relationship'
 import { StixRelationshipTypes } from '../../global/enums/stix-relationship-types.enum';
 import { canCrud } from '../../global/static/stix-permissions';
 import { SearchParameters } from '../models/search-parameters';
-import { finalize } from 'rxjs/operators';
+import { GridFSFile } from '../../global/models/grid-fs-file';
+import { Constance } from '../../utils/constance';
 
 @Component({
     selector: 'indicator-card',
@@ -31,6 +32,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
     @Input() public sensors: any;
     @Input() public searchParameters: Observable<SearchParameters>;
     @Input() public collapseAllCardsSubject: BehaviorSubject<boolean>;
+    @Input() public userToken: string;
     @Input() public highlightObj = {
         labels: {},
         intrusionSets: {},
@@ -339,6 +341,10 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
     public flashTooltip(toolTip: MatTooltip) {
         toolTip.show();
         setTimeout(() => toolTip.hide(), this.FLASH_TOOLTIP_TIMER);
+    }
+
+    public generateAttachmentLink(attachment: GridFSFile): string {
+        return `${Constance.DOWNLOAD_URL}/file/${this.indicator.id}/${attachment._id}?authorization=${this.userToken}`;
     }
 
     private flashMessage(msg: string) {

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -91,7 +91,8 @@
                                     [sensors]="getSensorsByIndicatorId(indicator.id)"
                                     [creator]="getIdentityNameById(indicator.created_by_ref)" 
                                     [highlightObj]="highlightObj"
-                                    [collapseAllCardsSubject]="collapseAllCardsSubject" 
+                                    [collapseAllCardsSubject]="collapseAllCardsSubject"
+                                    [userToken]="userToken$ | async"
                                     (stateChange)="updateIndicator($event)" 
                                     (indicatorDeleted)="deleteIndicator($event)"
                                     (indicatorEdit)="editIndicator($event)"></indicator-card>

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -37,7 +37,8 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
     public filterOpened: boolean = false;
     public collapseAllCards: boolean = false;
     public activeMainWell: mainWell = 'tactics';
-    public totalIndicatorCount$: Observable<number>
+    public totalIndicatorCount$: Observable<number>;
+    public userToken$: Observable<string>;
     public collapseAllCardsSubject: BehaviorSubject<boolean> = new BehaviorSubject(this.collapseAllCards);
     public initialHighlightObj = {
         labels: {},
@@ -83,7 +84,7 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
                     console.log(err);
                 },
                 () => {
-                    filteredIndicatorSub$.unsubscribe();
+                    displayedIndicatorSub$.unsubscribe();
                 }
             );
 
@@ -154,6 +155,11 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
                         getUser$.unsubscribe();
                     }
                 }
+            );
+
+        this.userToken$ = this.store.select('users')
+            .pipe(
+                pluck('token')
             );
     }
 

--- a/src/app/indicator-sharing/indicator-sharing.module.ts
+++ b/src/app/indicator-sharing/indicator-sharing.module.ts
@@ -19,6 +19,7 @@ import {
         MatDialogModule,
         MatSidenavModule,
         MatMenuModule,
+        MatProgressBarModule,
     } from '@angular/material';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
@@ -67,7 +68,8 @@ const matModules = [
     MatTabsModule,
     MatTooltipModule,
     MatSidenavModule,
-    MatMenuModule
+    MatMenuModule,
+    MatProgressBarModule
 ];
 
 @NgModule({

--- a/src/app/threat-dashboard/threat-report-editor/file-upload/upload.service.ts
+++ b/src/app/threat-dashboard/threat-report-editor/file-upload/upload.service.ts
@@ -37,6 +37,7 @@ export class UploadService {
         });
         return this.http.request<Array<JsonApiObject<Report>>>(req).pipe(
             map((event) => {
+                console.log(event);
                 if (event.type === HttpEventType.UploadProgress) {
                     const percentDone = Math.round(100 * event.loaded / event.total);
                     console.log(`File is ${percentDone}% uploaded`);

--- a/src/app/utils/constance.ts
+++ b/src/app/utils/constance.ts
@@ -118,6 +118,8 @@ export const Constance = {
   CONFIG_URL: 'api/config',
   WEB_ANALYTICS_URL: 'api/web-analytics',
   PATTERN_HANDLER_URL: 'api/pattern-handler',
+  DOWNLOAD_URL: 'api/download',
+  UPLOAD_URL: 'api/upload',
 
   IPGEO_LOOKUP_URL: 'api/lookup',
 

--- a/src/styles/partials/_angular_material_config.scss
+++ b/src/styles/partials/_angular_material_config.scss
@@ -187,6 +187,10 @@ $utility-theme: mat-light-theme($utility-theme-primary, $utility-theme-accent, $
   }
 }
 
+a.mat-icon-button {
+  outline: none !important;
+}
+
 a.mat-button {
   text-decoration: none;
 }

--- a/src/styles/partials/_unfetter_custom_elements.scss
+++ b/src/styles/partials/_unfetter_custom_elements.scss
@@ -82,11 +82,11 @@
   }
 
   tr {
-    *:first-child {
+    >*:first-child {
       padding-left: 24px;
     }
 
-    *:last-child {
+    >*:last-child {
       padding-right: 24px;
     }
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
@@ -108,6 +108,11 @@
     tr {
       align-items: center;
     }
+  }
+
+  .mat-icon-button-cell-wrapper {
+    margin-top: -10px;
+    margin-bottom: -10px;
   }
 }
 


### PR DESCRIPTION
Requires `issue-1207` on `unfetter`, `unfetter-ui`, and `unfetter-store`.

Associated PRs:
- https://github.com/unfetter-discover/unfetter/pull/1277
- https://github.com/unfetter-discover/unfetter-store/pull/232

Instructions:
- Stop stack, remove containers, `docker rmi unfetter-discover-api`
- Start stack
- Go to Analytic Exchange > Add Analytic => Associated Data => Attachments, and attach some files
- Save, verify you can see the list of attachments in the analytic and that you can download the attachments
- Edit the analytic (the attachments portion should be hidden), and confirm that the attachments are still on the analytic after the edit

Notes:
- This should work with even large files
- The filepicker is the default HTML one which will likely be changed in the future, this PR is focused around the functionality

![image](https://user-images.githubusercontent.com/30236110/42899461-186f9a2a-8a94-11e8-8d24-35f919c16538.png)
