### PR TITLE
Hides empty carousel columns on column filtering

### DIFF
--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.spec.ts
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.spec.ts
@@ -13,7 +13,7 @@ import {
 import { TacticsCarouselControlComponent } from './tactics-carousel-control.component';
 import { TacticsControlService } from '../tactics-control.service';
 
-describe('TacticCarouselControlComponent', () => {
+fdescribe('TacticCarouselControlComponent', () => {
 
     let fixture: ComponentFixture<TacticsCarouselControlComponent>;
     let component: TacticsCarouselControlComponent;
@@ -45,7 +45,7 @@ describe('TacticCarouselControlComponent', () => {
     });
 
     it('should handle page control events', fakeAsync(() => {
-        component['controls'].state.pager = {totalPages: 3};
+        component['controls'].state.pager = {page: 0, totalPages: 3};
         component['controls'].change.emit({pager: component['controls'].state.pager});
         tick(250);
         expect(component.pages).toEqual(3);

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.spec.ts
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.spec.ts
@@ -13,7 +13,7 @@ import {
 import { TacticsCarouselControlComponent } from './tactics-carousel-control.component';
 import { TacticsControlService } from '../tactics-control.service';
 
-fdescribe('TacticCarouselControlComponent', () => {
+describe('TacticCarouselControlComponent', () => {
 
     let fixture: ComponentFixture<TacticsCarouselControlComponent>;
     let component: TacticsCarouselControlComponent;

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.ts
@@ -52,6 +52,9 @@ export class TacticsCarouselControlComponent implements OnInit, OnChanges, OnDes
                 if (event && event.pager) {
                     requestAnimationFrame(() => {});
                 }
+                if (this.controls.state.pager && (this.controls.state.page !== this.controls.state.pager.page)) {
+                    requestAnimationFrame(() => this.controls.state.page = this.controls.state.pager.page);
+                }
                 if (this.controls.state.pager && (this.controls.state.pages !== this.controls.state.pager.totalPages)) {
                     requestAnimationFrame(() => this.controls.state.pages = this.controls.state.pager.totalPages);
                 }

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel-control.component.ts
@@ -51,9 +51,9 @@ export class TacticsCarouselControlComponent implements OnInit, OnChanges, OnDes
             (event) => {
                 if (event && event.pager) {
                     requestAnimationFrame(() => {});
-                }
-                if (this.controls.state.pager && (this.controls.state.page !== this.controls.state.pager.page)) {
-                    requestAnimationFrame(() => this.controls.state.page = this.controls.state.pager.page);
+                    if (this.controls.state.pager && (this.controls.state.page !== this.controls.state.pager.page)) {
+                        requestAnimationFrame(() => this.controls.state.page = this.controls.state.pager.page);
+                    }
                 }
                 if (this.controls.state.pager && (this.controls.state.pages !== this.controls.state.pager.totalPages)) {
                     requestAnimationFrame(() => this.controls.state.pages = this.controls.state.pager.totalPages);

--- a/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel.component.ts
+++ b/src/app/global/components/tactics-pane/tactics-carousel/tactics-carousel.component.ts
@@ -68,7 +68,8 @@ export class TacticsCarouselComponent extends TacticsView<UnfetterCarouselCompon
         const p = (this.frameworks || Object.keys(this.chainedTactics))
             .map(chain => (this.chainedTactics || {})[chain])
             .filter(chain => chain !== null && chain !== undefined)
-            .reduce((phases, chain) => phases.concat(chain.phases), []);
+            .reduce((phases, chain) => phases.concat(chain.phases), [])
+            .filter(phase => !this.filters.columns || (this.count(phase.tactics) > 0));
         return p;
     }
 
@@ -111,13 +112,18 @@ export class TacticsCarouselComponent extends TacticsView<UnfetterCarouselCompon
             this.readied = true;
         }
 
-        const sub$ = this.controls.change.pipe(
-            finalize(() => sub$ && sub$.unsubscribe()))
+        const sub$ = this.controls.change
+            .pipe(
+                finalize(() => sub$ && sub$.unsubscribe())
+            )
             .subscribe(
                 (event) => {
                     if (event) {
                         if (event.toggle) {
-                            requestAnimationFrame(() => {});
+                            requestAnimationFrame(() => {
+                                this.view.setPage(this.view.page, false);
+                                this.controls.onChange({pager: this.view});
+                            });
                         } else if (event.page >= 0) {
                             this.view.setPage(event.page, false);
                         }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1389.

- Pull up a page with a tactics carousel/heatmap, such as analytics exchange or intrusion set dashboard. Be sure the display has at least one empty column (for vanilla analytics exchange using mitre-attack framework, this will be the Collection [9th] column). In this context, "empty" means a column with no selected attack patterns.

- Select carousel view. Scroll left/right to view empty column. Click the "Compress columns" button in the control bar above the carousel.

  - Previous behavior, the column would appear empty, but still take up space.

  - Corrected behavior, the column should completely disappear.

- Ensure paging controls above the carousel continue to act correctly (left/right, page dropdown).