### PR TITLE
Allows demo users to click the Details button on tactics tooltips

### DIFF
--- a/src/app/global/components/heatmap/heatmap.renderer.ts
+++ b/src/app/global/components/heatmap/heatmap.renderer.ts
@@ -426,10 +426,12 @@ export abstract class HeatmapRenderer {
         const scale = d3.zoomTransform(this.minimap.workspace.panner.node()).k;
         if (scale < 1) { // don't bother if we are already zoomed all the way out
             const ev = event.sourceEvent || event;
+            const offsetX = ev.layerX || ev.offsetX;
+            const offsetY = ev.layerY || ev.offsetY;
             const pannerRect = this.minimap.workspace.panner.node().getBoundingClientRect();
             const transform = d3.zoomIdentity
-                .translate(ev.offsetX - this.minimap.workspace.startX - pannerRect.width / 2,
-                    ev.offsetY - this.minimap.workspace.startY - pannerRect.height / 2)
+                .translate(offsetX - this.minimap.workspace.startX - pannerRect.width / 2,
+                    offsetY - this.minimap.workspace.startY - pannerRect.height / 2)
                 .scale(scale);
             const tx = Math.min(Math.max(0, transform.x), this.minimap.view.width * (1 - transform.k));
             const ty = Math.min(Math.max(0, transform.y), this.minimap.view.height * (1 - transform.k));

--- a/src/app/global/components/tactics-pane/tactics-tooltip/tactics-tooltip.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-tooltip/tactics-tooltip.component.ts
@@ -10,6 +10,7 @@ import {
     Renderer2,
     EventEmitter,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { OverlayRef, Overlay } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
@@ -17,7 +18,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { Tactic } from '../tactics.model';
 import { TacticsTooltipService, TooltipEvent } from './tactics-tooltip.service';
 import { AuthService } from '../../../../core/services/auth.service';
-import { Subscription } from 'rxjs';
+import { environment } from '../../../../../environments/environment';
 
 @Component({
     selector: 'tactics-tooltip',
@@ -172,7 +173,7 @@ export class TacticsTooltipComponent implements OnInit, OnDestroy {
      * @description
      */
     public isAdminUser(): boolean {
-        return this.authService.isAdmin();
+        return environment.runMode === 'DEMO' ||  this.authService.isAdmin();
     }
 
 }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1332.

- Start unfetter in demo mode (`ansible-playbook deploy-dev-demo.yml`).

- Go to a page with a tactics heatmap (such as the threat dashboard).

- Click on an attack pattern in the heatmap. Tooltip should appear; Details button should appear, be clickable, and, when clicked, will display the STIX page for that attack pattern.