### PR TITLE
Issue 1278

### DIFF
--- a/src/app/assess/v3/wizard/models/measurement.ts
+++ b/src/app/assess/v3/wizard/models/measurement.ts
@@ -1,0 +1,6 @@
+export interface Measurement {
+    name: string;
+    options: { name: string, risk: number }[];
+    selected_value: any;
+    risk: number;
+}

--- a/src/app/assess/v3/wizard/models/measurements.spec.ts
+++ b/src/app/assess/v3/wizard/models/measurements.spec.ts
@@ -1,0 +1,158 @@
+import { Measurement } from './measurement';
+import { Measurements } from './measurements';
+
+describe('Measurements', () => {
+
+  let measurementsService;
+  beforeEach(() => {
+    measurementsService = new Measurements();
+  });
+
+  it('should create', () => {
+    expect(measurementsService).toBeTruthy();
+  });
+
+  it('should create measurements for course of action', () => {
+
+    const expectedFirstQuestions = [
+      'No Policy',
+      'Not Implemented',
+      'Not Automated',
+      'Not Reported'
+    ];
+    const measurements = measurementsService.buildMeasurements('course-of-action--1234123');
+
+    expect(measurements);
+    expect(Array.isArray(measurements)).toBeTruthy();
+    expect(measurements.length).toBe(4);
+
+    let curArrayIndex = 0;
+    const spotCheckFirstQuestion = (measurement: Measurement, expectedFirstQuestion: string) => {
+      expect(measurements[curArrayIndex]).toBeDefined();
+      expect(measurements[curArrayIndex].options).toBeDefined();
+      expect(measurements[curArrayIndex].options[0].name).toEqual(expectedFirstQuestions[curArrayIndex]);
+      expect(measurements[curArrayIndex].options[0].risk).toEqual(1);
+    };
+
+    // spot check the first questions
+    spotCheckFirstQuestion(measurements[curArrayIndex], expectedFirstQuestions[curArrayIndex]);
+    curArrayIndex = 1;
+    spotCheckFirstQuestion(measurements[curArrayIndex], expectedFirstQuestions[curArrayIndex]);
+    curArrayIndex = 2;
+    spotCheckFirstQuestion(measurements[curArrayIndex], expectedFirstQuestions[curArrayIndex]);
+    curArrayIndex = 3;
+    spotCheckFirstQuestion(measurements[curArrayIndex], expectedFirstQuestions[curArrayIndex]);
+  });
+
+  it('should create measurements for indicator', () => {
+    const expectedQuestions = [
+      'Nothing',
+      'Local Logging',
+      'Central Logging, No Alerting',
+      'Alerting, but false positives/negatives',
+      'Real Time Alerting, No False Positives/Negatives',
+    ];
+    const expectedRisks = [1, .75, .50, .25, 0];
+    const measurements = measurementsService.buildMeasurements('indicator--1234123');
+
+    expect(measurements);
+    expect(Array.isArray(measurements)).toBeTruthy();
+    expect(measurements.length).toBe(1);
+
+    expect(measurements[0]).toBeDefined();
+    expect(measurements[0].options).toBeDefined();
+    expect(measurements[0].options.length).toEqual(5);
+    // check measurements and risks for first question
+    for (let curMeasurementIndex = 0; curMeasurementIndex < 5; curMeasurementIndex++) {
+      expect(measurements[0].options[curMeasurementIndex].name).toEqual(expectedQuestions[curMeasurementIndex]);
+      expect(measurements[0].options[curMeasurementIndex].risk).toEqual(expectedRisks[curMeasurementIndex]);
+    }
+
+  });
+
+  it('should create measurements for capability', () => {
+    const expectedQuestions = [
+      'no coverage',
+      'some coverage',
+      'half coverage',
+      'most critical systems covered',
+      'all critical systems covered',
+    ];
+    const expectedRisks = [1, .75, .50, .25, 0];
+    const measurements = measurementsService.buildMeasurements('x-unfetter-assessment-set--1234123');
+
+    expect(measurements);
+    expect(Array.isArray(measurements)).toBeTruthy();
+    expect(measurements.length).toBe(1);
+
+    expect(measurements[0]).toBeDefined();
+    expect(measurements[0].options).toBeDefined();
+    expect(measurements[0].options.length).toEqual(5);
+    // check measurements and risks for first question
+    for (let curMeasurementIndex = 0; curMeasurementIndex < 5; curMeasurementIndex++) {
+      expect(measurements[0].options[curMeasurementIndex].name).toEqual(expectedQuestions[curMeasurementIndex]);
+      expect(measurements[0].options[curMeasurementIndex].risk).toEqual(expectedRisks[curMeasurementIndex]);
+    }
+
+  });
+
+  it('should create format the risk string', () => {
+    const risk = .0513413;
+    const formatted = measurementsService.displayRisk(risk);
+    expect(formatted).toBeDefined();
+    expect(formatted).toEqual('5.13');
+  });
+
+  it('should create calculate risk', () => {
+    const genRiskObj = (risk: number) => {
+      return {
+        risk
+      };
+    }
+    const assessments = [
+      genRiskObj(1),
+      genRiskObj(1),
+      genRiskObj(.5),
+      genRiskObj(0),
+      genRiskObj(0),
+    ];
+    const calc = measurementsService.calculateRisk(assessments);
+    expect(calc).toBeDefined();
+    expect(calc).toEqual(.5);
+  });
+
+  it('should create a single measurement', () => {
+    const options = ['low', 'medium', 'high'];
+    const measurement: Measurement = measurementsService.createMeasurement('question1', -1, options);
+    expect(measurement).toBeDefined();
+    expect(measurement.name).toEqual('question1');
+    expect(measurement.options).toBeDefined();
+    expect(measurement.options.length).toBe(3);
+    expect(measurement.options[0].name).toBe('low');
+    expect(measurement.options[0].risk).toBe(1);
+  });
+
+  it('should get a given measurements selected risk', () => {
+    const options = ['low', 'medium', 'high'];
+    const measurement1: Measurement = measurementsService.createMeasurement('question1', 0, options);
+    expect(measurement1).toBeDefined();
+    expect(measurement1.name).toEqual('question1');
+    expect(measurement1.options).toBeDefined();
+    expect(measurement1.options.length).toBe(3);
+    expect(measurement1.selected_value.name).toEqual('low');
+    expect(measurement1.selected_value.risk).toEqual(1);
+
+    const measurement2: Measurement = measurementsService.createMeasurement('question2', 2, options);
+    expect(measurement2).toBeDefined();
+    expect(measurement2.name).toEqual('question2');
+    expect(measurement2.options).toBeDefined();
+    expect(measurement2.options.length).toBe(3);
+    expect(measurement2.selected_value.name).toEqual('high');
+    expect(measurement2.selected_value.risk).toEqual(0);
+
+    const selectedRisk = measurementsService.getRisk([measurement1, measurement2]);
+    expect(selectedRisk).toBeDefined();
+    expect(selectedRisk).toEqual(.5);
+  });
+
+});

--- a/src/app/assess/v3/wizard/models/measurements.ts
+++ b/src/app/assess/v3/wizard/models/measurements.ts
@@ -1,13 +1,16 @@
+import { Measurement } from './measurement';
+
 /**
  * Report Dashboard Mitigation Mixin to for computed related properties
  * Builds out the referenced objects.
  */
 export class Measurements {
-  protected changeMeasurement(measurement, selected_value) {
+  public changeMeasurement(measurement, selected_value) {
     measurement.selected_value = selected_value;
     measurement.risk = parseFloat(selected_value.risk);
     return measurement;
   }
+
   /**
    * Build Measurements
    *
@@ -16,9 +19,10 @@ export class Measurements {
    *
    * @return {Object} will build the measurements based on the type
    */
-  protected buildMeasurements(dataType): any[] {
+  public buildMeasurements(dataType: string): Measurement[] {
     const measurements = [];
-    if (dataType.substr(0, 6) === 'course') {
+    dataType = (dataType) ? dataType.trim() : '';
+    if (dataType.startsWith('course')) {
       // If the data type starts with course of action
       const policyOptions = [
         'No Policy',
@@ -61,7 +65,7 @@ export class Measurements {
       measurements.push(
         this.createMeasurement('reporting', -1, reportingOptions)
       );
-    } else if (dataType.substr(0, 6) === 'indicator') {
+    } else if (dataType.startsWith('indicator')) {
       // Then, assuming its an indicator
       const indicatorOption = [
         'Nothing',
@@ -92,11 +96,15 @@ export class Measurements {
    * @param  number risk
    * @returns string
    */
-  protected displayRisk(risk: number): string {
+  public displayRisk(risk: number): string {
     return Number(risk * 100).toFixed(2);
   }
 
-  protected calculateRisk(assessments): number {
+  /**
+   * @param  {} assessments
+   * @returns number
+   */
+  public calculateRisk(assessments): number {
     let risk = 0;
     assessments.forEach(assessment => {
       if (assessment.risk && typeof assessment.risk === 'number') {
@@ -107,10 +115,14 @@ export class Measurements {
     return risk / assessments.length;
   }
 
-  protected getRisk(measureObject) {
+  /**
+   * @param  {} measureObject
+   * @returns number
+   */
+  public getRisk(measureObject: Measurement[]): number {
     let risk = 0;
     let count = 0;
-    measureObject.forEach(measurement => {
+    measureObject.forEach((measurement) => {
       const selected_value = measurement.selected_value;
       risk = risk + parseFloat(selected_value.risk);
       count = count + 1;
@@ -118,7 +130,7 @@ export class Measurements {
     return risk / measureObject.length;
   }
 
-  protected getRiskByName(assessments) {
+  public getRiskByName(assessments) {
     if (Array.isArray(assessments)) {
       const riskMap = [];
       assessments.forEach(assessment => {
@@ -148,7 +160,14 @@ export class Measurements {
     }
   }
 
-  protected createMeasurement(name, selectedOption, options) {
+  /**
+   * @description create a single measurement
+   * @param  {} name
+   * @param  {} selectedOption
+   * @param  {} options
+   * @returns Measurement
+   */
+  public createMeasurement(name, selectedOption: number, options): Measurement {
     const measurement: any = {};
     measurement.name = name;
     measurement.options = [];
@@ -167,7 +186,6 @@ export class Measurements {
       measurement.risk = -1;
     }
 
-    /***measurement.selected_option = selectedOption;**/
     return measurement;
   }
 
@@ -176,7 +194,7 @@ export class Measurements {
    * @param  {any[]} measurements an object w/ a risk field
    * @returns number -1 is the measurements are empty others an avg of the risk
    */
-  protected calculateMeasurementsAvgRisk(measurements: any[]): number {
+  public calculateMeasurementsAvgRisk(measurements: any[]): number {
     const validMeasurements = measurements.filter((measurement) => measurement.risk !== -1);
     if (!validMeasurements || validMeasurements.length === 0) {
       return -1;
@@ -188,7 +206,7 @@ export class Measurements {
     return sum / validMeasurements.length;
   }
 
-  protected updateQuestionRisk(question, risk) {
+  public updateQuestionRisk(question, risk) {
     if (question.selected_value === undefined) {
       question.selected_value = {};
     }

--- a/src/app/core/services/genericapi.service.spec.ts
+++ b/src/app/core/services/genericapi.service.spec.ts
@@ -253,14 +253,14 @@ describe('GenericApi service', () => {
     });
 
     describe('uploadAttachments', () => {
-        const mockFilelist: any = {
-            0: {
+        const mockFilelist: any = [
+            {
                 name: 'foo'
             },
-            1: {
+            {
                 name: 'bar'
             }
-        };
+        ];
 
         it('should update progress', (done) => {
             let count = 0;

--- a/src/app/core/services/genericapi.service.ts
+++ b/src/app/core/services/genericapi.service.ts
@@ -228,9 +228,9 @@ export class GenericApi {
      * @description This is the observable to upload a list of files to the upload/files route.
      * The optional callback will assist in driving progress bars.
      */
-    public uploadAttachments(files: FileList, progressCallback?: (number) => void): Observable<GridFSFile[]> {
+    public uploadAttachments(files: File[], progressCallback?: (number) => void): Observable<GridFSFile[]> {
         const formData: FormData = new FormData();
-        Object.values(files).forEach((file) => formData.append('attachments', file));
+        files.forEach((file) => formData.append('attachments', file));
         const req = new HttpRequest('POST', `${Constance.UPLOAD_URL}/files`, formData, {
             reportProgress: true
         }); 

--- a/src/app/core/services/run-config.service.ts
+++ b/src/app/core/services/run-config.service.ts
@@ -32,6 +32,7 @@ export interface MasterConfig extends PublicConfig {
     lastReviewed?: number;
     lastModified?: number;
     footerTextHtml?: string;
+    blockAttachments?: boolean;
 }
 
 @Injectable()
@@ -47,15 +48,21 @@ export class RunConfigService {
     }
     
     private loadPrivateConfig() {
-        this._config = this.http.get<MasterConfig>('./assets/config/local-settings.json').pipe(catchError(() => {
-            console.warn('Could not load assets/config/local-settings.json. Default configuration will be used.');
-            console.warn('If you create or edit the file, be sure to restart the application.');
-            return observableOf({} as MasterConfig);
-        }));
+        this._config = this.http.get<MasterConfig>('./assets/config/local-settings.json')
+            .pipe(
+                catchError(() => {
+                    console.warn('Could not load assets/config/local-settings.json. Default configuration will be used.');
+                    console.warn('If you create or edit the file, be sure to restart the application.');
+                    return observableOf({} as MasterConfig);
+                })
+            );
     }
 
     public get config(): Observable<MasterConfig> {
-        return this._config.pipe(map(cfg => ({...public_config[this.runMode] as PublicConfig, ...cfg})));
+        return this._config
+            .pipe(
+                map(cfg => ({...public_config[this.runMode] as PublicConfig, ...cfg}))
+            );
     }
 
 }

--- a/src/app/global/components/file-list/file-list.component.html
+++ b/src/app/global/components/file-list/file-list.component.html
@@ -11,7 +11,7 @@
       <tr *ngFor="let file of files; let i = index">
         <td>
           <div class="flex flexItemsCenter mat-icon-button-cell-wrapper">
-            <span>{{file.name}} ~ {{ file | json }}</span>
+            <span>{{file.name}}</span>
             <span class="flex1">&nbsp;</span>
             <span>
               <button type="button" mat-icon-button (click)="removeFile(i)">

--- a/src/app/global/components/file-list/file-list.component.html
+++ b/src/app/global/components/file-list/file-list.component.html
@@ -1,0 +1,26 @@
+<div id="fileListComponent">
+  <input type="file" name="attachments" id="attachments" class="displayNone" (change)="fileInputChange($event)" multiple #fileInput>
+  <div class="mb-5 mt-5">
+    <button type="button" mat-raised-button (click)="selectFiles()" color="accent">Select Files</button>
+  </div>
+  <table class="uf-table mb-10" *ngIf="this.files && this.files.length">
+    <thead>
+      <th>Files</th>
+    </thead>
+    <tbody>
+      <tr *ngFor="let file of files; let i = index">
+        <td>
+          <div class="flex flexItemsCenter mat-icon-button-cell-wrapper">
+            <span>{{file.name}} ~ {{ file | json }}</span>
+            <span class="flex1">&nbsp;</span>
+            <span>
+              <button type="button" mat-icon-button (click)="removeFile(i)">
+                <i class="material-icons mat-24">delete</i>
+              </button>
+            </span>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/global/components/file-list/file-list.component.spec.ts
+++ b/src/app/global/components/file-list/file-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FileListComponent } from './file-list.component';
+
+describe('FileListComponent', () => {
+  let component: FileListComponent;
+  let fixture: ComponentFixture<FileListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FileListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FileListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/global/components/file-list/file-list.component.ts
+++ b/src/app/global/components/file-list/file-list.component.ts
@@ -1,0 +1,52 @@
+import { Component, ViewChild, ElementRef, Output, EventEmitter, Input, OnInit } from '@angular/core';
+
+import { GridFSFile } from '../../models/grid-fs-file';
+
+@Component({
+  selector: 'file-list',
+  templateUrl: './file-list.component.html',
+  styleUrls: ['./file-list.component.scss']
+})
+export class FileListComponent implements OnInit {
+
+  @Input() public existingFiles: GridFSFile[];
+
+  @Output() public filesChange: EventEmitter<File[]> = new EventEmitter();
+
+  @ViewChild('fileInput') public fileInput: ElementRef;
+
+  public readonly TABLE_HEADERS = [ 'File' ];
+  public files: File[] = [];
+
+  ngOnInit() {
+    if (this.existingFiles) {
+      this.files = this.files.concat(
+        this.existingFiles.map((file: GridFSFile) => { 
+          const newObj = new File([''], file.filename);
+          (newObj as any ).existingFile = true;
+          (newObj as any )._id = file._id;
+          return newObj;
+        })
+      );
+      this.filesChange.emit(this.files);
+    }
+  }
+
+
+  fileInputChange(event) {
+    if (event.target.files) {
+      const fileList: FileList = event.target.files;
+      this.files = this.files.concat(Object.values(fileList));
+    }
+    this.filesChange.emit(this.files);
+  }
+
+  selectFiles() {
+    this.fileInput.nativeElement.click();
+  }
+
+  removeFile(index: number) {
+    this.files.splice(index, 1);
+    this.filesChange.emit(this.files);
+  }
+}

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -83,6 +83,7 @@ import { MarkdownEditorComponent } from './components/markdown-editor/markdown-e
 import { SelectionListComponent } from './components/selection-list/selection-list.component';
 import { ErrorPageComponent } from './components/error-page/error-page.component';
 import { ReadableBytesPipe } from './pipes/readable-bytes.pipe';
+import { FileListComponent } from './components/file-list/file-list.component';
 
 const matModules = [
     MatAutocompleteModule,
@@ -156,7 +157,8 @@ const unfetterComponents = [
     MarkdownEditorComponent,
     SelectionListComponent,
     ErrorPageComponent,
-    ReadableBytesPipe
+    ReadableBytesPipe,
+    FileListComponent,
 ];
 
 @NgModule({
@@ -183,7 +185,7 @@ const unfetterComponents = [
         ...matModules
     ],
     declarations: [
-        ...unfetterComponents,      
+        ...unfetterComponents,             
     ],
     exports: [
         ...unfetterComponents,

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -182,14 +182,9 @@
                     <add-label-reactive [parentForm]="form" [stixType]="'indicator'"></add-label-reactive>
                 </div>
 
-                <div *ngIf="!editMode">
-                    <h5>File Attachments</h5>
-                    <div class="uf-well">
-                        <p>
-                            <input type="file" name="attachments" id="attachments" (change)="fileInputChange($event)" multiple>
-                        </p>
-                    </div>
-                </div>
+                <h5>Attachments</h5>
+                <file-list [existingFiles]="editData && editData.metaProperties && editData.metaProperties.attachments" (filesChange)="filesChange($event)"></file-list>
+                <br>
 
                 <div class="mt-6">
                     <button mat-raised-button matStepperNext type="button" color="primary">CONTINUE</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -182,9 +182,11 @@
                     <add-label-reactive [parentForm]="form" [stixType]="'indicator'"></add-label-reactive>
                 </div>
 
-                <h5>Attachments</h5>
-                <file-list [existingFiles]="editData && editData.metaProperties && editData.metaProperties.attachments" (filesChange)="filesChange($event)"></file-list>
-                <br>
+                <div *ngIf="!blockAttachments">
+                    <h5>Attachments</h5>
+                    <file-list [existingFiles]="editData && editData.metaProperties && editData.metaProperties.attachments" (filesChange)="filesChange($event)"></file-list>
+                    <br>
+                </div>
 
                 <div class="mt-6">
                     <button mat-raised-button matStepperNext type="button" color="primary">CONTINUE</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.spec.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.spec.ts
@@ -11,6 +11,7 @@ import { of as observableOf, Observable } from 'rxjs';
 import { AuthService } from '../../core/services/auth.service';
 import { take } from 'rxjs/operators';
 import { GenericApi } from '../../core/services/genericapi.service';
+import { RunConfigService } from '../../core/services/run-config.service';
 
 describe('AddIndicatorComponent', () => {
     let component: AddIndicatorComponent;
@@ -136,6 +137,12 @@ describe('AddIndicatorComponent', () => {
                 {
                     provide: GenericApi,
                     useValue: mockGenericApi
+                },
+                {
+                    provide: RunConfigService,
+                    useValue: {
+                        config: observableOf({})
+                    }
                 }
             ]
         })

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
@@ -43,7 +43,7 @@ export class AddIndicatorComponent implements OnInit {
     public patternObjs: PatternHandlerPatternObject[] = [];
     public patternObjSubject: Subject<PatternHandlerPatternObject[]> = new Subject();
     public editMode: boolean = false;
-    public files: FileList;
+    public files: File[];
     public uploadProgress: number;
     public submitErrorMsg: string;
 
@@ -201,7 +201,25 @@ export class AddIndicatorComponent implements OnInit {
             if (!tempIndicator.metaProperties) {
                 tempIndicator.metaProperties = {};
             }
-            tempIndicator.metaProperties.attachments = filesToUpload;
+            if (this.editMode && this.editData.metaProperties && this.editData.metaProperties.attachments) {
+                const attachmentsToKeep = this.editData.metaProperties.attachments
+                    .filter((att) => {
+                        return this.files
+                            .filter((file) => (file as any)._id)
+                            .find((file) => (file as any)._id === att._id)
+                    });
+                tempIndicator.metaProperties.attachments = attachmentsToKeep.concat(filesToUpload);
+            } else {
+                tempIndicator.metaProperties.attachments = filesToUpload;
+            }
+        } else if (this.editMode && this.editData.metaProperties && this.editData.metaProperties.attachments) {
+            const attachmentsToKeep = this.editData.metaProperties.attachments
+                .filter((att) => {
+                    return this.files
+                        .filter((file) => (file as any)._id)
+                        .find((file) => (file as any)._id === att._id)
+                });
+            tempIndicator.metaProperties.attachments = attachmentsToKeep;
         }
 
         if (uploadError) {
@@ -212,10 +230,7 @@ export class AddIndicatorComponent implements OnInit {
             tempIndicator.id = this.editData.id;
             if (this.editData.metaProperties && this.editData.metaProperties.interactions) {
                 tempIndicator.metaProperties.interactions = this.editData.metaProperties.interactions;
-            }
-            if (this.editData.metaProperties && this.editData.metaProperties.attachments) {
-                tempIndicator.metaProperties.attachments = this.editData.metaProperties.attachments;
-            }
+            }            
             this.dialogRef.close({
                 'indicator': tempIndicator,
                 'newRelationships': (tempIndicator.metaProperties !== undefined && tempIndicator.metaProperties.relationships !== undefined),
@@ -243,8 +258,8 @@ export class AddIndicatorComponent implements OnInit {
 
     }
 
-    public fileInputChange(event) {
-        this.files = event.target.files;
+    public filesChange(files: File[]) {
+        this.files = files;
     }
 
     public stepperChanged(event: StepperSelectionEvent) {
@@ -256,9 +271,10 @@ export class AddIndicatorComponent implements OnInit {
 
     private uploadFiles(): Promise<[any, GridFSFile[]]> {
         this.uploadProgress = 0;
-        return new Promise((resolve, reject) => {
-            if (this.files && this.files.length) {
-                const uploadFile$ = this.genericApi.uploadAttachments(this.files, (prog) => this.uploadProgress = prog)
+        return new Promise((resolve) => {
+            const newFiles = this.files.filter((file) => !(file as any).existingFile);
+            if (newFiles.length) {
+                const uploadFile$ = this.genericApi.uploadAttachments(newFiles, (prog) => this.uploadProgress = prog)
                     .pipe(
                         finalize(() => this.uploadProgress = 0 || uploadFile$ && uploadFile$.unsubscribe())
                     )

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
@@ -19,6 +19,7 @@ import { KillChainPhasesForm } from '../../global/form-models/kill-chain-phases'
 import { FormatHelpers } from '../../global/static/format-helpers';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { GridFSFile } from '../../global/models/grid-fs-file';
+import { RunConfigService } from '../../core/services/run-config.service';
 
 @Component({
     selector: 'add-indicator',
@@ -46,6 +47,7 @@ export class AddIndicatorComponent implements OnInit {
     public files: File[];
     public uploadProgress: number;
     public submitErrorMsg: string;
+    public blockAttachments: boolean;
 
     @ViewChild('associatedDataStep') 
     public associatedDataStep: MatStep;
@@ -69,7 +71,8 @@ export class AddIndicatorComponent implements OnInit {
         @Inject(MAT_DIALOG_DATA) public editData: any,
         private indicatorSharingService: IndicatorSharingService,
         private authService: AuthService,
-        private genericApi: GenericApi
+        private genericApi: GenericApi,
+        private runConfigService: RunConfigService
     ) { }    
 
     public ngOnInit() {
@@ -178,6 +181,11 @@ export class AddIndicatorComponent implements OnInit {
                     patternChange$.unsubscribe();
                 }
             );
+
+        this.runConfigService.config.subscribe((config) => {
+                this.blockAttachments = config.blockAttachments;
+            }
+        );
     }
 
     public resetForm(e = null) {
@@ -272,6 +280,11 @@ export class AddIndicatorComponent implements OnInit {
     private uploadFiles(): Promise<[any, GridFSFile[]]> {
         this.uploadProgress = 0;
         return new Promise((resolve) => {
+            if (this.blockAttachments) {
+                console.log('Attachments are blocked');
+                resolve([null, null]);
+                return;
+            }
             const newFiles = this.files.filter((file) => !(file as any).existingFile);
             if (newFiles.length) {
                 const uploadFile$ = this.genericApi.uploadAttachments(newFiles, (prog) => this.uploadProgress = prog)

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -219,7 +219,7 @@
           </div>
         </mat-tab>
 
-        <mat-tab label="Attachments" *ngIf="indicator.metaProperties && indicator.metaProperties.attachments && indicator.metaProperties.attachments.length">
+        <mat-tab label="Attachments" *ngIf="!blockAttachments && indicator.metaProperties && indicator.metaProperties.attachments && indicator.metaProperties.attachments.length">
           <br>
           <table class="uf-table">
             <thead>

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -219,7 +219,7 @@
           </div>
         </mat-tab>
 
-        <mat-tab label="Attachments" *ngIf="indicator.metaProperties && indicator.metaProperties.attachments">
+        <mat-tab label="Attachments" *ngIf="indicator.metaProperties && indicator.metaProperties.attachments && indicator.metaProperties.attachments.length">
           <br>
           <table class="uf-table">
             <thead>

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.spec.ts
@@ -20,6 +20,7 @@ import { ConfigService } from '../../core/services/config.service';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { of as observableOf, Observable } from 'rxjs';
 import { ReadableBytesPipe } from '../../global/pipes/readable-bytes.pipe';
+import { RunConfigService } from '../../core/services/run-config.service';
 
 describe('IndicatorCardComponent', () => {
     let component: IndicatorCardComponent;
@@ -159,6 +160,12 @@ describe('IndicatorCardComponent', () => {
                 {
                     provide: ConfigService,
                     useValue: mockConfigService
+                },
+                {
+                    provide: RunConfigService,
+                    useValue: {
+                        config: observableOf({})
+                    }
                 }
             ],
         })

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.ts
@@ -14,6 +14,7 @@ import { canCrud } from '../../global/static/stix-permissions';
 import { SearchParameters } from '../models/search-parameters';
 import { GridFSFile } from '../../global/models/grid-fs-file';
 import { Constance } from '../../utils/constance';
+import { RunConfigService, MasterConfig } from '../../core/services/run-config.service';
 
 @Component({
     selector: 'indicator-card',
@@ -54,6 +55,7 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
     public canCrud: boolean = false;
     public collapseContents: boolean = false;
     public copyText: string = 'Copied';
+    public blockAttachments: boolean;
 
     public readonly runMode = environment.runMode;
 
@@ -67,7 +69,8 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
     constructor(
         private indicatorSharingService: IndicatorSharingService, 
         private authService: AuthService,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private runConfigService: RunConfigService
     ) { }
 
     public ngOnInit() {
@@ -111,6 +114,11 @@ export class IndicatorCardComponent implements OnInit, AfterViewInit, OnDestroy 
                     }
                 );
         }
+
+        this.runConfigService.config.subscribe((config) => {
+                this.blockAttachments = config.blockAttachments;
+            }
+        );
     }
 
     public ngAfterViewInit() {

--- a/src/app/threat-dashboard/services/report-translation.service.ts
+++ b/src/app/threat-dashboard/services/report-translation.service.ts
@@ -1,7 +1,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { empty as observableEmpty, Observable, OperatorFunction } from 'rxjs';
+import { EMPTY, Observable, OperatorFunction } from 'rxjs';
 import { map } from '../../../../node_modules/rxjs/operators';
 import { Constance } from '../../utils/constance';
 import { ExternalDataTranslationRequest } from '../models/adapter/external-data-translation-request';
@@ -28,7 +28,7 @@ export class ReportTranslationService {
    */
   public translateUrl(req: UrlTranslationRequest): Observable<UrlTranslationResponse> {
     if (!req || !req.systemName || !req.url) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const jsonApiObject = new JsonApiObject<UrlTranslationRequest>();
@@ -51,7 +51,7 @@ export class ReportTranslationService {
     if (!req || !req.systemName || !req.payload) {
       console.log(req);
       console.log('system name and payload is required to request a data tranlation but was not found, attempting to move on...');
-      return observableEmpty();
+      return EMPTY;
     }
 
     const jsonApiObject = new JsonApiObject<ExternalDataTranslationRequest>();
@@ -80,7 +80,7 @@ export class ReportTranslationService {
    */
   public fetchExternalReport(url: string, withCredentials = true, includeAuthHeaders = false): Observable<any> {
     if (!url) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     let headers = this.headers;

--- a/src/app/threat-dashboard/services/threat-report-overview.service.ts
+++ b/src/app/threat-dashboard/services/threat-report-overview.service.ts
@@ -1,7 +1,7 @@
 
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { empty as observableEmpty, forkJoin as observableForkJoin, from as observableFrom, merge as observableMerge, Observable, of as observableOf, throwError as observableThrowError, zip as observableZip } from 'rxjs';
+import { EMPTY, forkJoin as observableForkJoin, from as observableFrom, merge as observableMerge, Observable, of as observableOf, throwError as observableThrowError, zip as observableZip } from 'rxjs';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { catchError, filter, first, map, mergeMap, reduce, tap } from 'rxjs/operators';
 import * as UUID from 'uuid';
@@ -85,7 +85,7 @@ export class ThreatReportOverviewService {
    */
   public loadReport(id: string): Observable<Report> {
     if (!id) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const query = { 'stix.type': 'report', 'stix.id': id };
@@ -314,7 +314,7 @@ export class ThreatReportOverviewService {
    */
   public saveThreatReport(threatReport: Partial<ThreatReport>): Observable<Partial<ThreatReport>> {
     if (!threatReport) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const url = this.reportsUrl;
@@ -339,7 +339,7 @@ export class ThreatReportOverviewService {
    */
   public deleteReport(id: string): Observable<Report> {
     if (!id || id.trim().length === 0) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const url = this.reportsUrl + '/' + id;
@@ -355,7 +355,7 @@ export class ThreatReportOverviewService {
    */
   public removeReport(report: Report, threatReport: ThreatReport): Observable<Report> {
     if (!report || !threatReport) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const url = this.reportsUrl;
@@ -415,7 +415,7 @@ export class ThreatReportOverviewService {
    */
   public deleteThreatReport(id: string): Observable<Observable<Report[]>> {
     if (!id || id.trim().length === 0) {
-      return observableEmpty();
+      return EMPTY;
     }
 
     const url = this.reportsUrl;

--- a/src/app/threat-dashboard/threat-dashboard.component.ts
+++ b/src/app/threat-dashboard/threat-dashboard.component.ts
@@ -1,11 +1,9 @@
-
-import { empty as observableEmpty, of as observableOf, forkJoin as observableForkJoin,  Observable ,  Subscription  } from 'rxjs';
-
-import { finalize, take, pluck, tap, map } from 'rxjs/operators';
 import { Component, EventEmitter, OnDestroy, OnInit, Output, Renderer2 } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
+import { EMPTY, forkJoin as observableForkJoin, Observable, of as observableOf, Subscription } from 'rxjs';
+import { finalize, map, pluck, take, tap } from 'rxjs/operators';
 import { ConfirmationDialogComponent } from '../components/dialogs/confirmation/confirmation-dialog.component';
 import { AttackPatternService } from '../core/services/attack-pattern.service';
 import { GenericApi } from '../core/services/genericapi.service';
@@ -22,6 +20,7 @@ import { AttackPatternChild } from './collapsible-tree/attack-pattern-child';
 import { CourseOfActionChild } from './collapsible-tree/course-of-action-child';
 import { KillChainPhaseChild } from './collapsible-tree/kill-chain-phase-child';
 import { TreeNode } from './collapsible-tree/tree-node';
+import { KillChainEntry } from './models/kill-chain-entry';
 import { SelectOption } from './models/select-option';
 import { ThreatDashboard } from './models/threat-dashboard';
 import { ThreatDashboardIntrusion } from './models/threat-dashboard-intrusion';
@@ -30,7 +29,6 @@ import { RadarChartDataPoint } from './radar-chart/radar-chart-datapoint';
 import { ThreatReportOverviewService } from './services/threat-report-overview.service';
 import { ThreatReportSharedService } from './services/threat-report-shared.service';
 import { ThreatReportOverviewDataSource } from './threat-report-overview.datasource';
-import { KillChainEntry } from './models/kill-chain-entry';
 
 type troColName = keyof ThreatReport | 'actions';
 
@@ -112,8 +110,8 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
         (id: string) => {
           const getUser$ = this.userStore
             .select('users').pipe(
-            pluck('userProfile'),
-            take(1))
+              pluck('userProfile'),
+              take(1))
             .subscribe((user: UserProfile) => {
               this.user = user;
               this.threatReport = null;
@@ -617,7 +615,7 @@ export class ThreatDashboardComponent implements OnInit, OnDestroy {
    */
   public load(workProductId: string): Observable<Partial<ThreatReport>> {
     if (!workProductId || workProductId.trim().length === 0) {
-      return observableEmpty();
+      return EMPTY;
     }
     return this.threatReportService.load(workProductId);
   }

--- a/src/app/threat-dashboard/threat-report-editor/threat-report-editor.component.spec.ts
+++ b/src/app/threat-dashboard/threat-report-editor/threat-report-editor.component.spec.ts
@@ -4,16 +4,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatChipsModule, MatDatepickerModule, MatFormFieldModule, MatIconModule, MatOptionModule, MatProgressSpinnerModule, MatSelectModule, MatSnackBarModule, MatTableDataSource, MatTableModule } from '@angular/material';
 import { ActivatedRoute, Router } from '@angular/router';
-import { empty, from as observableFrom, Observable, of as observableOf } from 'rxjs';
+import { EMPTY, from as observableFrom, Observable, of as observableOf } from 'rxjs';
 import * as UUID from 'uuid';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { GlobalModule } from '../../global/global.module';
 import { Report } from '../../models/report';
 import { ExternalReference } from '../../models/stix/external_reference';
 import { ThreatReportOverviewService } from '../../threat-dashboard/services/threat-report-overview.service';
+import { SelectOption } from '../models/select-option';
 import { ThreatReport } from '../models/threat-report.model';
 import { ThreatReportEditorComponent } from './threat-report-editor.component';
-import { SelectOption } from '../models/select-option';
 
 class MockThreatReport {
     public static empty(): ThreatReport {
@@ -39,7 +39,7 @@ describe('ThreatReportEditorComponent', () => {
 
         saveThreatReport(report: ThreatReport): Observable<ThreatReport> {
             if (!report) {
-                return empty();
+                return EMPTY;
             }
             report.id = report.id || UUID.v4();
             const saveReports$ = this.upsertReports(report.reports as Report[], report)


### PR DESCRIPTION
Requires `issue-1278` on `unfetter-ui` and `unfetter-store`

Disclaimer: This update will break any previously uploaded attachments, as now attachments are stored in a compressed format

Instructions
- Confirm basic attachment functionality still works

![image](https://user-images.githubusercontent.com/30236110/43287547-59708682-90f3-11e8-9587-1903fddf60d8.png)

- Confirm editing attachments, with both adding and deleting attachments, works
- Confirm attachment downloading still works
- Run the `unfetter-utils/api_configuration_tool.py` script, disable attachments, and confirm you can not find the attachments in the UI

fixes unfetter-discover/unfetter#1278