### PR TITLE
Issue 1432

### DIFF
--- a/src/app/global/components/add-label/add-label.component.html
+++ b/src/app/global/components/add-label/add-label.component.html
@@ -8,7 +8,7 @@
                 </mat-option>
             </mat-autocomplete>
         </mat-form-field>        
-        <button tabindex="{{ showAddLabel ? 0 : -1 }}" id="sendLabelBtn" (click)="localForm.status === 'VALID' ? addToParent() : ''" matTooltip="Attach Label to {{ parentDocumentType | capitalize }}">
+        <button tabindex="{{ showAddLabel && localForm.status === 'VALID' ? 0 : -1 }}" id="sendLabelBtn" (click)="localForm.status === 'VALID' ? addToParent() : ''" matTooltip="Attach Label to {{ parentDocumentType | capitalize }}">
             <i class="material-icons mat-24 cursor-pointer sendLabelBtnIcon" [ngClass]="{'text-muted': localForm.status === 'INVALID'}">send</i>
         </button>
     </div>

--- a/src/app/global/components/add-label/add-label.component.html
+++ b/src/app/global/components/add-label/add-label.component.html
@@ -1,7 +1,7 @@
 <span [ngClass]="{'showAddLabel': showAddLabel}" class="inlineFlex flexItemsCenter addLabelComponentWrapper">
     <div id="addLabelInputWrapper" class="inlineFlex flexItemsCenter">
         <mat-form-field>
-            <input type="text" matInput [formControl]="localForm" [matAutocomplete]="auto">
+            <input type="text" matInput [formControl]="localForm" [matAutocomplete]="auto" (keydown.enter)="inputEnter($event)">
             <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let ov of openVocabList" [value]="ov">
                     {{ ov }}

--- a/src/app/global/components/add-label/add-label.component.html
+++ b/src/app/global/components/add-label/add-label.component.html
@@ -1,14 +1,16 @@
 <span [ngClass]="{'showAddLabel': showAddLabel}" class="inlineFlex flexItemsCenter addLabelComponentWrapper">
     <div id="addLabelInputWrapper" class="inlineFlex flexItemsCenter">
         <mat-form-field>
-            <input type="text" matInput [formControl]="localForm" [matAutocomplete]="auto" (keydown.enter)="inputEnter($event)">
+            <input type="text" matInput [formControl]="localForm" [matAutocomplete]="auto" (keydown.enter)="inputEnter($event)" #labelInput tabindex="{{ showAddLabel ? 0 : -1 }}">
             <mat-autocomplete #auto="matAutocomplete">
                 <mat-option *ngFor="let ov of openVocabList" [value]="ov">
                     {{ ov }}
                 </mat-option>
             </mat-autocomplete>
         </mat-form-field>        
-        <i class="material-icons mat-24 cursor-pointer sendLabelbtn" [ngClass]="{'text-muted': localForm.status === 'INVALID'}" (click)="localForm.status === 'VALID' ? addToParent() : ''" matTooltip="Attach Label to {{ parentDocumentType | capitalize }}">send</i>
+        <button tabindex="{{ showAddLabel ? 0 : -1 }}" id="sendLabelBtn" (click)="localForm.status === 'VALID' ? addToParent() : ''" matTooltip="Attach Label to {{ parentDocumentType | capitalize }}">
+            <i class="material-icons mat-24 cursor-pointer sendLabelBtnIcon" [ngClass]="{'text-muted': localForm.status === 'INVALID'}">send</i>
+        </button>
     </div>
     <button mat-mini-fab color="accent" (click)="buttonClick($event)" id="addLabelBtn" class="inlineBlock">
         <i class="material-icons mat-24">add</i>

--- a/src/app/global/components/add-label/add-label.component.scss
+++ b/src/app/global/components/add-label/add-label.component.scss
@@ -18,7 +18,18 @@
     background-color: #e0e0e0;    
 }
 
-.sendLabelbtn {
+#sendLabelBtn {
+    padding: 0;
+    background: inherit;
+    border: none;
+    outline: none !important;
+
+    &:focus i {
+        text-shadow: 1px 1px 3px #9E9E9E;
+    }
+}
+
+.sendLabelBtnIcon {
     margin-right: 20px !important;
 }
 

--- a/src/app/global/components/add-label/add-label.component.ts
+++ b/src/app/global/components/add-label/add-label.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output, ViewChild, ElementRef } from '@angular/core';
 import { FormControl, FormGroup, FormArray, Validators } from '@angular/forms';
 
 import { ConfigService } from '../../../core/services/config.service';
@@ -17,6 +17,9 @@ export class AddLabelReactiveComponent implements OnInit {
     @Input() public currentLabels: string[] = [];
     @Input() public parentDocumentType: string = 'analytic';
     @Output() public labelAdded: EventEmitter<string> = new EventEmitter();
+
+    @ViewChild('labelInput')
+    public labelInput: ElementRef;
 
     public localForm: FormControl;
     public showAddLabel: boolean = false;
@@ -43,8 +46,12 @@ export class AddLabelReactiveComponent implements OnInit {
     }
 
     public buttonClick(e) {
+        console.log('~~~~', this.labelInput);
         e.preventDefault();
         this.showAddLabel = !this.showAddLabel;
+        if (this.showAddLabel) {
+            this.labelInput.nativeElement.focus();
+        }
     }
 
     public inputEnter(e: KeyboardEvent) {

--- a/src/app/global/components/add-label/add-label.component.ts
+++ b/src/app/global/components/add-label/add-label.component.ts
@@ -47,6 +47,17 @@ export class AddLabelReactiveComponent implements OnInit {
         this.showAddLabel = !this.showAddLabel;
     }
 
+    public inputEnter(e: KeyboardEvent) {
+        // requestAnimationFrame is used to give time to auto complete to change form value
+        // The value is checked as well so there is not a submit if the value was set by the autocomplete
+        const valueBeforeCallback = this.localForm.value;
+        requestAnimationFrame(() => {
+            if (this.localForm.status === 'VALID' && valueBeforeCallback === this.localForm.value) {
+                this.addToParent();                
+            }
+        });
+    }
+
     private setStixType() {
         switch (this.stixType) {
         case 'indicator':

--- a/src/app/users/register/register.component.html
+++ b/src/app/users/register/register.component.html
@@ -34,9 +34,9 @@
 
                 <mat-card-content>
                     <br class="mt-10">
-                    <form [formGroup]="form" novalidate (ngSubmit)="registerSubmit()">
+                    <form [formGroup]="form" (keydown.enter)="enterPressed($event)" (ngOnSubmit)="registerSubmit()">
 
-                        <mat-vertical-stepper [linear]="true">
+                        <mat-vertical-stepper [linear]="true" #stepper>
 
                             <mat-step label="User Information" [stepControl]="form.get('unfetterInformation')">
                                 <div id="unfetterInformationForm" formGroupName="unfetterInformation">

--- a/src/app/users/register/register.component.html
+++ b/src/app/users/register/register.component.html
@@ -158,7 +158,7 @@
                         </mat-vertical-stepper>                       
 
                         <p class="text-right mt-10">
-                            <button mat-button routerLink="/">Cancel</button>
+                            <button mat-button type="button" name="cancelBtn" (click)="logOut()">Cancel</button>
                             <button mat-raised-button color="accent" [disabled]="form.status === 'INVALID' || registrationSubmitted" type="submit">Register</button>
                         </p>
 

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -162,12 +162,12 @@ To get the most out of Unfetter, users should be in one or more organizations. A
     public enterPressed(e: KeyboardEvent) {
         console.log(e)
 
-        if (e.target.name === 'cancelBtn') {
-            this.logout();
+        if ((e.target as any).name === 'cancelBtn') {
+            this.logOut();
         }
 
         // Ignore if the cancel button or a stepper back button is clicked
-        if (e.target.name === 'cancelBtn' || ((e as any).target.attributes && (e as any).target.attributes.matstepperprevious)) {
+        if ((e.target as any).name === 'cancelBtn' || ((e as any).target.attributes && (e as any).target.attributes.matstepperprevious)) {
             return;
         }
 

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -1,10 +1,11 @@
 
 import { timer as observableTimer,  Observable  } from 'rxjs';
-
 import { map, switchMap } from 'rxjs/operators';
 import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatStepper } from '@angular/material';
+import { tokenNotExpired } from 'angular2-jwt';
 
 import { UsersService } from '../../core/services/users.service';
 import { AuthService } from '../../core/services/auth.service';
@@ -32,6 +33,9 @@ export class RegisterComponent implements OnInit {
     @ViewChild('importStix')
     public importStixEl: ElementRef;
 
+    @ViewChild('stepper')
+    public stepper: MatStepper;
+
     public helpHtml: string = `
 #### Approval Process
 
@@ -53,7 +57,7 @@ To get the most out of Unfetter, users should be in one or more organizations. A
 
     public ngOnInit() {
         const token = localStorage.getItem('unfetterUiToken');
-        if (token) {
+        if (token && tokenNotExpired('unfetterUiToken')) {
             const userFromToken$ = this.usersService.getUserFromToken()
                 .subscribe(
                     (user) => {
@@ -98,17 +102,22 @@ To get the most out of Unfetter, users should be in one or more organizations. A
                 .catch((err) => console.log(err));
                 
         } else {
-            console.log('User token not set');            
+            console.log('User token not set or is expired');
+            this.router.navigate(['/']);            
         }
     }
 
     public registerSubmit() {
+        if (this.form.status !== 'VALID') {
+            console.log('Invalid attempt to submit registration');
+            return;
+        }
         this.registrationSubmitted = true;
 
         const unfetterInformation = this.form.get('unfetterInformation').value;
         for (let control in unfetterInformation) {
             if (unfetterInformation[control] && unfetterInformation[control] !== '') {
-                if (unfetterInformation[control] instanceof Array) {                    
+                if (unfetterInformation[control] instanceof Array) {
                     let validValues = unfetterInformation[control].filter((el) => el && el !== '');
                     if (validValues && validValues.length) {
                         this.userReturn[control] = validValues;
@@ -116,29 +125,27 @@ To get the most out of Unfetter, users should be in one or more organizations. A
                 } else {
                     this.userReturn[control] = unfetterInformation[control];
                 }
-            }            
-        }  
+            }
+        }
 
-        this.userReturn.identity = { 
-            ...this.importedStixIdentity, 
-            ...cleanObjectProperties({}, { ...this.form.get('identity').value }) 
+        this.userReturn.identity = {
+            ...this.importedStixIdentity,
+            ...cleanObjectProperties({}, { ...this.form.get('identity').value })
         };
         this.userReturn.registrationInformation = cleanObjectProperties({}, { ...this.form.get('registrationInformation').value });
-        
+
         const submitRegistration$ = this.usersService.finalizeRegistration(this.userReturn)
             .subscribe(
                 (res) => {
-                    console.log('SUBMIT RES', res);
-                    
                     let registered = res.attributes.registered;
                     if (registered) {
                         // TODO registration notification
-                        this.authService.setUser(res.attributes);   
-                        this.router.navigate(['/']);                      
+                        this.authService.setUser(res.attributes);
+                        this.router.navigate(['/']);
                     } else {
-                        console.warn('Server did not properly register user.');                        
+                        console.warn('Server did not properly register user.');
                         this.submitError = true;
-                    }    
+                    }
                 },
                 (err) => {
                     console.log(err);
@@ -149,7 +156,30 @@ To get the most out of Unfetter, users should be in one or more organizations. A
                         submitRegistration$.unsubscribe();
                     }
                 }
-            );             
+            );
+    }
+
+    public enterPressed(e: KeyboardEvent) {
+
+        // Ignore if a stepper back button is clicked
+        if ((e as any).target.attributes && (e as any).target.attributes.matstepperprevious) {
+            return;
+        }
+
+        e.preventDefault();
+
+        // Form is valid
+        if (this.form.status === 'VALID') {
+            this.registerSubmit();
+
+        // Step 1 is selected and valid
+        } else if (this.stepper.selectedIndex === 0 && this.form.get('registrationInformation').status === 'VALID') {
+            this.stepper.next();
+
+        // Step 2 is selected
+        } else if (this.stepper.selectedIndex === 1) {
+            this.stepper.next();
+        }
     }
 
     public openFileUpload() {

--- a/src/app/users/register/register.component.ts
+++ b/src/app/users/register/register.component.ts
@@ -160,9 +160,14 @@ To get the most out of Unfetter, users should be in one or more organizations. A
     }
 
     public enterPressed(e: KeyboardEvent) {
+        console.log(e)
 
-        // Ignore if a stepper back button is clicked
-        if ((e as any).target.attributes && (e as any).target.attributes.matstepperprevious) {
+        if (e.target.name === 'cancelBtn') {
+            this.logout();
+        }
+
+        // Ignore if the cancel button or a stepper back button is clicked
+        if (e.target.name === 'cancelBtn' || ((e as any).target.attributes && (e as any).target.attributes.matstepperprevious)) {
             return;
         }
 
@@ -204,6 +209,10 @@ To get the most out of Unfetter, users should be in one or more organizations. A
         } catch (error) {
             this.importErrorMsg = 'Unable to read file';
         }        
+    }
+
+    public logOut() {
+        this.authService.logOut();
     }
 
     private processImportedIdentity(stixContent: any) {


### PR DESCRIPTION
The bulk of this is to prevent accidental submissions via the enter key from the registration page.

Some other things considered while I was looking at this issue:
- Valid submissions still didn't seem to submit correctly via enter
- When I added handling for the enter key in the form, that broke keyboard control of the continue/back buttons
- Expired tokens on the `/users/register` page would prevent the user data from returning on reload
- The custom add label component used in the analytic exchange didn't respond to keyboard controls correctly

Instructions:

Run `npm run lint` locally, due to the rxjs bug still being present.  It will show rxjs related error messages.

On the registration page...
- Hit enter while in a text box and confirm nothing happens
- Complete step 1, and confirm enter takes you to step 2
- Confirm enter on step 2 takes you to step 3 (there are no required steps on step 2)
- Confirm keyboard tabbing to the back buttons work as expected
- Confirm enter while in a text box on step 3 being typing a stix identity name does nothing
- Confirm hitting enter from a valid form submits as expected

In analytic exchange...
- Confirm keyboard handling of adding labels on an analytic card works in an intuitive way, in regards to tabbing and entering, including handling of the auto complete

fixes unfetter-discover/unfetter#1432