### PR TITLE
Issue 1237/blsidebar

### DIFF
--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -95,7 +95,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 capabilities: [...action.payload],
             });
         case baselineActions.ADD_CAPABILITY_TO_BASELINE:
-            const capList1 = state.baselineCapabilities;
+            const capList1 = [...state.baselineCapabilities];
             capList1.push(action.payload);
             return genAssessState({
                 ...state,
@@ -104,7 +104,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
         case baselineActions.REPLACE_CAPABILITY_IN_BASELINE:
             const oldCap = action.payload[0];
             const newCap = action.payload[1];    
-            const capList2 = state.baselineCapabilities;
+            const capList2 = [...state.baselineCapabilities];
             const replIndex = capList2.indexOf(oldCap);
             capList2[replIndex] = newCap;
             return genAssessState({
@@ -112,7 +112,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 baselineCapabilities: capList2,
             });
         case baselineActions.REMOVE_CAPABILITY_FROM_BASELINE:
-            const capList3 = state.baselineCapabilities;
+            const capList3 = [...state.baselineCapabilities];
             const remIndex = capList3.indexOf(action.payload);
             capList3.splice(remIndex, 1);
             return genAssessState({
@@ -130,7 +130,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 currentCapability: action.payload,
             });
         case baselineActions.ADD_OBJECT_ASSESSMENT:
-            const objAssessments = state.baselineObjAssessments;
+            const objAssessments = [...state.baselineObjAssessments];
             objAssessments.push(action.payload);
             return genAssessState({
                 ...state,
@@ -142,7 +142,7 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
             // Add object assessment to baseline and list of object assessments in this baseline
             const currBaseline = state.baseline;
             currBaseline.assessments.push(objAssessment.id);
-            const objAssessments2 = state.baselineObjAssessments;
+            const objAssessments2 = [...state.baselineObjAssessments];
             objAssessments2.push(objAssessment);
 
             return genAssessState({

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.html
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.html
@@ -13,7 +13,8 @@
               <form>
                 <mat-form-field class="full-width">
                   <mat-select #existingCapability name="existingCapability" (selectionChange)="updateCapability(existingCapability, i)" [value]="selectedCapability(existingCapability, i)">
-                    <mat-option *ngFor="let capability of allCapabilities | sortByField:'name':'ascending'" [value]="capability">
+                    <mat-option *ngFor="let capability of getCapabilities(currentCapabilityGroup) | sortByField:'name':'ascending'"
+                                [disabled]="getCapabilityDisabled(capability)" [value]="capability">
                       {{ capability.name }}
                     </mat-option>
                   </mat-select>
@@ -33,7 +34,8 @@
           <form>
             <mat-form-field class="full-width">
               <mat-select #newCapability name="newCapability" (selectionChange)="updateCapability(newCapability, -1)">
-                <mat-option *ngFor="let capability of getCapabilities(currentCapabilityGroup) | sortByField:'name':'ascending'" [value]="capability">
+                <mat-option *ngFor="let capability of getCapabilities(currentCapabilityGroup) | sortByField:'name':'ascending'"
+                            [disabled]="getCapabilityDisabled(capability)" [value]="capability">
                   {{ capability.name }}
                 </mat-option>
               </mat-select>

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
@@ -21,9 +21,7 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   public currentCapabilityGroup: Category;
   public selectedCapabilities: Capability[] = [];
   public allCapabilities: Capability[];
-  public availableCapabilities: Capability[];
   private baselineCapabilities: Capability[] = [];
-  private baselineObjAssessments: ObjectAssessment[] = [];
 
   private subscriptions: Subscription[] = [];
 
@@ -52,7 +50,7 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
       .subscribe(
         (currentCapabilityGroup: Category) => {
           this.currentCapabilityGroup = currentCapabilityGroup;
-          this.updateCapLists();
+          this.updateCapList();
         },
         (err) => console.log(err));
 
@@ -63,21 +61,11 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
       .subscribe(
         (baselineCapabilities: any[]) => {
           this.baselineCapabilities = (baselineCapabilities) ? baselineCapabilities.slice() : [];
-          this.updateCapLists();
+          this.updateCapList();
         },
         (err) => console.log(err));
 
-    const capSub4$ = this.wizardStore
-      .select('baseline').pipe(
-      pluck('baselineObjAssessments'),
-      distinctUntilChanged())
-      .subscribe(
-        (objAssessments: any[]) => {
-          this.baselineObjAssessments = objAssessments;
-        },
-        (err) => console.log(err));
-
-    this.subscriptions.push(capSub1$, capSub2$, capSub3$, capSub4$);
+    this.subscriptions.push(capSub1$, capSub2$, capSub3$);
   }
 
   ngAfterViewInit() {
@@ -178,7 +166,7 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
     return true;
   }
 
-  /** 
+    /** 
    * Returns only those capabilities which are specific to current category
    * @return {any[]}
    */
@@ -196,16 +184,20 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
       .sort();
   }
 
-  private updateCapLists(): void {
+  private updateCapList(): void {
     if (this.currentCapabilityGroup) {
       this.selectedCapabilities = this.baselineCapabilities.filter((cap) =>
                           cap.category === this.currentCapabilityGroup.id);
-      this.availableCapabilities = this.allCapabilities.filter((capability) =>
-                          capability.category === this.currentCapabilityGroup.id &&
-                          this.selectedCapabilities.findIndex((cap) => cap.id === capability.id) === -1);
     } else {
       this.selectedCapabilities = [];
     }
   }
 
+  private shouldCapabilityBeDisabled(capability: Capability) {
+    return this.selectedCapabilities.findIndex((cap) => cap.id === capability.id) !== -1;
+  }
+
+  public getCapabilityDisabled(capability: Capability) {
+    return (this.shouldCapabilityBeDisabled(capability) ? 'true' : 'false');
+  }
 }

--- a/src/app/baseline/wizard/category/category.component.html
+++ b/src/app/baseline/wizard/category/category.component.html
@@ -24,21 +24,22 @@
           </div>
         </div>
       </div>
-      <div class="row margin-bottom" *ngFor="let selCategory of selectedCapabilityGroups; index as i; trackBy: trackByFn">
+      <div class="row margin-bottom" *ngFor="let selCategory of selectedCategories; index as i; trackBy: trackByFn">
         <div class="col-xs-12">
           <div class="row">
             <div class="col-xs-10">
               <form>
                 <mat-form-field class="full-width">
                   <mat-select #existingCategory name="existingCategory" (selectionChange)="updateCategory(existingCategory, i)" [value]="selectedCategory(existingCategory, i)">
-                    <mat-option *ngFor="let category of categories | sortByField:'name':'ascending'" [value]="category">
+                    <mat-option *ngFor="let category of categories | sortByField:'name':'ascending'"
+                                [disabled]="getCategoryDisabled(category)" [value]="category">
                       {{ category.name }}
                     </mat-option>
                   </mat-select>
                 </mat-form-field>
               </form>
             </div>
-            <div class="col-xs-1" [hidden]="selectedCapabilityGroups.length === 0">
+            <div class="col-xs-1" [hidden]="selectedCategories.length === 0">
               <button mat-icon-button (click)="onDeleteCategory(existingCategory)">
                 <mat-icon class="mat-24">delete</mat-icon>
               </button>
@@ -51,7 +52,8 @@
           <form>
             <mat-form-field class="full-width">
               <mat-select #newCategory name="newCategory" (selectionChange)="updateCategory(newCategory, -1)">
-                <mat-option *ngFor="let category of categories | sortByField:'name':'ascending'" [value]="category">
+                <mat-option *ngFor="let category of categories | sortByField:'name':'ascending'"
+                            [disabled]="getCategoryDisabled(category)" [value]="category">
                   {{ category.name }}
                 </mat-option>
               </mat-select>

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -125,7 +125,7 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
     const newCategoryName = option.selected.value;
 
     // Verify a selection and that this category doesn't already exist
-    const indexInList = this.selectedCapabilityGroups.indexOf(newCategoryName);
+    const indexInList = this.selectedCapabilityGroups.findIndex((category) => category.id === newCategoryName.id);
     if (indexInList < 0 && option.value !== CategoryComponent.DEFAULT_VALUE) {
       if (index === -1) {
         this.selectedCapabilityGroups.push(newCategoryName);

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -198,7 +198,8 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
       const sub12$ = this.wizardStore
         .select('baseline').pipe(
-        pluck('baselineCapabilities'))
+        pluck('baselineCapabilities'),
+        distinctUntilChanged())
         .subscribe(
           (capabilities: Capability[]) => {
             this.baselineCapabilities = (capabilities) ? capabilities.slice() : [];

--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -1,4 +1,6 @@
-<mat-toolbar color="primary" id="navComponent" class="mat-elevation-z4" [ngClass]="{ 'demoMode': demoMode === true }" [style.top]="topPx">
+<mat-toolbar id="navComponent" class="mat-elevation-z4" [ngClass]="{ 'demoMode': demoMode === true }"
+      [style.top]="topPx" color="primary">
+
   <a [routerLink]=" ['./'] " routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="flex">
     <header-logo [title]="title"></header-logo>  
   </a>
@@ -11,14 +13,23 @@
 
   <span class="flex1">&nbsp;</span>
 
-  <button id="login-button" mat-raised-button *ngIf="!demoMode && !authService.loggedIn()"
-      [matMenuTriggerFor]="loginMenu" color="accent">Sign In / Register</button>
-  <mat-menu #loginMenu="matMenu" class="login-options" [overlapTrigger]="false">
-    <a *ngFor="let service of authServices" mat-button color="primary" href="/api/auth/{{service}}-login">
-      <img src="assets/images/logos/{{service}}.png" width="32" height="32">
-      <span class="login-option">... Using {{service | capitalize}}</span>
-    </a>
-  </mat-menu>
+  <ng-container *ngIf="!demoMode && !authService.loggedIn()">
+    <ng-container *ngIf="authServices.length === 1">
+      <a href="/api/auth/{{authServices[0]}}-login/">
+        <button id="login-button" mat-raised-button color="accent">Sign In / Register</button>
+      </a>
+    </ng-container>
+    <ng-container *ngIf="authServices.length > 1">
+      <button id="login-button" mat-raised-button *ngIf="!demoMode && !authService.loggedIn()"
+          [matMenuTriggerFor]="loginMenu" color="accent">Sign In / Register</button>
+      <mat-menu #loginMenu="matMenu" class="login-options" [overlapTrigger]="false">
+        <a *ngFor="let service of authServices" mat-button color="primary" href="/api/auth/{{service}}-login">
+          <img src="assets/images/logos/{{service}}.png" width="32" height="32">
+          <span class="login-option">... Using {{service | capitalize}}</span>
+        </a>
+      </mat-menu>
+    </ng-container>
+  </ng-container>
 
   <span *ngIf="authService.loggedIn() && user$ | async as user" class="flex flexItemsCenter">   
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1237

Duplicate categories (capability groups) and capabilities will be prevented in the baselines wizard.  Already-selected groups and capabilities will still appear in the dropdowns on these screens, but selecting them will do nothing and will not accept them as selected.

### To test:
1. Pull this branch
2. Create a new baseline
3. Select a group
4. Attempt to select the same group in the empty dropdown - it should not be accepted.
5. Do steps 3 and 4 for the capability screen
6. Save the baseline
7. Edit the baseline and attempt steps 3 through 5 to make sure the behavior is the same
