### PR TITLE
Add clear button and make button placement consistent

### DIFF
--- a/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
+++ b/src/app/baseline/wizard/attack-pattern-chooser/attack-pattern-chooser.component.html
@@ -1,10 +1,6 @@
 <h2 mat-dialog-title>
     <div class="flex">
         <span>Choose Related Attack Patterns</span>
-        <span class="flex1"></span>
-        <button mat-button (click)="clearSelections()">CLEAR</button>
-        <button mat-button [mat-dialog-close]="false">CANCEL</button>
-        <button mat-raised-button color="primary" (click)="close()">SUBMIT</button>
     </div>
 </h2>
 <mat-dialog-content>
@@ -13,3 +9,8 @@
                 (click)="toggleAttackPattern($event)"></tactics-heatmap>
     </div>
 </mat-dialog-content>
+<mat-dialog-actions>
+    <button mat-button (click)="clearSelections()">CLEAR</button>
+    <button mat-button [mat-dialog-close]="false">CANCEL</button>
+    <button mat-raised-button color="primary" (click)="close()">ACCEPT</button>
+</mat-dialog-actions>

--- a/src/app/indicator-sharing/indicator-tactics/indicator-heatmap-filter.component.html
+++ b/src/app/indicator-sharing/indicator-tactics/indicator-heatmap-filter.component.html
@@ -6,6 +6,7 @@
     </div>
 </mat-dialog-content>
 <mat-dialog-actions>
+    <button mat-button (click)="clearSelections()">CLEAR</button>
     <button mat-button [mat-dialog-close]="false">CANCEL</button>
     <button mat-raised-button color="primary" (click)="close()">ACCEPT</button>
 </mat-dialog-actions>

--- a/src/app/indicator-sharing/indicator-tactics/indicator-heatmap-filter.component.ts
+++ b/src/app/indicator-sharing/indicator-tactics/indicator-heatmap-filter.component.ts
@@ -161,6 +161,13 @@ export class IndicatorHeatMapFilterComponent implements AfterViewInit {
     public close() {
         this._selections = Array.from(new Set(this.selectedPatterns.map(pattern => pattern.id)));
         this.dialogRef.close(this.selections);
+    }  
+
+    /**
+     * @description Remove all selections
+      */
+    public clearSelections() {
+      this.selectedPatterns.slice(0).forEach(pattern => this.toggleAttackPattern({data: pattern}));
     }
   
-}
+  }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1272

Buttons placed in lower left for both baseline wizard AP selector and AE AP filter, and Clear button added to AE AP filter.

### To test:
1. Pull this branch
2. Verify Clear, Cancel, and Accept buttons present for both baseline wizard AP selector and AE AP filter
3. Verify Clear button works for AE AP filter.
