### PR TITLE
Signs in without dropdown with singly-configured authentication service

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -1,4 +1,6 @@
-<mat-toolbar color="primary" id="navComponent" class="mat-elevation-z4" [ngClass]="{ 'demoMode': demoMode === true }" [style.top]="topPx">
+<mat-toolbar id="navComponent" class="mat-elevation-z4" [ngClass]="{ 'demoMode': demoMode === true }"
+      [style.top]="topPx" color="primary">
+
   <a [routerLink]=" ['./'] " routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="flex">
     <header-logo [title]="title"></header-logo>  
   </a>
@@ -11,14 +13,23 @@
 
   <span class="flex1">&nbsp;</span>
 
-  <button id="login-button" mat-raised-button *ngIf="!demoMode && !authService.loggedIn()"
-      [matMenuTriggerFor]="loginMenu" color="accent">Sign In / Register</button>
-  <mat-menu #loginMenu="matMenu" class="login-options" [overlapTrigger]="false">
-    <a *ngFor="let service of authServices" mat-button color="primary" href="/api/auth/{{service}}-login">
-      <img src="assets/images/logos/{{service}}.png" width="32" height="32">
-      <span class="login-option">... Using {{service | capitalize}}</span>
-    </a>
-  </mat-menu>
+  <ng-container *ngIf="!demoMode && !authService.loggedIn()">
+    <ng-container *ngIf="authServices.length === 1">
+      <a href="/api/auth/{{authServices[0]}}-login/">
+        <button mat-raised-button color="accent">Sign In / Register</button>
+      </a>
+    </ng-container>
+    <ng-container *ngIf="authServices.length > 1">
+      <button id="login-button" mat-raised-button *ngIf="!demoMode && !authService.loggedIn()"
+          [matMenuTriggerFor]="loginMenu" color="accent">Sign In / Register</button>
+      <mat-menu #loginMenu="matMenu" class="login-options" [overlapTrigger]="false">
+        <a *ngFor="let service of authServices" mat-button color="primary" href="/api/auth/{{service}}-login">
+          <img src="assets/images/logos/{{service}}.png" width="32" height="32">
+          <span class="login-option">... Using {{service | capitalize}}</span>
+        </a>
+      </mat-menu>
+    </ng-container>
+  </ng-container>
 
   <span *ngIf="authService.loggedIn() && user$ | async as user" class="flex flexItemsCenter">   
 

--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -16,7 +16,7 @@
   <ng-container *ngIf="!demoMode && !authService.loggedIn()">
     <ng-container *ngIf="authServices.length === 1">
       <a href="/api/auth/{{authServices[0]}}-login/">
-        <button mat-raised-button color="accent">Sign In / Register</button>
+        <button id="login-button" mat-raised-button color="accent">Sign In / Register</button>
       </a>
     </ng-container>
     <ng-container *ngIf="authServices.length > 1">


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1281.

- Edit `src/assets/config/local-settings.json` with at least two authServices (you can make up names, since we aren't testing any of the actual services; pre-recognized names are: "demo", "local", "ldap", "github" and "gitlab").

- If the stack is not up, start it. You do not need to restart it.

- If the web page is not up, bring it up. Otherwise, sign out, then refresh the page.

- Click the `Sign In` button. You should get a dropdown for each service you listed above. (You don't have to click one, but if you do, go ahead and sign back out.)

- Re-edit `src/assets/config/local-settings.json` and provide only one authService. Make it a real one, one that you actually set up on the back-end, like "github".

- Refresh the page. Click the `Sign In` button. No dropdown should appear; instead, you should get signed in. Your service avatar should appear in the upper right, as normal.