### PR TITLE
Issue 1291/oalistnoup

### DIFF
--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -18,11 +18,12 @@ export const SET_CAPABILITIES = '[Baseline] SET_CAPABILITIES';
 export const SET_BASELINE_CAPABILITIES = '[Baseline] SET_BASELINE_CAPABILITIES';
 export const ADD_CAPABILITY_TO_BASELINE = '[Baseline] ADD_CAPABILITY_TO_BASELINE';
 export const REPLACE_CAPABILITY_IN_BASELINE = '[Baseline] REPLACE_CAPABILITY_IN_BASELINE';
-export const REMOVE_CAPABILITY_FROM_BASELINE = '[Baseline] REMOVE_CAPABILITY_FROM_BASELINE';
-export const REMOVE_OBJECT_ASSESSMENT_FROM_BASELINE = '[Baseline] REMOVE_OBJECT_ASSESSMENT_FROM_BASELINE';
+export const REMOVE_CAPABILITIES_FROM_BASELINE = '[Baseline] REMOVE_CAPABILITIES_FROM_BASELINE';
+export const REMOVE_OBJECT_ASSESSMENTS_FROM_BASELINE = '[Baseline] REMOVE_OBJECT_ASSESSMENTS_FROM_BASELINE';
 export const SET_CURRENT_BASELINE_CAPABILITY = '[Baseline] SET_CURRENT_BASELINE_CAPABILITY';
 export const SET_BASELINE = '[Baseline] SET_BASELINE';
 export const ADD_CAPABILITY_GROUP = '[Baseline] ADD_CAPABILITY_GROUP';
+export const REMOVE_CAPABILITY_GROUP_FROM_BASELINE = '[Baseline] REMOVE_CAPABILITY_GROUP_FROM_BASELINE'
 export const SAVE_OBJECT_ASSESSMENTS = '[Baseline] SAVE_OBJECT_ASSESSMENTS';
 export const FAILED_TO_LOAD = '[Baseline] FAILED_TO_LOAD';
 export const SET_AND_READ_ASSESSMENT_SET = '[Baseline] SET_AND_READ_ASSESSMENT_SET';
@@ -68,28 +69,16 @@ export class SaveBaseline implements Action {
     constructor(public payload: AssessmentSet) { }
 }
 
-export class AddObjectAssessment implements Action {
-    public readonly type = ADD_OBJECT_ASSESSMENT;
-
-    constructor(public payload: ObjectAssessment) { }
-}
-
-export class SaveObjectAssessments implements Action {
-    public readonly type = SAVE_OBJECT_ASSESSMENTS;
-
-    constructor(public payload: ObjectAssessment[]) { }
-}
-
 export class AddObjectAssessmentToBaseline implements Action {
     public readonly type = ADD_OBJECT_ASSESSMENT_TO_BASELINE;
 
     constructor(public payload: ObjectAssessment) { }
 }
 
-export class RemoveObjectAssessmentFromBaseline implements Action {
-    public readonly type = REMOVE_OBJECT_ASSESSMENT_FROM_BASELINE;
+export class RemoveObjectAssessmentsFromBaseline implements Action {
+    public readonly type = REMOVE_OBJECT_ASSESSMENTS_FROM_BASELINE;
 
-    constructor(public payload: ObjectAssessment) { }
+    constructor(public payload: ObjectAssessment[]) { }
 }
 
 export class FetchBaseline implements Action {
@@ -140,6 +129,12 @@ export class AddCapabilityGroup implements Action {
     constructor(public payload: Category) { }
 }
 
+export class RemoveCapabilityGroupFromBaseline implements Action {
+    public readonly type = REMOVE_CAPABILITY_GROUP_FROM_BASELINE;
+
+    constructor(public payload: Category) { }
+}
+
 export class SetBaselineGroups implements Action {
     public readonly type = SET_BASELINE_GROUPS;
 
@@ -182,10 +177,10 @@ export class AddCapabilityToBaseline implements Action {
     constructor(public payload: Capability) { }
 }
 
-export class RemoveCapabilityFromBaseline implements Action {
-    public readonly type = REMOVE_CAPABILITY_FROM_BASELINE;
+export class RemoveCapabilitiesFromBaseline implements Action {
+    public readonly type = REMOVE_CAPABILITIES_FROM_BASELINE;
 
-    constructor(public payload: Capability) { }
+    constructor(public payload: Capability[]) { }
 }
 
 export class ReplaceCapabilityInBaseline implements Action {
@@ -258,7 +253,6 @@ export class FailedToLoad implements Action {
   }  
 
 export type BaselineActions =
-    AddObjectAssessment |
     AddObjectAssessmentToBaseline |
     CleanBaselineWizardData |
     FailedToLoad |
@@ -270,7 +264,7 @@ export type BaselineActions =
     FinishedSaving |
     SaveBaseline |
     AddCapabilityGroup |
-    SaveObjectAssessments |
+    RemoveCapabilityGroupFromBaseline |
     SetAndReadAssessmentSet |
     SetAndReadObjectAssessments |
     SetAndReadCapabilities |
@@ -278,8 +272,8 @@ export type BaselineActions =
     SetBaseline |
     AddCapabilityToBaseline |
     ReplaceCapabilityInBaseline |
-    RemoveCapabilityFromBaseline |
-    RemoveObjectAssessmentFromBaseline |
+    RemoveCapabilitiesFromBaseline |
+    RemoveObjectAssessmentsFromBaseline |
     SetBaselineGroups |
     SetCapabilities |
     SetBaselineCapabilities |

--- a/src/app/baseline/store/baseline.reducers.ts
+++ b/src/app/baseline/store/baseline.reducers.ts
@@ -74,6 +74,13 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 ...state,
                 baselineObjAssessments: action.payload,
             });
+        case baselineActions.REMOVE_CAPABILITY_GROUP_FROM_BASELINE:
+            const catToDelete = action.payload;
+            const updatedGroupList = state.baselineGroups.filter((group) => group.id !== catToDelete.id);
+            return genAssessState({
+                ...state,
+                baselineGroups: [...updatedGroupList],
+            });
         case baselineActions.SET_CAPABILITY_GROUPS:
             return genAssessState({
                 ...state,
@@ -111,10 +118,13 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 ...state,
                 baselineCapabilities: capList2,
             });
-        case baselineActions.REMOVE_CAPABILITY_FROM_BASELINE:
+        case baselineActions.REMOVE_CAPABILITIES_FROM_BASELINE:
+            const capsToRemove = [...action.payload];
             const capList3 = [...state.baselineCapabilities];
-            const remIndex = capList3.indexOf(action.payload);
-            capList3.splice(remIndex, 1);
+            capsToRemove.forEach((cap) => {
+                const remIndex = capList3.indexOf(cap);
+                capList3.splice(remIndex, 1);
+            });
             return genAssessState({
                 ...state,
                 baselineCapabilities: capList3,
@@ -128,13 +138,6 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
             return genAssessState({
                 ...state,
                 currentCapability: action.payload,
-            });
-        case baselineActions.ADD_OBJECT_ASSESSMENT:
-            const objAssessments = [...state.baselineObjAssessments];
-            objAssessments.push(action.payload);
-            return genAssessState({
-                ...state,
-                baselineObjAssessments: objAssessments,
             });
         case baselineActions.ADD_OBJECT_ASSESSMENT_TO_BASELINE:
             const objAssessment = action.payload;
@@ -150,19 +153,20 @@ export function baselineReducer(state = initialState, action: baselineActions.Ba
                 baseline: currBaseline,
                 baselineObjAssessments: objAssessments2,
             });
-        case baselineActions.REMOVE_OBJECT_ASSESSMENT_FROM_BASELINE:
-            const oaToRemove = action.payload;
-
-            // Remove object assessment from OAs in this baseline
-            const oasInBL = state.baselineObjAssessments;
-            const oaBLIndex = oasInBL.findIndex((oa) => oa.id === oaToRemove.id);
-            oasInBL.splice(oaBLIndex, 1);
-
-            // Remove object assessment from baseline
+        case baselineActions.REMOVE_OBJECT_ASSESSMENTS_FROM_BASELINE:
+            const oasToRemove = action.payload;
             const currBaseline2 = state.baseline;
-            const oaIndex = currBaseline2.assessments.findIndex((oaId) => oaId === oaToRemove.id);
-            currBaseline2.assessments.splice(oaIndex, 1);
-            
+
+            const oasInBL = state.baselineObjAssessments;
+            oasToRemove.forEach((oaToRemove) => {
+                // Remove object assessment from OAs in this baseline
+                const oaBLIndex = oasInBL.findIndex((oa) => oa.id === oaToRemove.id);
+                oasInBL.splice(oaBLIndex, 1);    
+                // Remove object assessment from baseline
+                const oaIndex = currBaseline2.assessments.findIndex((oaId) => oaId === oaToRemove.id);
+                currBaseline2.assessments.splice(oaIndex, 1);
+            })
+
             return genAssessState({
                 ...state,
                 baseline: currBaseline2,

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
@@ -21,6 +21,7 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   public currentCapabilityGroup: Category;
   public selectedCapabilities: Capability[] = [];
   public allCapabilities: Capability[];
+  public availableCapabilities: Capability[];
   private baselineCapabilities: Capability[] = [];
 
   private subscriptions: Subscription[] = [];
@@ -200,4 +201,5 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   public getCapabilityDisabled(capability: Capability) {
     return (this.shouldCapabilityBeDisabled(capability) ? 'true' : 'false');
   }
+
 }

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
@@ -21,7 +21,6 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   public currentCapabilityGroup: Category;
   public selectedCapabilities: Capability[] = [];
   public allCapabilities: Capability[];
-  public availableCapabilities: Capability[];
   private baselineCapabilities: Capability[] = [];
 
   private subscriptions: Subscription[] = [];
@@ -201,5 +200,4 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   public getCapabilityDisabled(capability: Capability) {
     return (this.shouldCapabilityBeDisabled(capability) ? 'true' : 'false');
   }
-
 }

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -128,7 +128,9 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
       // First remove the existing group
       const confirmed = this.confirmDelete(this.selectedCategories[index]);
 
-      if (!confirmed) return;
+      if (!confirmed) {
+        return;
+      }
 
       // Update wizard store with current category selections
       this.wizardStore.dispatch(new assessActions.RemoveCapabilityGroupFromBaseline(this.selectedCategories[index]));

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -6,7 +6,6 @@ import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
 import { Category, Capability } from 'stix/assess/v3/baseline';
 import * as assessActions from '../../store/baseline.actions';
-import { SetBaselineGroups } from '../../store/baseline.actions';
 import * as assessReducers from '../../store/baseline.reducers';
 
 @Component({
@@ -126,8 +125,13 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // If this is replacing a selected group, do a replace
     if (this.selectedCategories[index]) {
-      // Must remove any capabilities for which this category was associated
-      this.wizardStore.dispatch(new assessActions.SetBaselineCapabilities(this.baselineCapabilities.filter(capability => capability.category !== this.selectedCategories[index].id)));
+      // First remove the existing group
+      const confirmed = this.confirmDelete(this.selectedCategories[index]);
+
+      if (!confirmed) return;
+
+      // Update wizard store with current category selections
+      this.wizardStore.dispatch(new assessActions.RemoveCapabilityGroupFromBaseline(this.selectedCategories[index]));
 
       this.selectedCategories[index] = newCategory;
     } else {
@@ -137,7 +141,7 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     // Update wizard store with current category selections
-    this.wizardStore.dispatch(new SetBaselineGroups(this.selectedCategories));
+    this.wizardStore.dispatch(new assessActions.SetBaselineGroups(this.selectedCategories));
   }
 
   /*
@@ -157,33 +161,27 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   /**
-   * @description Delete category from the list, with confirmation
+   * @description Delete category and associated objects from the list, with confirmation
    * @param {LastModifiedAssessment} baseline
    * @return {void}
    */
   public onDeleteCategory(option: any): void {
-    const confirmed = this.confirmDelete(option.value);
+    let catToDelete = option.value as Category;
+    const confirmed = this.confirmDelete(catToDelete);
 
     if (confirmed) {
-      let catToDelete = option.value as Category;
-      const index = this.selectedCategories.findIndex(category => category.id === catToDelete.id);
-      this.selectedCategories.splice(index, 1); 
-
-      // Must remove any capabilities for which this category were associated
-      this.wizardStore.dispatch(new assessActions.SetBaselineCapabilities(this.baselineCapabilities.filter(capability => capability.category !== option.value.id)));
-
       // Update wizard store with current category selections
-      this.wizardStore.dispatch(new SetBaselineGroups(this.selectedCategories.filter((capabilityGroup) => capabilityGroup !== undefined)));
+      this.wizardStore.dispatch(new assessActions.RemoveCapabilityGroupFromBaseline(catToDelete));
     }
   }
 
   /**
    * @description Confirm deletion of a category from the list
-   * @param {string} category the name of the category to remove
+   * @param {string} category the category to remove
    * @param {UIEvent} optional event
    * @return {boolean} true to delete, false otherwise
    */
-  public confirmDelete(category: string, event?: UIEvent): boolean {
+  public confirmDelete(category: Category, event?: UIEvent): boolean {
     // TODO: Add confirmation dialog
 
     return true;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1291
Fixes unfetter-discover/unfetter#1286
Fixes unfetter-discover/unfetter#1257
Fixes unfetter-discover/unfetter#1167

The approach for removal and/or replacing of capability groups and capabiliities had been to just set the updated lists in the store, and there was only partial removal of associated DB objects (i.e. ObjectAssessments) and related attributes on the baseline.  Now, a remove (for delete) and a remove and add (for replace) is done, and NGRX actions are used to systematically update the entire baseline.

### To test:
1. Pull this branch
2. Create a baseline with 2 groups and 2 capabilities for each group (use Network Firewall and Packet Analyzer to ensure adequate numbers of capabilities to choose from)
3. At one of the capability selection screens, click the trash can icon for one of the capabilities.
4. Use Redux Devtools to verify that the baselineCapabilities, baselineObjectAssessments, and baseline itself have been updated appropriately (i.e. one capability, one object assessment, and one entry in the assessments array removed)
5. In your favorite Mongo DB utility, verify that the baseline in the DB has only 3 objects in the `assessments` array for the baseline (step #3 removed one of the capabilities, which removed the associated object assessments)
6. Save the baseline
7. Click `Complete` to edit the baseline
8. On the capability groups screen, click the trash can for the 2nd group
9. Use Redux Devtools to verify that the baselineCapabilities, baselineObjectAssessments, and baseline itself have been updated appropriately (i.e. one capability, one object assessment, and one entry in the assessments array removed)
10. In your favorite Mongo DB utility, verify that the baseline in the DB has only 2 objects in the `assessments` array for the baseline (step #8 removed one of the capabilities, which removed the associated object assessments)
