### PR TITLE
Issue 1370

### DIFF
--- a/src/app/core/services/auth.guard.ts
+++ b/src/app/core/services/auth.guard.ts
@@ -1,14 +1,16 @@
 
-import { map, take } from 'rxjs/operators';
+import { map, take, switchMap, skip, delay } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Router, CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { tokenNotExpired } from 'angular2-jwt';
-import { Observable } from 'rxjs';
+import { Observable, of as observableOf, race } from 'rxjs';
 
 import * as fromUsers from '../../root-store/users/users.reducers';
 import * as fromApp from '../../root-store/app.reducers';
 import { environment } from '../../../environments/environment';
+import { tap } from 'rxjs/internal/operators/tap';
+import { FetchUserOnly } from '../../root-store/users/user.actions';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -16,43 +18,71 @@ export class AuthGuard implements CanActivate {
 
     constructor(
         private router: Router,
-        private store: Store<fromApp.AppState>
+        private store: Store<fromApp.AppState>,
+
     ) { }
 
     public canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
         const allowedRoles = route.data['ROLES'];
-        return this.store.select('users').pipe(
-            take(1),
-            map((userState: fromUsers.UserState) => { 
-                if (this.demoMode) {
-                    return true;
-                } else {
-                    if (allowedRoles !== undefined && allowedRoles.length) {
-
-                        if (this.loggedIn(userState) && this.hasRole(allowedRoles, userState.role)) {
-                            return true;
-                        } else {
-                            this.router.navigate(['/']);
-                            return false;
-                        }
-
-                        // No specific role is required
-                    } else {
-
-                        if (this.loggedIn(userState)) {
-                            return true;
-                        } else {
-                            this.router.navigate(['/']);
-                            return false;
-                        }
-
-                    } 
-                }             
-            }));
+        return this.store.select('users')
+            .pipe(
+                take(1),
+                map((userState: fromUsers.UserState) => this.authorizeUser(userState, allowedRoles)),
+                switchMap((authorized) => {
+                    if (authorized) {
+                        return observableOf(true);
+                    }
+                    // Update user, try again based off of updated user object
+                    this.store.dispatch(new FetchUserOnly());
+                    // This is a hack to get the updated user state from the effect, or to continue with the auth guard after a delay
+                    return race(
+                        this.store.select('users')
+                            .pipe(
+                                skip(1),
+                                take(1),
+                                map((userState: fromUsers.UserState) => this.authorizeUser(userState, allowedRoles))
+                            ),
+                        observableOf(authorized)
+                            .pipe(
+                                delay(500)
+                            )
+                    );
+                }),
+                tap((authorized) => {
+                    if (!authorized) {
+                        this.router.navigate(['/']);
+                    }
+                })
+            );
     }
 
     public loggedIn(userState: fromUsers.UserState) {
         return userState.approved && userState.authenticated && tokenNotExpired('unfetterUiToken');
+    }
+
+    private authorizeUser(userState: fromUsers.UserState, allowedRoles: string[]): boolean {
+        if (this.demoMode) {
+            return true;
+        } else {
+            if (allowedRoles !== undefined && allowedRoles.length) {
+
+                if (this.loggedIn(userState) && this.hasRole(allowedRoles, userState.role)) {
+                    return true;
+                } else {                    
+                    return false;
+                }
+
+                // No specific role is required
+            } else {
+
+                if (this.loggedIn(userState)) {
+                    return true;
+                } else {
+                    return false;
+                }
+
+            }
+        } 
     }
 
     private hasRole(allowedRoles: string[], userRole: string): boolean {

--- a/src/app/global/enums/ws-message-types.enum.ts
+++ b/src/app/global/enums/ws-message-types.enum.ts
@@ -3,5 +3,6 @@ export const enum WSMessageTypes {
     STIX = 'STIX',
     SYSTEM = 'SYSTEM',
     SOCIAL = 'SOCIAL',
-    STIXID = 'STIXID'
+    STIXID = 'STIXID',
+    USER_OBJECT = 'USER_OBJECT'
 }

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.html
@@ -4,7 +4,7 @@
     </a>
 
     <mat-sidenav-container>
-        <mat-sidenav #filterContainer id="filterContainer" opened="false" mode="side" class="mat-elevation-z8" (openedStart)="openedStart()"
+        <mat-sidenav #filterContainer id="filterContainer" opened="{{ filtersInitOpen$ | async  }}" mode="side" class="mat-elevation-z8" (openedStart)="openedStart()"
             (closedStart)="closedStart()">
             <div id="filterTitle" class="flex flexItemsCenter">
                 <button mat-button (click)="filterContainer.close()">

--- a/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
+++ b/src/app/indicator-sharing/indicator-sharing-list/indicator-sharing-list.component.ts
@@ -1,4 +1,4 @@
-import { take, filter, pluck, distinctUntilChanged, finalize, debounceTime } from 'rxjs/operators';
+import { take, filter, pluck, distinctUntilChanged, finalize, debounceTime, map } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef, ViewChild } from '@angular/core';
 import { MatDialog, MatSidenav } from '@angular/material';
 import { Store } from '@ngrx/store';
@@ -45,6 +45,7 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
         phases: {}
     };
     public highlightObj = { ...this.initialHighlightObj };
+    public filtersInitOpen$: Observable<boolean>;
 
     @ViewChild('filterContainer') public filterContainer: MatSidenav;
 
@@ -58,6 +59,13 @@ export class IndicatorSharingListComponent extends IndicatorBase implements OnIn
         super(store, changeDetectorRef);
         this.totalIndicatorCount$ = this.store.select('indicatorSharing')
             .pipe(pluck('totalIndicatorCount'));
+
+        this.filtersInitOpen$ = this.store.select('indicatorSharing')
+            .pipe(
+                pluck('searchParameters'),
+                take(1),
+                map((searchParameters) => JSON.stringify(searchParameters) !== JSON.stringify(initialSearchParameters))
+            );
     }
 
     public ngOnInit() {

--- a/src/app/root-store/users/user.actions.ts
+++ b/src/app/root-store/users/user.actions.ts
@@ -7,6 +7,7 @@ export const UPDATE_USER_DATA = '[User] Add User Data';
 export const LOGOUT_USER = '[User] Logout User';
 export const SET_TOKEN = '[User] Set Token';
 export const REFRESH_TOKEN = '[User] Refresh Token';
+export const START_USER_OBJECT_STREAM = '[User] Start User Object Stream';
 
 export class FetchUser implements Action {
     public readonly type = FETCH_USER;
@@ -45,6 +46,10 @@ export class RefreshToken implements Action {
     public readonly type = REFRESH_TOKEN;
 }
 
+export class StartUserObjectStream implements Action {
+    public readonly type = START_USER_OBJECT_STREAM;
+}
+
 export type UserActions = 
     FetchUser |
     FetchUserOnly |
@@ -52,4 +57,5 @@ export type UserActions =
     UpdateUserData |
     LogoutUser |
     SetToken |
-    RefreshToken;
+    RefreshToken |
+    StartUserObjectStream;


### PR DESCRIPTION
Requires `issue-1370` on `unfetter-store` and `unfetter-ui`, and two github accounts (one as a standard user)

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/245

Goal: Correctly promotion people to organization leader

Instructions:
- Restart stack
- Join a group with user 2, request to become leader from the user settings page (stay logged into that user)
- On user 2, confirm that the `Organizations` is *not* in the nav menu
- On user 1, go to the `/admin/organization-leader-approval` dashboard and approve
- On user 2, confirm that the `Organizations` *is* in the nav menu, also verify that there was 
- Confirm you can navigate to the Org dashboard with user 2

I also fixed an unrelated problem in this PR:
- Go to AE, confirm that the filters sidebar is not open by default
- Do some filtering
- Go to Add Analytic
- Route back, and confirm sidebar *is* open, which the filters still applied

fixes unfetter-discover/unfetter#1370