### PR TITLE
data sources selection list

### DIFF
--- a/src/app/global/components/data-sources/data-sources.component.html
+++ b/src/app/global/components/data-sources/data-sources.component.html
@@ -1,9 +1,3 @@
 <div class="dataSourcesComponent">
-  <mat-form-field class="full-width">
-    <mat-select placeholder="Data Sources" [formControl]="formCtrl" [multiple]="true">
-      <mat-option *ngFor="let dataSource of dataSources$ | async" [value]="dataSource">
-        {{ dataSource }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
+  <unf-selection-list [stix]="dataSources$ | async" [formCtrl]="formCtrl"></unf-selection-list>
 </div>

--- a/src/app/global/components/data-sources/data-sources.component.spec.ts
+++ b/src/app/global/components/data-sources/data-sources.component.spec.ts
@@ -8,6 +8,7 @@ import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { MatSelectModule } from '@angular/material';
 import { makeRootMockStore, mockConfig } from '../../../testing/mock-store';
 import { take } from 'rxjs/operators';
+import { NO_ERRORS_SCHEMA } from '../../../../../node_modules/@angular/core';
 
 describe('DataSourcesComponent', () => {
   let component: DataSourcesComponent;
@@ -20,11 +21,9 @@ describe('DataSourcesComponent', () => {
         DataSourcesComponent 
       ],
       imports: [
-        BrowserAnimationsModule,
-        ReactiveFormsModule,
-        MatSelectModule,
         StoreModule.forRoot(reducers)
-      ]
+      ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   }));
@@ -48,7 +47,7 @@ describe('DataSourcesComponent', () => {
       .subscribe(
         (dataSources) => {          
           expect(dataSources).toBeTruthy();
-          expect(dataSources).toEqual(mockConfig.dataSources);
+          expect(dataSources.length).toBe(mockConfig.dataSources.length);
           done();
         },
         (err) => {

--- a/src/app/global/components/data-sources/data-sources.component.ts
+++ b/src/app/global/components/data-sources/data-sources.component.ts
@@ -17,16 +17,20 @@ export class DataSourcesComponent implements OnInit {
 
   @Input()
   public formCtrl: FormControl;
-  public dataSources$: Observable<string[]>;
+
+  public dataSources$: Observable<any[]>;
 
   constructor(public store: Store<AppState>) { }
 
   ngOnInit() {
-    this.dataSources$ = this.store.select('config').pipe(
-      pluck('configurations'),
-      filter(RxjsHelpers.filterByConfigKey(ConfigKeys.DATA_SOURCES)),
-      pluck(ConfigKeys.DATA_SOURCES),
-      map((dataSources: string[]) => dataSources.sort()));
+    this.dataSources$ = this.store.select('config')
+      .pipe(
+        pluck('configurations'),
+        filter(RxjsHelpers.filterByConfigKey(ConfigKeys.DATA_SOURCES)),
+        pluck(ConfigKeys.DATA_SOURCES),
+        // Hack to get this data structure compatible with the selection list
+        map((dataSources: string[]) => dataSources.sort().map((ds) => ({ id: ds, name: ds })))
+      );
   }
 
 }

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -71,14 +71,15 @@
                     </mat-error>
                 </mat-form-field>
 
-                <p id="patternWarning" 
+                <!-- TODO delete this if its determine that only showing valid stix pattern is ok -->
+                <!-- <p id="patternWarning" 
                     [style.opacity]="form.get('pattern').dirty && !form.get('metaProperties').get('validStixPattern').value && form.get('pattern').value.length > 0 ? 1 : 0"
                     [style.marginTop]="!form.get('pattern').hasError('required') ? '-20px' : '-5px'" 
-                    [style.marginBottom]="!form.get('pattern').hasError('required') ? '15px' : '0px'">(Warning) Optional STIX patterning validation failed</p>
+                    [style.marginBottom]="!form.get('pattern').hasError('required') ? '15px' : '0px'">(Warning) Optional STIX patterning validation failed</p> -->
 
                 <p id="patternSuccess" 
                     [style.opacity]="form.get('metaProperties').get('validStixPattern').value && form.get('pattern').dirty && form.get('pattern').value.length > 0 ? 1 : 0"                    
-                    [style.marginTop]="!form.get('pattern').hasError('required') ? '-30px' : '-5px'" 
+                    [style.marginTop]="!form.get('pattern').hasError('required') ? '-20px' : '-5px'" 
                     [style.marginBottom]="!form.get('pattern').hasError('required') ? '15px' : '0px'"><i class="material-icons">check</i> Valid STIX Pattern</p>
                     
                 <pii-check-message [formCtrl]="form.get('pattern')"></pii-check-message>
@@ -196,21 +197,10 @@
                 </div>
             </mat-step>
             
-            <!-- TODO remove ngif once edit mode can update relationships -->
             <mat-step label="Relationships">
                 <div formGroupName="metaProperties" *ngIf="attackPatterns && attackPatterns.length">
                     <h5>Indicated Techniques</h5>
                     <unf-selection-list [stix]="attackPatterns" [formCtrl]="form.get('metaProperties').get('relationships')"></unf-selection-list>
-                    <!-- <mat-selection-list formControlName="relationships">
-                        <mat-list-option *ngFor="let ap of attackPatterns | sortByField:'name':'ascending'" [value]="ap.id">
-                        {{ap.name}}
-                        </mat-list-option>
-                    </mat-selection-list> -->
-                    <!-- <mat-form-field class="full-width mt-10">
-                        <mat-select placeholder="Indicated Techniques" [multiple]="true" formControlName="relationships">
-                            <mat-option [value]="ap.id" *ngFor="let ap of attackPatterns | sortByField:'name':'ascending'">{{ ap.name }}</mat-option>
-                        </mat-select>
-                    </mat-form-field> -->
                     <div class="mt-6">
                         <button mat-raised-button matStepperNext type="button" color="primary">CONTINUE</button>
                         <button mat-button matStepperPrevious type="button">BACK</button>
@@ -224,6 +214,7 @@
                 <div class="mt-10">
                     <observable-data-tree [parentForm]="form" [patternObjSubject]="patternObjSubject"></observable-data-tree>
                 </div>
+                <h5>Data Sources</h5>
                 <div class="mt-15">
                     <data-sources [formCtrl]="form.get('x_mitre_data_sources')"></data-sources>
                 </div>


### PR DESCRIPTION
Requires `issue-1267` on the 3 main projects.

Associated PRs:
- https://github.com/unfetter-discover/unfetter/pull/1279
- https://github.com/unfetter-discover/unfetter-store/pull/234

Instructions
- `db.getCollection('config').remove({})`
- Stop stack, remove containers, `docker rm unfetter-socket-server`
- AE => Add Analytic => Input Data => Data Sources
- Verify filters work as expected, select a few and save
- Verify data sources display in analytic card
- Verify edit functionality works as expected with data sources

Some functionality included in the PR unrelated to the issue is a refactor of deploy mode.  Bring up the stack in deploy mode and confirm everything works as expected, including the socket server.

fixes unfetter-discover/unfetter#1267
supports unfetter-discover/unfetter#658