### PR TITLE
Issue 1308

### DIFF
--- a/src/app/global/components/header-navigation/header-navigation.component.html
+++ b/src/app/global/components/header-navigation/header-navigation.component.html
@@ -13,7 +13,7 @@
 
   <span class="flex1">&nbsp;</span>
 
-  <ng-container *ngIf="!demoMode && !authService.loggedIn()">
+  <ng-container *ngIf="!demoMode && !authService.loggedIn() && authServices">
     <ng-container *ngIf="authServices.length === 1">
       <a href="/api/auth/{{authServices[0]}}-login/">
         <button id="login-button" mat-raised-button color="accent">Sign In / Register</button>

--- a/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.html
+++ b/src/app/indicator-sharing/add-attack-pattern/add-attack-pattern.component.html
@@ -11,7 +11,7 @@
     <div class="uf-well-accent">
       <mat-form-field class="full-width">
         <mat-select placeholder="Techniques" [multiple]="true" [(ngModel)]="selectedAttackPatterns">
-          <mat-option [value]="ap.id" *ngFor="let ap of (displayedAttackPatterns$ | async) | sortByField:'name':'ascending'">{{ ap.name }}</mat-option>
+          <mat-option [value]="ap.id" *ngFor="let ap of displayedAttackPatterns$ | async">{{ ap.name }}</mat-option>
         </mat-select>
       </mat-form-field>
       <button mat-button color="accent" [disabled]="!selectedAttackPatterns.length" (click)="saveRelationsips()">Save Technique Relationships</button>

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -159,7 +159,7 @@
                 </div>
                 
                 <!-- ~~~ Kill Chain Phases ~~~ -->
-                <div>
+                <!-- <div>
                     <kill-chain-phases-reactive [parentForm]="form"></kill-chain-phases-reactive>
                     <mat-chip-list formArrayName="kill_chain_phases" *ngIf="form.get('kill_chain_phases').value.length > 0" class="chipListPadding">
                         <mat-chip *ngFor="let kill_chain of form.get('kill_chain_phases').value; let i = index" class="cursor-pointer chipListChip"
@@ -168,7 +168,7 @@
                             <mat-icon matChipRemove (click)="form.get('kill_chain_phases').removeAt(i)">cancel</mat-icon>
                         </mat-chip>
                     </mat-chip-list>
-                </div>
+                </div> -->
                 
                 <!-- ~~~ Labels ~~~ -->
                 <h5>Add Labels</h5>
@@ -203,6 +203,7 @@
                         <button mat-button matStepperPrevious type="button">BACK</button>
                     </div>
                 </div>
+                <!-- <div *ngFor="let kcp of form.get('kill_chain_phases')">{{ kcp.value | json }}</div> -->
             </mat-step>
             
             <mat-step label="Input Data">

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.html
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.html
@@ -158,18 +158,6 @@
                     </mat-chip-list>
                 </div>
                 
-                <!-- ~~~ Kill Chain Phases ~~~ -->
-                <!-- <div>
-                    <kill-chain-phases-reactive [parentForm]="form"></kill-chain-phases-reactive>
-                    <mat-chip-list formArrayName="kill_chain_phases" *ngIf="form.get('kill_chain_phases').value.length > 0" class="chipListPadding">
-                        <mat-chip *ngFor="let kill_chain of form.get('kill_chain_phases').value; let i = index" class="cursor-pointer chipListChip"
-                            color="primary" selected="true" removable="true">
-                            <span class="flex1 flexNowrap">{{ kill_chain.phase_name | capitalize}}</span>
-                            <mat-icon matChipRemove (click)="form.get('kill_chain_phases').removeAt(i)">cancel</mat-icon>
-                        </mat-chip>
-                    </mat-chip-list>
-                </div> -->
-                
                 <!-- ~~~ Labels ~~~ -->
                 <h5>Add Labels</h5>
                 <div class="flex flexItemsCenter" id="labelsWrapper">
@@ -203,7 +191,14 @@
                         <button mat-button matStepperPrevious type="button">BACK</button>
                     </div>
                 </div>
-                <!-- <div *ngFor="let kcp of form.get('kill_chain_phases')">{{ kcp.value | json }}</div> -->
+                <div *ngIf="form.get('kill_chain_phases').value.length">
+                    <h5>Derived Tactics</h5>
+                    <mat-chip-list class="chipListPadding">
+                        <mat-chip *ngFor="let kcp of form.get('kill_chain_phases').value" class="cursor-pointer chipListChip">
+                            {{ kcp.phase_name | capitalize }}
+                        </mat-chip>
+                    </mat-chip-list>   
+                </div>
             </mat-step>
             
             <mat-step label="Input Data">

--- a/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
+++ b/src/app/indicator-sharing/add-indicator/add-indicator.component.ts
@@ -207,7 +207,6 @@ export class AddIndicatorComponent implements OnInit {
                             kcpForm.patchValue(kcp);
                             this.form.get('kill_chain_phases').push(kcpForm);
                         });
-                    console.log('####', this.form.get('kill_chain_phases'));
                 },
                 (err) => {
                     console.log(err);

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -66,7 +66,7 @@
         </div>
 
         <label *ngIf="(attackPatterns && attackPatterns.length > 0) || canCrud">Indicated Techniques</label>
-        <add-attack-pattern [existingAttackPatterns]="attackPatterns" [indicatorId]="indicator.id" [createdByRef]="indicator.created_by_ref" [canCrud]="canCrud"></add-attack-pattern>
+        <add-attack-pattern [existingAttackPatterns]="attackPatterns" [indicator]="indicator" [createdByRef]="indicator.created_by_ref" [canCrud]="canCrud"></add-attack-pattern>
 
       <div *ngIf="attackPatterns && attackPatterns.length > 0">
         <div class="uf-collapsible-control mb-10 mt-6" (click)="showAttackPatternDetails = !showAttackPatternDetails">

--- a/src/app/indicator-sharing/indicator-card/indicator-card.component.html
+++ b/src/app/indicator-sharing/indicator-card/indicator-card.component.html
@@ -78,7 +78,7 @@
             <h4 class="fw400">
               <a routerLink="/stix/attack-patterns/{{ap.id}}">{{ap.name}}</a>
             </h4>
-            <div *ngIf="ap.kill_chain_phases">
+            <div *ngIf="ap.kill_chain_phases && ap.kill_chain_phases.length">
               <label>Tactics</label>
               <p>
                 <span *ngFor="let phase of ap.kill_chain_phases; let i = index" class="text-muted">
@@ -112,7 +112,7 @@
             <markdown-editor [editing]="false" [flushed]="true" [truncate]="true"
                 [value]="indicator.description"></markdown-editor>
           </div>
-          <div *ngIf="indicator.kill_chain_phases">
+          <div *ngIf="indicator.kill_chain_phases && indicator.kill_chain_phases.length">
             <label>Tactics</label>
             <p>
               <span *ngFor="let phase of indicator.kill_chain_phases; let i = index" class="text-muted">

--- a/src/app/indicator-sharing/store/indicator-sharing.actions.ts
+++ b/src/app/indicator-sharing/store/indicator-sharing.actions.ts
@@ -180,7 +180,7 @@ export class FetchIndicators implements Action {
 
 export type IndicatorSharingActions =
     FetchData |
-    CreateIndicatorToApRelationship |
+    CreateIndicatorToApRelationships |
     RefreshApMap |
     StartDeleteIndicator |
     StartUpdateIndicator |

--- a/src/app/indicator-sharing/store/indicator-sharing.actions.ts
+++ b/src/app/indicator-sharing/store/indicator-sharing.actions.ts
@@ -7,7 +7,7 @@ export const FETCH_DATA = '[Indicator Sharing] FETCH_DATA';
 export const FETCH_INDICATORS = '[Indicator Sharing] FETCH_INDICATORS';
 export const START_DELETE_INDICATOR = '[Indicator Sharing] START_DELETE_INDICATOR';
 export const START_UPDATE_INDICATOR = '[Indicator Sharing] START_UPDATE_INDICATOR';
-export const CREATE_IND_TO_AP_RELATIONSHIP = '[Indicator Sharing] CREATE_IND_TO_AP_RELATIONSHIP';
+export const CREATE_IND_TO_AP_RELATIONSHIPS = '[Indicator Sharing] CREATE_IND_TO_AP_RELATIONSHIPS';
 export const REFRESH_AP_MAP = '[Indicator Sharing] REFRESH_AP_MAP';
 
 // For reducers
@@ -36,10 +36,10 @@ export class FetchData implements Action {
     public readonly type = FETCH_DATA;
 }
 
-export class CreateIndicatorToApRelationship implements Action {
-    public readonly type = CREATE_IND_TO_AP_RELATIONSHIP;
+export class CreateIndicatorToApRelationships implements Action {
+    public readonly type = CREATE_IND_TO_AP_RELATIONSHIPS;
     
-    constructor(public payload: { indicatorId: string, attackPatternId: string, createdByRef: string } ) { }
+    constructor(public payload: { indicatorId: string, attackPatternIds: string[], createdByRef: string } ) { }
 }
 
 export class RefreshApMap implements Action {

--- a/src/app/indicator-sharing/store/indicator-sharing.effects.ts
+++ b/src/app/indicator-sharing/store/indicator-sharing.effects.ts
@@ -134,13 +134,44 @@ export class IndicatorSharingEffects {
 
     @Effect()
     public createIndicatorToAttackPatternRelationship = this.actions$
-        .ofType(indicatorSharingActions.CREATE_IND_TO_AP_RELATIONSHIP)
+        .ofType(indicatorSharingActions.CREATE_IND_TO_AP_RELATIONSHIPS)
         .pipe(
             pluck('payload'),
-            switchMap((payload: { indicatorId: string, attackPatternId: string, createdByRef: string }) => {
-                return this.indicatorSharingService.createIndToApRelationship(payload.indicatorId, payload.attackPatternId, payload.createdByRef);
+            switchMap((payload: { indicatorId: string, attackPatternIds: string[], createdByRef: string }) => {
+                const obs$ = [];
+                payload.attackPatternIds.forEach((attackPatternId) => {
+                    obs$.push(this.indicatorSharingService.createIndToApRelationship(payload.indicatorId, attackPatternId, payload.createdByRef));
+                });
+                return observableForkJoin(...obs$);
             }),
-            map((_) => new indicatorSharingActions.RefreshApMap())
+            withLatestFrom(this.store.select('indicatorSharing')),
+            map(([responses, indicatorSharingStore]: [any, fromIndicators.IndicatorSharingState]) => {
+                const killChainPhaseSet = new Set();
+
+                const indicatorId = responses.length > 0 && responses[0].length > 0 && responses[0][0].attributes && responses[0][0].attributes.source_ref;
+                const indicator = indicatorSharingStore.indicators.find((ind) => ind.id === indicatorId);
+                if (indicator && indicator.kill_chain_phases && indicator.kill_chain_phases.length) {
+                    indicator.kill_chain_phases.forEach((kcp) => killChainPhaseSet.add(JSON.stringify(kcp)));
+                }
+                const originalKcpSize = killChainPhaseSet.size;
+
+                responses
+                    .filter((response) => response.length && response[0].attributes && response[0].attributes.target_ref)
+                    .map((response) => indicatorSharingStore.attackPatterns.find((attackPattern) => attackPattern.id === response[0].attributes.target_ref))
+                    .filter((attackPattern) => !!attackPattern && attackPattern.kill_chain_phases && attackPattern.kill_chain_phases.length)
+                    .forEach((attackPattern) => {
+                        attackPattern.kill_chain_phases.forEach((kcp) => killChainPhaseSet.add(JSON.stringify(kcp)));
+                    });
+                
+                if (killChainPhaseSet.size > originalKcpSize) {
+                    indicator.kill_chain_phases = Array.from(killChainPhaseSet)
+                        .map((kcp) => JSON.parse(kcp));
+
+                    return new indicatorSharingActions.StartUpdateIndicator(indicator);
+                } else {
+                    return new indicatorSharingActions.RefreshApMap();
+                }
+            })
         );
         
     @Effect()

--- a/src/app/users/settings/settings.component.ts
+++ b/src/app/users/settings/settings.component.ts
@@ -130,7 +130,7 @@ export class SettingsComponent implements OnInit {
         const changeSubscription$ = this.usersService.changeOrgSubscription(this.user._id, orgId, checked)
             .subscribe(
                 (res) => {
-                    console.log('#####', res);
+                    console.log('Subscription changed');
                 },
                 (err) => {
                     console.log(err);


### PR DESCRIPTION
Requires `issue-1308` on `unfetter-store` and `unfetter-ui`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/237

Goal: Analytics now derive tactics from the related techniques, as opposed to having the user add tactics separately

Instructions: 
- Created an analytic with Related attack patterns, confirm "Derived Techniques" list under the techniques selector is properly populated.
- Confirm analytic card shows these techinques
- Confirm editing of techniques works correctly
- Confirm all tactics are removed when all relationships are removed
- Confirm inline editing of techniques inside of the analytic card properly updates tactics

![image](https://user-images.githubusercontent.com/30236110/43409019-b97126fe-93f0-11e8-998e-60fdf8723c50.png)

fixes unfetter-discover/unfetter#1308