### PR TITLE
issue-1288 Baselines - Add back button to return to summary

### DIFF
--- a/src/app/baseline/create/create3.component.ts
+++ b/src/app/baseline/create/create3.component.ts
@@ -9,7 +9,7 @@ import * as assessReducers from '../store/baseline.reducers';
 import { BaselineForm } from '../../global/form-models/baseline';
 import { BaselineMeta } from '../../models/baseline/baseline-meta';
 import { BaselineStateService } from '../services/baseline-state.service';
-import { UpdatePageTitle } from '../store/baseline.actions';
+import { UpdatePageTitle, FinishedLoading } from '../store/baseline.actions';
 import { AssessmentSet } from 'stix/assess/v3/baseline';
 
 @Component({
@@ -89,6 +89,7 @@ export class Create3Component implements OnInit {
    */
   public onTitleBlur(event?: UIEvent): void {
     this.store.dispatch(new UpdatePageTitle(this.form.value.title));
+    this.store.dispatch(new FinishedLoading(true));
   }
 
   /**

--- a/src/app/baseline/layout/baseline-layout.component.ts
+++ b/src/app/baseline/layout/baseline-layout.component.ts
@@ -6,6 +6,8 @@ import { Store } from '@ngrx/store';
 import { BehaviorSubject } from 'rxjs';
 import { fadeInOut } from '../../global/animations/fade-in-out';
 import * as baselineReducers from '../store/baseline.reducers';
+import { AssessmentSet } from 'stix/assess/v3/baseline';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'baseline-layout',
@@ -18,9 +20,13 @@ export class BaselineLayoutComponent implements OnInit, AfterViewInit {
   public title = new BehaviorSubject('').asObservable();
   public showBackButton = new BehaviorSubject(false).asObservable();
 
+  private baselineId;
+
+  
   public constructor(
     private store: Store<baselineReducers.BaselineState>,
     private location: Location,
+    private router: Router,
     private changeDetectorRef: ChangeDetectorRef,
   ) { }
 
@@ -53,6 +59,16 @@ export class BaselineLayoutComponent implements OnInit, AfterViewInit {
         return el;
       }));
     this.changeDetectorRef.detectChanges();
+
+    const baselinesRetrieve$ = this.store
+    .select('baseline').pipe(
+    pluck('baseline'),
+    distinctUntilChanged())
+    .subscribe(
+      (baseline: AssessmentSet) => {
+        this.baselineId = baseline.id;
+      },
+      (err) => console.log(err));
   }
 
   /**
@@ -60,7 +76,8 @@ export class BaselineLayoutComponent implements OnInit, AfterViewInit {
    * @param event
    */
   onBack(event: UIEvent): void {
-    this.location.back();
+    // this.location.back();
+    this.router.navigate(['/baseline/result/summary/' + this.baselineId]);
   }
 
 }

--- a/src/app/baseline/wizard/category/category.component.ts
+++ b/src/app/baseline/wizard/category/category.component.ts
@@ -62,6 +62,7 @@ export class CategoryComponent implements OnInit, AfterViewInit, OnDestroy {
     this.subscriptions.push(catSub1$, catSub2$, catSub3$);
 
     this.wizardStore.dispatch(new assessActions.FetchCapabilityGroups());
+    this.wizardStore.dispatch(new assessActions.FinishedLoading(true));
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1288

To test: 
1. Create a new baseline, type a name and click continue. The following pages should now show a back arrow at the top left. Clicking this at any point will return the user to the summary screen (with this newly created baseline).
2. Edit a baseline - ensure same functionality as (1).