### PR TITLE
Fixed bug in Baseline capability Heat Map icon drop shadow not being centered on icon

### DIFF
--- a/src/app/baseline/wizard/capability/capability.component.html
+++ b/src/app/baseline/wizard/capability/capability.component.html
@@ -1,15 +1,14 @@
 
 <mat-card-content>
     <div class="row margin-bottom top-row flex-sm flexItemsCenter">
-      <div class="col-lg-9">
+      <div class="col-lg-10">
         <mat-card-title>
           {{ currentCapabilityName }}
         </mat-card-title>
       </div>
       <div class="col-lg-1">
         <button mat-icon-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(dataSource.data)">
-          <mat-icon class="mat-24" aria-hidden="true" aria-label="view heat map">view_comfy</mat-icon>
-          {{ attackMatrix }}
+          <i class="material-icons mat-24">view_comfy</i>
         </button>
       </div>
     </div>
@@ -31,8 +30,9 @@
       <div class="row margin-bottom">
         <div class="col-sm-12">
             <button mat-raised-button matTooltip="HeatMap Chart View" (click)="onToggleHeatMap.emit(dataSource.data)">
-              {{ openAttackMatrix }}
+              <i class="material-icons mat-24">view_comfy</i>
             </button>
+            {{ openHeatMapMatrix }}
         </div>
       </div>
     </div>

--- a/src/app/baseline/wizard/capability/capability.component.ts
+++ b/src/app/baseline/wizard/capability/capability.component.ts
@@ -27,10 +27,10 @@ export class CapabilityComponent implements OnInit {
   pageToggle: number = 2;    // 1 for heatmap, 2 for pdr score picker
 
   // Attack Matrix
-  public attackMatrix: string = 'ATT&CK MATRIX';
+  public heatMapMatrix: string = 'HEAT MAP MATRIX';
   public noAttackPatterns: string = 'You have no Attack Patterns yet';
   public addAttackPatterns: string = 'Add a Kill Chain Phase and Attack Patterns and they will show up here';
-  public openAttackMatrix: string = 'Open Att&ck Matrix';
+  public openHeatMapMatrix: string = 'Open Heat Map Matrix';
 
 
   @Output()


### PR DESCRIPTION
Fixed bug in Baseline capability Heat Map icon drop shadow not being centered on icon.
And removed 'ATT&CK MATRIX' text after icon, as Baseline may be used for other attack pattern frameworks.