### PR TITLE
minor style improvements

### DIFF
--- a/src/app/threat-dashboard/bar-chart/bar-chart.component.ts
+++ b/src/app/threat-dashboard/bar-chart/bar-chart.component.ts
@@ -1,17 +1,6 @@
-import {
-        Component,
-        OnInit,
-        ChangeDetectionStrategy,
-        Renderer2,
-        EventEmitter,
-        Output,
-        Input,
-        OnDestroy,
-        OnChanges,
-    } from '@angular/core';
-import { Subscription } from 'rxjs';
-
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, Renderer2 } from '@angular/core';
 import * as d3 from 'd3';
+import { Subscription } from 'rxjs';
 import { BarChartItem } from './bar-chart-item';
 
 @Component({
@@ -147,8 +136,19 @@ export class BarChartComponent implements OnInit, OnDestroy, OnChanges {
                 return height - yVal;
             })
             .on('mouseover', function(d) {
-                tooltipDiv.html('<ul style="max-height: ' + (height - 10) + 'px;">'
-                        + d.patterns.map(pattern => '<li>' + pattern.name + '</li>').join('') + '</ul>');
+                const maxItems = 4;
+                const numItems = d.patterns.length;
+                const numLinesToShow = (numItems <= maxItems) ? numItems : maxItems;
+                const listItems = d.patterns.slice(0, numLinesToShow).map((pattern) => `<li>${pattern.name}</li>`).join('');
+                let innerHtml = '<ul style="max-height: ' + (height - 10) + 'px;">' + listItems;
+                if (numItems !== numLinesToShow) {
+                   const numItemsHidden = numItems - numLinesToShow;
+                   if (numItemsHidden > 0) {
+                       innerHtml += `<li>...and ${numItemsHidden} more</li>`;
+                   }
+                }
+                innerHtml += '</ul>';
+                tooltipDiv.html(innerHtml);
                 const ht: number = parseInt(tooltipDiv.style('height'), 10);
                 const widthOffset = 2 * x.bandwidth() - 15;
                 const scrollOffset = graphElement.property('scrollLeft');

--- a/src/app/threat-dashboard/export/export.component.html
+++ b/src/app/threat-dashboard/export/export.component.html
@@ -1,6 +1,10 @@
 <p class="mat-subheader">
     Copy and paste STIX JSON for this work product
+    <button *ngIf="jsonText" mat-icon-button color="primary" ngxClipboard [cbContent]="jsonText" (cbOnError)="onCopy($event, copiedTooltip)" (cbOnSuccess)="onCopy($event, copiedTooltip)">
+        <mat-icon>content_copy</mat-icon>
+        <div #copiedTooltip="matTooltip" matTooltip="{{ copyText || '...' }}" matTooltipPosition="after" class="inlineBlock"></div>
+      </button>
 </p>
 <pre>
-    {{generateJson()}}
+    {{jsonText}}
 </pre>

--- a/src/app/threat-dashboard/export/export.component.ts
+++ b/src/app/threat-dashboard/export/export.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, Input, OnDestroy } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
-import { Subscription ,  Observable } from 'rxjs';
-
-import { Constance } from '../../utils/constance';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { MatTooltip } from '../../../../node_modules/@angular/material/tooltip';
 import { ThreatReport } from '../models/threat-report.model';
 
 @Component({
@@ -11,20 +10,24 @@ import { ThreatReport } from '../models/threat-report.model';
   styleUrls: ['./export.component.scss']
 })
 export class ExportComponent implements OnInit, OnDestroy {
-  @Input()
-  public threatReport: ThreatReport;
+  @Input() public threatReport: ThreatReport;
+  public copyText: string;
+  public jsonText: string;
 
-  public readonly subscriptions: Subscription[] = [];
+  private readonly FLASH_TOOLTIP_TIMER = 500;
+  private readonly subscriptions: Subscription[] = [];
 
   constructor(
-    protected router: Router,
     protected route: ActivatedRoute,
+    protected router: Router,
   ) { }
 
   /**
    * @description init this component
    */
-  public ngOnInit() { }
+  public ngOnInit() {
+    this.jsonText = this.generateJson();
+  }
 
   /**
    * @description 
@@ -36,10 +39,35 @@ export class ExportComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * @description
+   * @description take this components threat report and JSON stringify
    */
   public generateJson(): string {
     return JSON.stringify(this.threatReport, undefined, 2);
+  }
+
+  /**
+   * @description flash a tool tip stating if the copy succeeded or failed
+   * @param  {{isSuccess:true}} event
+   * @param  {MatTooltip} toolTip
+   * @returns void
+   */
+  public onCopy(event: { isSuccess: true }, toolTip: MatTooltip): void {
+    if (!event.isSuccess) {
+      this.copyText = 'Copy Failed';
+    } else {
+      this.copyText = 'Copied';
+    }
+    this.flashTooltip(toolTip);
+  }
+
+  /**
+   * @description flash a tool tip stating if the copy succeeded or failed
+   * @param  {MatTooltip} toolTip
+   * @returns void
+   */
+  public flashTooltip(toolTip: MatTooltip): void {
+    toolTip.show();
+    setTimeout(() => toolTip.hide(), this.FLASH_TOOLTIP_TIMER);
   }
 
 }

--- a/src/app/threat-dashboard/threat-dashboard.module.ts
+++ b/src/app/threat-dashboard/threat-dashboard.module.ts
@@ -3,23 +3,23 @@ import { PlatformModule } from '@angular/cdk/platform';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, MatDialogModule, MatExpansionModule, 
-  MatFormFieldModule, MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatNativeDateModule, MatPaginatorModule, MatProgressBarModule, 
-  MatSelectModule, MatSlideToggleModule, MatSnackBarModule, MatStepperModule, MatTableModule, MatTabsModule, MatTooltipModule } from '@angular/material';
+import { 
+  MatButtonModule, MatCardModule, MatCheckboxModule, MatChipsModule, MatDatepickerModule, MatDialogModule, MatExpansionModule, 
+  MatFormFieldModule, MatIconModule, MatInputModule, MatListModule, MatMenuModule, MatNativeDateModule, MatPaginatorModule, 
+  MatProgressBarModule, MatSelectModule, MatSlideToggleModule, MatSnackBarModule, MatStepperModule, MatTableModule, 
+  MatTabsModule, MatTooltipModule 
+} from '@angular/material';
 import { CarouselModule } from 'primeng/components/carousel/carousel';
+import { ClipboardModule } from 'ngx-clipboard';
 import { GlobalModule } from '../global/global.module';
 import { BarChartComponent } from './bar-chart/bar-chart.component';
 import { CollapsibleTreeComponent } from './collapsible-tree/collapsible-tree.component';
 import { ExportComponent } from './export/export.component';
 import { RadarChartComponent } from './radar-chart/radar-chart.component';
-import { ReportTranslationService } from './services/report-translation.service';
-import { ThreatReportOverviewService } from './services/threat-report-overview.service';
-import { ThreatReportSharedService } from './services/threat-report-shared.service';
 import { ThreatDashboardComponent } from './threat-dashboard.component';
 import { routing } from './threat-dashboard.routing';
 import { ReportEditorComponent } from './threat-report-editor/report-editor/report-editor.component';
 import { ReportImporterComponent } from './threat-report-editor/report-importer/report-importer.component';
-import { ReportUploadService } from './threat-report-editor/report-importer/report-upload.service';
 import { ThreatReportEditorComponent } from './threat-report-editor/threat-report-editor.component';
 import { ThreatReportNavigateGuard } from './threat-report-navigate.guard';
 import { ThreatTacticsComponent } from './threat-tactics/threat-tactics.component';
@@ -80,6 +80,7 @@ const primengModules = [
     ReactiveFormsModule,
     ...materialModules,
     ...primengModules,
+    ClipboardModule,
     GlobalModule,
     routing,
   ],

--- a/src/app/threat-dashboard/threat-report-editor/report-editor/report-editor.component.ts
+++ b/src/app/threat-dashboard/threat-report-editor/report-editor/report-editor.component.ts
@@ -1,10 +1,9 @@
 
-import { of as observableOf,  Observable  } from 'rxjs';
-
-import { map, pluck, take } from 'rxjs/operators';
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { Store } from '@ngrx/store';
+import { Observable, of as observableOf } from 'rxjs';
+import { map, pluck, take } from 'rxjs/operators';
 import { AttackPatternService } from '../../../core/services/attack-pattern.service';
 import { GenericApi } from '../../../core/services/genericapi.service';
 import { AttackPattern } from '../../../models/attack-pattern';
@@ -39,43 +38,48 @@ export class ReportEditorComponent implements OnInit, OnDestroy {
     private readonly subscriptions = [];
 
     constructor(
-        public dialogRef: MatDialogRef<any>,
-        @Inject(MAT_DIALOG_DATA) public data: Report,
+        @Inject(MAT_DIALOG_DATA) protected data: Report,
         protected attackPatternService: AttackPatternService,
+        protected dialogRef: MatDialogRef<any>,
         protected genericApiService: GenericApi,
         protected userStore: Store<AppState>,
     ) { }
 
     ngOnInit() {
         const getUser$ = this.userStore
-            .select('users').pipe(
-            pluck('userProfile'),
-            take(1))
-            .subscribe((user: UserProfile) => {
-                this.user = user;
-                // start loading the full list of attack patterns
-                const sub$ = this.loadAttackPatterns().pipe(
-                    map((arr) => arr.sort(this.genAttackPatternSorter())))
-                    .subscribe(
-                        (val) => {
-                            this.attackPatterns = val;
-                            // convert our report patterns to a list containing the already-selected attack patterns
-                            this.reportPatterns = val
-                                .filter(pattern => this.report.attributes.object_refs.includes(pattern.id))
-                                .map(pattern => {
-                                    return {
-                                        id: pattern.id,
-                                        name: pattern.attributes.name
-                                    };
-                                });
-                        },
-                        (err) => console.log(err),
-                        () => this.loading = false
-                    );
-                this.subscriptions.push(sub$);
-                this.initializeReport(this.data);
-            },
-                (err) => console.log(err));
+            .select('users')
+            .pipe(
+                pluck('userProfile'),
+                take(1)
+            ).subscribe(
+                (user: UserProfile) => {
+                    this.user = user;
+                    // start loading the full list of attack patterns
+                    const sub$ = this.loadAttackPatterns()
+                        .pipe(
+                            map((arr) => arr.sort(this.genAttackPatternSorter()))
+                        )
+                        .subscribe(
+                            (val) => {
+                                this.attackPatterns = val;
+                                // convert our report patterns to a list containing the already-selected attack patterns
+                                this.reportPatterns = val
+                                    .filter((pattern) => this.report.attributes.object_refs.includes(pattern.id))
+                                    .map((pattern) => {
+                                        return {
+                                            id: pattern.id,
+                                            name: pattern.attributes.name
+                                        };
+                                    });
+                            },
+                            (err) => console.log(err),
+                            () => this.loading = false
+                        );
+                    this.subscriptions.push(sub$);
+                    this.initializeReport(this.data);
+                },
+                (err) => console.log(err)
+            );
         this.subscriptions.push(getUser$);
     }
 
@@ -90,8 +94,10 @@ export class ReportEditorComponent implements OnInit, OnDestroy {
 
         const userFramework = (this.user && this.user.preferences && this.user.preferences.killchain)
             ? this.user.preferences.killchain : '';
-        return this.attackPatternService.fetchAttackPatterns1(userFramework).pipe(
-            map((el) => this.attackPatterns = el));
+        return this.attackPatternService.fetchAttackPatterns1(userFramework)
+            .pipe(
+                map((el) => this.attackPatterns = el)
+            );
     }
 
     /**
@@ -167,7 +173,7 @@ export class ReportEditorComponent implements OnInit, OnDestroy {
         if (!patternId) {
             return;
         }
-        this.reportPatterns = this.reportPatterns.filter(pattern => pattern.id !== patternId);
+        this.reportPatterns = this.reportPatterns.filter((pattern) => pattern.id !== patternId);
     }
 
     /**
@@ -202,7 +208,7 @@ export class ReportEditorComponent implements OnInit, OnDestroy {
         if (this.isValid()) {
             const attribs = this.report.attributes;
             attribs.modified = new Date();
-            attribs.object_refs = this.reportPatterns.map(pattern => pattern.id);
+            attribs.object_refs = this.reportPatterns.map((pattern) => pattern.id);
             if (!this.editing) {
                 this.report.id = attribs.id = undefined;
                 this.report.type = 'report';

--- a/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.html
+++ b/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.html
@@ -23,6 +23,45 @@
             <input #fileUpload id="fileInput" name="file" type="file" class="hide" ([value])="fName" (change)="fileChanged($event)">
         </div>
 
+        <div class="col-xs-12 col-sm-12 fadeIn" *ngIf="imports.data.length">
+            <mat-table #table id="imported-reports-table" [dataSource]="imports">
+                <ng-container matColumnDef="title">
+                    <mat-header-cell *matHeaderCellDef> Title </mat-header-cell>
+                    <mat-cell *matCellDef="let report" class="flexCol">
+                        <span class="flex0 full-width" *ngIf="report.attributes.external_references[0].url">
+                            <a href="{{report.attributes.external_references[0].url}}" target="_blank">
+                                {{report.attributes.title || report.attributes.name}}
+                                <mat-icon aria-label="visit report">open_in_new</mat-icon>
+                            </a>
+                        </span>
+                        <span class="flex0 full-width mat-caption text-muted text-fadeable"> {{report.attributes.description}} </span>
+                    </mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="author">
+                    <mat-header-cell *matHeaderCellDef> Author </mat-header-cell>
+                    <mat-cell *matCellDef="let report">
+                        <span class="mat-caption"> {{ resolveIdentityIdToName(report.attributes.created_by_ref) }} </span>
+                    </mat-cell>
+                </ng-container>
+                <ng-container matColumnDef="date">
+                    <mat-header-cell *matHeaderCellDef> Modified Date </mat-header-cell>
+                    <mat-cell *matCellDef="let report" [style.color]="report.color">
+                        <span class="mat-caption"> {{report.attributes.modified | date:'medium' }} </span>
+                    </mat-cell>
+                </ng-container>
+                <ng-container matColumnDef='actions'>
+                    <mat-header-cell *matHeaderCellDef> </mat-header-cell>
+                    <mat-cell *matCellDef="let report">
+                        <button mat-icon-button class="mat-24" color="warn" matTooltip="Drop Report" (click)="onDropReport(report, $event)">
+                            <mat-icon aria-label="exclude report from work product">remove_circle</mat-icon>
+                        </button>
+                    </mat-cell>
+                </ng-container>
+                <mat-header-row *matHeaderRowDef="displayColumns; sticky: true"></mat-header-row>
+                <mat-row *matRowDef="let report; columns: displayColumns;"></mat-row>
+            </mat-table>
+        </div>
+
         <div class="col-xs-12 col-sm-12 mt-18 imports-title">
             Option 2: Import by URL
             <button mat-icon-button id="uploadButton" class="mat-24" matTooltip="Upload a new report from a external system URL" (click)="shouldShowUrlInput = !shouldShowUrlInput"
@@ -35,7 +74,7 @@
                     <mat-form-field class="full-width">
                         <input matInput placeholder="Load Report" formControlName="url">
                     </mat-form-field>
-                    <button mat-raised-button [disabled]="loadReportByUrlForm.pristine" type="submit">Load</button>
+                    <button mat-raised-button [disabled]="!loadReportByUrlForm.valid" type="submit">Load</button>
                 </form>
         </div>
 
@@ -56,7 +95,7 @@
                 <ng-container matColumnDef="author">
                     <mat-header-cell *matHeaderCellDef> Author </mat-header-cell>
                     <mat-cell *matCellDef="let report">
-                        <span class="mat-caption"> {{report.attributes.created_by_ref}} </span>
+                        <span class="mat-caption"> {{ resolveIdentityIdToName(report.attributes.created_by_ref) }} </span>
                     </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="date">
@@ -72,42 +111,6 @@
                             <mat-icon aria-label="include report in work product">add_circle</mat-icon>
                         </button>
                         <button mat-icon-button *ngIf="isReportSelected(report)" class="mat-24" color="warn" matTooltip="Deselect Report" (click)="onDeselectReport(report, $event)">
-                            <mat-icon aria-label="exclude report from work product">remove_circle</mat-icon>
-                        </button>
-                    </mat-cell>
-                </ng-container>
-                <mat-header-row *matHeaderRowDef="displayColumns; sticky: true"></mat-header-row>
-                <mat-row *matRowDef="let report; columns: displayColumns;"></mat-row>
-            </mat-table>
-        </div>
-
-        <div class="col-xs-12 col-sm-12 fadeIn" *ngIf="imports.data.length">
-            <mat-table #table id="imported-reports-table" [dataSource]="imports">
-                <ng-container matColumnDef="title">
-                    <mat-header-cell *matHeaderCellDef> Title </mat-header-cell>
-                    <mat-cell *matCellDef="let report">
-                        <a href="{{report.attributes.external_references[0].url}}" class="report-name" target="_blank">
-                            {{report.attributes.title || report.attributes.name}}
-                        </a>
-                        <span class="mat-caption text-muted"> {{report.attributes.description}} </span>
-                    </mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="author">
-                    <mat-header-cell *matHeaderCellDef> Author </mat-header-cell>
-                    <mat-cell *matCellDef="let report">
-                        <span class="mat-caption"> {{report.attributes.created_by_ref}} </span>
-                    </mat-cell>
-                </ng-container>
-                <ng-container matColumnDef="date">
-                    <mat-header-cell *matHeaderCellDef> Modified Date </mat-header-cell>
-                    <mat-cell *matCellDef="let report" [style.color]="report.color">
-                        <span class="mat-caption"> {{report.attributes.modified | date:'medium' }} </span>
-                    </mat-cell>
-                </ng-container>
-                <ng-container matColumnDef='actions'>
-                    <mat-header-cell *matHeaderCellDef> </mat-header-cell>
-                    <mat-cell *matCellDef="let report">
-                        <button mat-icon-button class="mat-24" color="warn" matTooltip="Drop Report" (click)="onDropReport(report, $event)">
                             <mat-icon aria-label="exclude report from work product">remove_circle</mat-icon>
                         </button>
                     </mat-cell>
@@ -136,7 +139,7 @@
                 <ng-container matColumnDef="author">
                     <mat-header-cell *matHeaderCellDef> Author </mat-header-cell>
                     <mat-cell *matCellDef="let report">
-                        <span class="mat-caption"> {{report.attributes.created_by_ref}} </span>
+                        <span class="mat-caption"> {{ resolveIdentityIdToName(report.attributes.created_by_ref) }} </span>
                     </mat-cell>
                 </ng-container>
                 <ng-container matColumnDef="date">
@@ -160,7 +163,7 @@
                 <mat-row *matRowDef="let report; columns: displayColumns;"></mat-row>
             </mat-table>
             <!-- [showFirstLastButtons]="true" property caused error in tests and webapp? is this a new property and our lib is old? -->
-            <mat-paginator #paginator [length]="curDisplayLen | async" [pageIndex]="0" [pageSize]="5" [pageSizeOptions]="[5, 10, 25, 100]"
+            <mat-paginator #paginator [length]="currents.curDisplayLen$ | async" [pageIndex]="0" [pageSize]="5" [pageSizeOptions]="[5, 10, 25, 100]"
                 (page)="onPage($event)">
             </mat-paginator>
         </div>

--- a/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.scss
+++ b/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.scss
@@ -96,7 +96,11 @@
 
 }
 
-#current-reports-table {
+#imported-reports-table, #current-reports-table {
     height: 35vh;
     overflow-y: auto;
+}
+
+loading-spinner ::ng-deep .loadingContainer {
+    height: 200px;
 }

--- a/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.spec.ts
+++ b/src/app/threat-dashboard/threat-report-editor/report-importer/report-importer.component.spec.ts
@@ -1,7 +1,8 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogModule, MatDialogRef, MatIconModule, MatPaginatorModule, MatProgressSpinnerModule, MatSnackBarModule, MatTableModule, MAT_DIALOG_DATA, MatFormFieldModule } from '@angular/material';
+import { MatDialogModule, MatDialogRef, MatFormFieldModule, MatIconModule, MatInputModule, MatPaginatorModule, MatProgressSpinnerModule, MatSnackBarModule, MatTableModule, MAT_DIALOG_DATA } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Observable, of as observableOf } from 'rxjs';
 import * as UUID from 'uuid';
 import { GenericApi } from '../../../core/services/genericapi.service';
@@ -60,6 +61,7 @@ describe('ReportImporterComponent', () => {
             MatDialogModule,
             MatFormFieldModule,
             MatIconModule,
+            MatInputModule,
             MatPaginatorModule,
             MatProgressSpinnerModule,
             MatSnackBarModule,
@@ -69,6 +71,7 @@ describe('ReportImporterComponent', () => {
         TestBed.configureTestingModule({
             declarations: [ReportImporterComponent, LoadingSpinnerComponent],
             imports: [
+                NoopAnimationsModule,
                 HttpClientTestingModule,
                 FormsModule,
                 ReactiveFormsModule,
@@ -119,41 +122,42 @@ describe('ReportImporterComponent', () => {
         expect(component.imports.data[0]).toBe(import2);
     });
 
-    it('should load, select, and deselect existing reports', () => {
-        let goodReport, badReport;
+    it('should load, select, and deselect existing reports', fakeAsync(() => {
         component.load(goodReportID);
         component.currents.reports$.subscribe((reports) => {
             expect(reports.length).toBe(6);
-            goodReport = reports.find(report => report.id === goodReportID);
-            badReport = reports.find(report => report.id === badReportID);
+            const goodReport = reports.find(report => report.id === goodReportID);
+            const badReport = reports.find(report => report.id === badReportID);
+            expect(goodReport).toBeDefined();
+            expect(badReport).toBeDefined();
+
+            // select a report
+            expect(component.isReportSelected(goodReport)).toBeFalsy();
+            expect(component.isReportSelected(badReport)).toBeFalsy();
+            expect(component.selections.size).toBe(0);
+            component.onSelectReport(goodReport);
+            expect(component.selections.size).toBe(1);
+            expect(component.isReportSelected(goodReport)).toBeTruthy();
+            expect(component.isReportSelected(badReport)).toBeFalsy();
+
+            // try to select it again
+            component.onSelectReport(goodReport);
+            expect(component.selections.size).toBe(1);
+            expect(component.isReportSelected(goodReport)).toBeTruthy();
+            expect(component.isReportSelected(badReport)).toBeFalsy();
+
+            // select another one
+            component.onSelectReport(badReport);
+            expect(component.selections.size).toBe(2);
+            expect(component.isReportSelected(goodReport)).toBeTruthy();
+            expect(component.isReportSelected(badReport)).toBeTruthy();
+
+            // deselect the first report
+            component.onDeselectReport(goodReport);
+            expect(component.selections.size).toBe(1);
+            expect(component.isReportSelected(goodReport)).toBeFalsy();
+            expect(component.isReportSelected(badReport)).toBeTruthy();
         });
-
-        // select a report
-        expect(component.isReportSelected(goodReport)).toBeFalsy();
-        expect(component.isReportSelected(badReport)).toBeFalsy();
-        expect(component.selections.size).toBe(0);
-        component.onSelectReport(goodReport);
-        expect(component.selections.size).toBe(1);
-        expect(component.isReportSelected(goodReport)).toBeTruthy();
-        expect(component.isReportSelected(badReport)).toBeFalsy();
-
-        // try to select it again
-        component.onSelectReport(goodReport);
-        expect(component.selections.size).toBe(1);
-        expect(component.isReportSelected(goodReport)).toBeTruthy();
-        expect(component.isReportSelected(badReport)).toBeFalsy();
-
-        // select another one
-        component.onSelectReport(badReport);
-        expect(component.selections.size).toBe(2);
-        expect(component.isReportSelected(goodReport)).toBeTruthy();
-        expect(component.isReportSelected(badReport)).toBeTruthy();
-
-        // deselect the first report
-        component.onDeselectReport(goodReport);
-        expect(component.selections.size).toBe(1);
-        expect(component.isReportSelected(goodReport)).toBeFalsy();
-        expect(component.isReportSelected(badReport)).toBeTruthy();
-    });
+    }));
 
 });

--- a/src/app/threat-dashboard/threat-report-editor/report-importer/report-upload.service.ts
+++ b/src/app/threat-dashboard/threat-report-editor/report-importer/report-upload.service.ts
@@ -9,7 +9,7 @@ import { Constance } from '../../../utils/constance';
 
 @Injectable({
     providedIn: 'root',
-  })
+})
 export class ReportUploadService {
     private data: any = null;
     private headers: HttpHeaders;
@@ -36,19 +36,21 @@ export class ReportUploadService {
             reportProgress: true,
             headers
         });
-        return this.http.request<Array<JsonApiObject<Report>>>(req).pipe(
-            map((event) => {
-                if (event.type === HttpEventType.UploadProgress) {
-                    const percentDone = Math.round(100 * event.loaded / event.total);
-                    console.log(`File is ${percentDone}% uploaded`);
-                } else if (event instanceof HttpResponse) {
-                    console.log('File is completly uploaded');
-                    return event;
-                }
-            }),
-            map((event) => (event instanceof HttpResponse) ? event.body : []),
-            map((reports) => reports.map((report) => report.data)),
-            catchError(this.handleError));
+        return this.http.request<Array<JsonApiObject<Report>>>(req)
+            .pipe(
+                map((event) => {
+                    if (event.type === HttpEventType.UploadProgress) {
+                        const percentDone = Math.round(100 * event.loaded / event.total);
+                        console.log(`File is ${percentDone}% uploaded`);
+                    } else if (event instanceof HttpResponse) {
+                        console.log('File is completly uploaded');
+                        return event;
+                    }
+                }),
+                map((event) => (event instanceof HttpResponse) ? event.body : []),
+                map((reports) => reports.map((report) => report.data)),
+                catchError(this.handleError)
+            );
     }
 
     /**


### PR DESCRIPTION
supports unfetter-discover/unfetter#1245

## changes
fixed some minor styles
shorter tooltips in bar chart
copy to clipboard button in export tab
no longer show form validation error on successful load report by url
resolved created_by_ref ids to readable label
apply unfetter open identity to all new import reports

## test
pull this feature
visit the threat dashboard
hover over the bar chart
edit the work product
submit a load report by url, verify the input box is not red after successful submit

see screen shots

![screen shot 2018-07-19 at 4 09 51 pm](https://user-images.githubusercontent.com/30807406/42972120-f9f0229e-8b9d-11e8-8d9f-78661c73a4e1.png)

![screen shot 2018-07-19 at 4 09 26 pm](https://user-images.githubusercontent.com/30807406/42972130-03b8272c-8b9e-11e8-8df9-96da703f37e0.png)

![screen shot 2018-07-19 at 4 10 29 pm](https://user-images.githubusercontent.com/30807406/42972136-08e97ebc-8b9e-11e8-9463-c09df55cd0f2.png)



