### PR TITLE
Corrects intrusion set dashboard heatmap redraw

### DIFF
--- a/src/app/global/components/heatmap/heatmap.component.ts
+++ b/src/app/global/components/heatmap/heatmap.component.ts
@@ -118,7 +118,9 @@ export class HeatmapComponent implements OnInit, AfterViewInit, OnChanges, Heatm
      * @description Force a complete redraw of the heatmap.
      */
     public redraw() {
-        this.resizer.sensor.reset();
+        if (this.resizer && this.resizer.sensor) {
+            this.resizer.sensor.reset();
+        }
         this.helper.createHeatmap();
         this.changeDetector.markForCheck();
     }

--- a/src/app/global/components/heatmap/heatmap.renderer.ts
+++ b/src/app/global/components/heatmap/heatmap.renderer.ts
@@ -426,10 +426,12 @@ export abstract class HeatmapRenderer {
         const scale = d3.zoomTransform(this.minimap.workspace.panner.node()).k;
         if (scale < 1) { // don't bother if we are already zoomed all the way out
             const ev = event.sourceEvent || event;
+            const offsetX = ev.layerX || ev.offsetX;
+            const offsetY = ev.layerY || ev.offsetY;
             const pannerRect = this.minimap.workspace.panner.node().getBoundingClientRect();
             const transform = d3.zoomIdentity
-                .translate(ev.offsetX - this.minimap.workspace.startX - pannerRect.width / 2,
-                    ev.offsetY - this.minimap.workspace.startY - pannerRect.height / 2)
+                .translate(offsetX - this.minimap.workspace.startX - pannerRect.width / 2,
+                    offsetY - this.minimap.workspace.startY - pannerRect.height / 2)
                 .scale(scale);
             const tx = Math.min(Math.max(0, transform.x), this.minimap.view.width * (1 - transform.k));
             const ty = Math.min(Math.max(0, transform.y), this.minimap.view.height * (1 - transform.k));

--- a/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-heatmap/tactics-heatmap.component.ts
@@ -98,6 +98,7 @@ export class TacticsHeatmapComponent extends TacticsView<HeatmapComponent, Heatm
             if (this.heatmap && this.heatmap.options && this.heatmap.options.color) {
                 this.heatmap.options.color.heatColors = heats;
                 console['debug'](`(${new Date().toISOString()}) heatmap heats`, this.heatmap.options.color.heatColors);
+                this.heatmap.redraw();
             }
         });
     }

--- a/src/app/global/components/tactics-pane/tactics-tooltip/tactics-tooltip.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-tooltip/tactics-tooltip.component.ts
@@ -10,6 +10,7 @@ import {
     Renderer2,
     EventEmitter,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { OverlayRef, Overlay } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
@@ -17,7 +18,7 @@ import { TemplatePortal } from '@angular/cdk/portal';
 import { Tactic } from '../tactics.model';
 import { TacticsTooltipService, TooltipEvent } from './tactics-tooltip.service';
 import { AuthService } from '../../../../core/services/auth.service';
-import { Subscription } from 'rxjs';
+import { environment } from '../../../../../environments/environment';
 
 @Component({
     selector: 'tactics-tooltip',
@@ -172,7 +173,7 @@ export class TacticsTooltipComponent implements OnInit, OnDestroy {
      * @description
      */
     public isAdminUser(): boolean {
-        return this.authService.isAdmin();
+        return environment.runMode === 'DEMO' ||  this.authService.isAdmin();
     }
 
 }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1285.

- Bring up intrusion set dashboard

- Select a couple of intrusion sets (checkboxes on the left)
  - You should select ones that have relationships with attack patterns -- you can hover over an attack pattern to see if any intrusion sets highlight for them

- After the page refreshes, select another intrusion set. After the page refreshes the next time, all colors should appear for all attack patterns (the bug this PR fixes caused no changes to appear in the heatmap)