### PR TITLE
Added CSS to prevent sidepanel title from wordwrapping.

### DIFF
--- a/src/app/global/components/sidepanel/sidepanel.component.scss
+++ b/src/app/global/components/sidepanel/sidepanel.component.scss
@@ -68,6 +68,9 @@ markings-chips {
             white-space: normal;
             word-break: break-word;
             font-weight: lighter;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1256

Note that titles do not wrap.