### PR TITLE
pending users org placement

### DIFF
--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { MatButtonModule, MatInputModule } from '@angular/material';
-import { FormsModule } from '@angular/forms';
+import { MatButtonModule, MatInputModule, MatSelectModule } from '@angular/material';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { routing } from './admin-routing.module';
 import { GlobalModule } from '../global/global.module';
 import { AdminService } from './admin.service';
@@ -20,6 +20,8 @@ import { CurrentUsersComponent } from './current-users/current-users.component';
         GlobalModule,
         routing,
         FormsModule,
+        ReactiveFormsModule,
+        MatSelectModule,
         MatButtonModule,
         MatInputModule,
         ChartsModule

--- a/src/app/admin/approve-users/approve-users.component.html
+++ b/src/app/admin/approve-users/approve-users.component.html
@@ -11,7 +11,8 @@
                     <th>Name</th>
                     <th>Email</th>
                     <th>Registration Note</th>
-                    <th>Req. Organization</th>
+                    <th>Requested Orgs</th>
+                    <th>Join Orgs</th>
                     <th class="text-right" id="actionHeader">Approve / Deny User</th>
                 </thead>
                 <tbody>
@@ -28,6 +29,13 @@
                             <span *ngIf="user.registrationInformation && user.registrationInformation.requestedOrganization">
                                 {{ user.registrationInformation.requestedOrganization }}
                             </span>
+                        </td>
+                        <td>
+                            <mat-form-field class="full-width">
+                                <mat-select [formControl]="orgCtrl" multiple="true">
+                                    <mat-option *ngFor="let org of orgs$ | async" [value]="org.id">{{ org.name }}</mat-option>
+                                </mat-select>
+                            </mat-form-field>
                         </td>
                         <td class="text-right">
                             <button mat-button class="mat-24" (click)="userAction(user, 'APPROVE_USER')">

--- a/src/app/admin/approve-users/approve-users.component.ts
+++ b/src/app/admin/approve-users/approve-users.component.ts
@@ -1,5 +1,14 @@
 import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { FormControl } from '@angular/forms';
+import { map } from 'rxjs/operators';
+
+import { getOrganizations } from '../../root-store/identities/identity.selectors';
 import { AdminService } from '../admin.service';
+import { AppState } from '../../root-store/app.reducers';
+import { Constance } from '../../utils/constance';
+import { RxjsHelpers } from '../../global/static/rxjs-helpers';
 
 @Component({
     selector: 'approve-users',
@@ -10,11 +19,21 @@ export class ApproveUsersComponent implements OnInit {
 
     public users: any[];
     public message: string;
+    public orgs$: Observable<any>;
+    public orgCtrl = new FormControl([]);
 
-    constructor(private adminService: AdminService) { }
+    constructor(
+        private store: Store<AppState>,
+        private adminService: AdminService
+    ) { }
 
     public ngOnInit() {
         this.fetchUsers();
+        this.orgs$ = this.store.select(getOrganizations)
+            .pipe(
+                map((orgs) => orgs.filter((org) => org.id !== Constance.UNFETTER_OPEN_ID)),
+                RxjsHelpers.sortByField('name')
+            );
     }
 
     public userAction(user, action: string) {
@@ -22,6 +41,13 @@ export class ApproveUsersComponent implements OnInit {
         switch (action) {
             case 'APPROVE_USER':
                 tempUser = { ...user, approved: true, locked: false };
+                tempUser.organizations = tempUser.organizations
+                    .concat(this.orgCtrl.value.map((id) => ({
+                        id,
+                        subscribed: true,
+                        approved: true,
+                        role: 'STANDARD_USER'
+                    })));
                 break;
             case 'DENY_USER':
                 tempUser = { ...user, approved: false, locked: true };
@@ -33,31 +59,31 @@ export class ApproveUsersComponent implements OnInit {
         let processUserApproval$ = this.adminService
             .changeUserStatus({ data: { attributes: tempUser } })
             .subscribe(
-            (res) => {
-                this.fetchUsers();
-                this.message = `${tempUser.userName} (${tempUser.lastName}, ${tempUser.firstName}) has been ${tempUser.approved ? 'approved' : 'denied'}.`;
-            },
-            (err) => {
-                console.log(err);
-            },
-            () => {
-                processUserApproval$.unsubscribe();
-            }
+                (res) => {
+                    this.fetchUsers();
+                    this.message = `${tempUser.userName} (${tempUser.lastName}, ${tempUser.firstName}) has been ${tempUser.approved ? 'approved' : 'denied'}.`;
+                },
+                (err) => {
+                    console.log(err);
+                },
+                () => {
+                    processUserApproval$.unsubscribe();
+                }
             );
     }
 
     private fetchUsers() {
         let getUsersPendingApproval$ = this.adminService.getUsersPendingApproval()
             .subscribe(
-            (users) => {
-                this.users = users;
-            },
-            (err) => {
-                console.log(err);
-            },
-            () => {
-                getUsersPendingApproval$.unsubscribe();
-            }
+                (users) => {
+                    this.users = users;
+                },
+                (err) => {
+                    console.log(err);
+                },
+                () => {
+                    getUsersPendingApproval$.unsubscribe();
+                }
             );
     }
 }

--- a/src/app/root-store/identities/identity.selectors.ts
+++ b/src/app/root-store/identities/identity.selectors.ts
@@ -1,0 +1,18 @@
+import { createSelector } from '@ngrx/store';
+import { Identity } from 'stix';
+
+import { AppState } from '../app.reducers';
+
+export const getIdentityState = (state: AppState) => state.identities;
+
+export const getOrganizations = createSelector(
+    getIdentityState,
+    (identityState): Identity[] => {
+        if (identityState && identityState.identities) {
+            return identityState.identities
+                .filter((identity) => identity.identity_class && identity.identity_class.toLowerCase() === 'organization');
+        } else {
+            return null;
+        }
+    }
+);


### PR DESCRIPTION
Requires `issue-1191` on `unfetter-ui` and `unfetter-store`.  Requires a 2nd GitHub/Lab account with an unapproved user (you can delete the user object for the 2nd account if needed)

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/235

Instructions:
- Register to Unfetter with the 2nd account
- With account 1, go to approve the user and use the new `Join Orgs` select to add the user to some orgs
- Log into Unfetter with the 2nd user, confirm you have a "Welcome to Unfetter!" notification that links to user settings, and that the orgs you selected with account 1 were assigned

fixes unfetter-discover/unfetter#1191
