### PR TITLE
Issue 1424

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: trusty
 sudo: required
 lanugage: node_js
 node_js:
-  - "10"
+  - "io.js"
+  - "9"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: trusty
 sudo: required
 lanugage: node_js
 node_js:
-  - "io.js"
-  - "9"
+  - "10"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: trusty
 sudo: required
 lanugage: node_js
 node_js:
-  - "node"
+  - "io.js"
+  - "9"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: trusty
 sudo: required
 lanugage: node_js
 node_js:
-  - "io.js"
-  - "9"
+  - "node"
 
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@angular/language-service": "^6.0.5",
     "@angularclass/hmr": "^2.1.3",
     "@ngrx/store-devtools": "^6.0.1",
+    "@types/codemirror": "0.0.60",
     "@types/d3": "~4.12.0",
     "@types/d3-dsv": "^1.0.31",
     "@types/hammerjs": "^2.0.35",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@angular/language-service": "^6.0.5",
     "@angularclass/hmr": "^2.1.3",
     "@ngrx/store-devtools": "^6.0.1",
-    "@types/codemirror": "0.0.60",
+    "@types/codemirror": "~0.0.60",
     "@types/d3": "~4.12.0",
     "@types/d3-dsv": "^1.0.31",
     "@types/hammerjs": "^2.0.35",

--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -2,10 +2,11 @@
 import { pluck } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { UserProfile } from '../../models/user/user-profile';
+import { UserProfile, UserListItem } from '../../models/user/user-profile';
 import { Constance } from '../../utils/constance';
 import { GenericApi } from './genericapi.service';
 import { JsonApiData, Identity } from 'stix';
+import { RxjsHelpers } from '../../global/static/rxjs-helpers';
 
 @Injectable()
 export class UsersService {
@@ -68,6 +69,13 @@ export class UsersService {
         return this.genericApi.get(`${this.authUrl}/username-available/${userName}`).pipe(
             pluck('attributes'),
             pluck('available'));
+    }
+
+    public fetchUserList(): Observable<UserListItem[]> {
+        return this.genericApi.get(`${this.authUrl}/get-user-list`)
+            .pipe(
+                RxjsHelpers.unwrapJsonApi<any>()
+            )
     }
 
 }

--- a/src/app/global/components/markdown-mentions/markdown-mentions.component.html
+++ b/src/app/global/components/markdown-mentions/markdown-mentions.component.html
@@ -1,0 +1,3 @@
+<div (click)="onClick($event)">
+  <markdown [data]="rendered" *ngIf="rendered$ | async as rendered"></markdown>
+</div>

--- a/src/app/global/components/markdown-mentions/markdown-mentions.component.spec.ts
+++ b/src/app/global/components/markdown-mentions/markdown-mentions.component.spec.ts
@@ -1,14 +1,38 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StoreModule } from '@ngrx/store';
+import { MarkdownModule } from 'ngx-markdown';
 
 import { MarkdownMentionsComponent } from './markdown-mentions.component';
+import { reducers } from '../../../root-store/app.reducers';
+import { SetUserList } from '../../../root-store/users/user.actions';
+import { take } from 'rxjs/operators';
+import { UserListItem } from '../../../models/user/user-profile';
 
 describe('MarkdownMentionsComponent', () => {
   let component: MarkdownMentionsComponent;
   let fixture: ComponentFixture<MarkdownMentionsComponent>;
 
+  const mockUsers: UserListItem[] = [
+    {
+      _id: '1234',
+      firstName: 'test',
+      lastName: 'user',
+      userName: 'testuser',
+      avatar_url: 'testuser.com/testuser.jpg'
+    }
+  ];
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ MarkdownMentionsComponent ]
+      declarations: [ MarkdownMentionsComponent ],
+      imports: [
+        StoreModule.forRoot(reducers),
+        RouterTestingModule,
+        MarkdownModule.forRoot()
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();
   }));
@@ -16,10 +40,27 @@ describe('MarkdownMentionsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MarkdownMentionsComponent);
     component = fixture.componentInstance;
+    component['store'].dispatch(new SetUserList(mockUsers));
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render mention of users in user list', fakeAsync((done) => {
+    component.markDown = `@${mockUsers[0].userName}`;
+    const expected = `<a data-link="${mockUsers[0]._id}">@${mockUsers[0].userName}</a>`;
+    fixture.detectChanges();
+    tick(50);
+    expect(component['_markDown']).toBe(expected);
+  }));
+
+  it('should NOT render mention of users NOT in user list', fakeAsync((done) => {
+    component.markDown = '@fakeuser';
+    const expected = '@fakeuser';
+    fixture.detectChanges();
+    tick(50);
+    expect(component['_markDown']).toBe(expected);
+  }));
 });

--- a/src/app/global/components/markdown-mentions/markdown-mentions.component.spec.ts
+++ b/src/app/global/components/markdown-mentions/markdown-mentions.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MarkdownMentionsComponent } from './markdown-mentions.component';
+
+describe('MarkdownMentionsComponent', () => {
+  let component: MarkdownMentionsComponent;
+  let fixture: ComponentFixture<MarkdownMentionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MarkdownMentionsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MarkdownMentionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/global/components/markdown-mentions/markdown-mentions.component.ts
+++ b/src/app/global/components/markdown-mentions/markdown-mentions.component.ts
@@ -1,0 +1,96 @@
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Observable, Subject, combineLatest } from 'rxjs';
+import { map, tap, pluck, debounceTime  } from 'rxjs/operators';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+
+import { AppState } from '../../../app.service';
+import { UserListItem } from '../../../models/user/user-profile';
+
+@Component({
+  selector: 'markdown-mentions',
+  templateUrl: './markdown-mentions.component.html',
+  styleUrls: ['./markdown-mentions.component.scss']
+})
+export class MarkdownMentionsComponent implements OnInit {
+
+  /**
+   * @description If you wish to use this event emitter, be sure to pass in
+   * and empty functions for the onLinkCallback input
+   */
+  @Output()
+  public userIdClicked: EventEmitter<string> = new EventEmitter();
+
+  @Input()
+  public set markDown(md: string) {
+    this.markDown$.next(md)
+  }
+  public get markDown() { return this._markDown }
+
+  /**
+   * @description Used to pass in a Form Control's `valueChanges`
+   */
+  @Input()
+  public markDown$: Subject<string> = new Subject();
+
+  public rendered$: Observable<string>;
+  private _markDown: string;
+
+  /**
+   * @description Adds customizable behavior for clicking of a link to a user.
+   * 
+   * Default behavior is to them to their profile page.
+   * 
+   * If your callback has `this` in it, be sure to set `this.callbackName = this.callbackName.bind(this)`
+   * in the parent class's constructor.
+   */
+  @Input()
+  public onLinkCallback: (userId: string) => void = (userId: string): void => {
+    this.router.navigate([`/users/profile/${userId}`]);
+  };  
+
+  constructor(
+    private store: Store<AppState>,
+    private router: Router
+    ) { }
+
+  ngOnInit() {    
+    this.rendered$ = combineLatest(
+        this.markDown$,
+        this.store.select('users')
+          .pipe(
+            pluck<any, UserListItem[]>('userList')
+          )
+      )
+      .pipe(
+        debounceTime(100),
+        map(([md, users]) => {
+          return md.replace(
+            /(^@\w+)|(\W)(@\w+)/g,
+            (match, g1, g2, g3) => {
+              const user = users.find((_user) => _user.userName === (g1 || g3).substring(1));
+              if (user) {
+                if (g1) {
+                  return `<a data-link="${user._id}">${g1}</a>`;
+                } else {
+                  return `${g2}<a data-link="${user._id}">${g3}</a>`;
+                }
+              } else {
+                return match;
+              }
+            }
+          );
+        }),
+        tap((md) => this._markDown = md),
+      );
+  }
+
+  public onClick(e: any) {
+    const userId = e.target.getAttribute('data-link');
+    if (userId) {
+      this.onLinkCallback(userId);
+      this.userIdClicked.emit(userId);
+    }
+  }
+
+}

--- a/src/app/global/components/markdown-mentions/markdown-mentions.component.ts
+++ b/src/app/global/components/markdown-mentions/markdown-mentions.component.ts
@@ -23,7 +23,7 @@ export class MarkdownMentionsComponent implements OnInit {
 
   @Input()
   public set markDown(md: string) {
-    this.markDown$.next(md)
+    this.markDown$.next(md);
   }
   public get markDown() { return this._markDown }
 
@@ -63,7 +63,7 @@ export class MarkdownMentionsComponent implements OnInit {
           )
       )
       .pipe(
-        debounceTime(100),
+        debounceTime(30),
         map(([md, users]) => {
           return md.replace(
             /(^@\w+)|(\W)(@\w+)/g,

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -1,0 +1,3 @@
+<div class="simpleMdeMentions">
+  <simplemde [(ngModel)]="value"></simplemde>
+</div>

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -9,5 +9,7 @@
         <strong class="flexNowrap">{{ user.userName }}</strong>
     </div>
   </span>
+  <!-- TODO delete this -->
   <p>{{ displayedUsers$ | async | json }}</p>
+  <p>{{ mentionTerm$ | async | json }}</p>
 </div>

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -1,5 +1,5 @@
 <div class="simpleMdeMentions">
-  <simplemde [(ngModel)]="value" #mde></simplemde>
+  <simplemde [(ngModel)]="value" [options]="mdeOptions" #mde></simplemde>
 
   <span id="userMentions" #userMentions [style.display]="showUserMentions ? 'inline-block' : 'none'" class="mat-elevation-z6">
     <div *ngFor="let user of displayedUsers$ | async; let i = index" [class.selected]="i === selectedUserIndex" class="mention flex flesxItemsCenter" (mouseenter)="selectedUserIndex = i" (click)="addMention()">
@@ -9,4 +9,5 @@
         <strong class="flexNowrap">{{ user.userName }}</strong>
     </div>
   </span>
+  <p>{{ displayedUsers$ | async | json }}</p>
 </div>

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -2,11 +2,11 @@
   <simplemde [(ngModel)]="value" [options]="mdeOptions" #mde></simplemde>
 
   <span id="userMentions" #userMentions [style.display]="showUserMentions ? 'inline-block' : 'none'" class="mat-elevation-z6">
-    <div *ngFor="let user of displayedUsers$ | async; let i = index" [class.selected]="i === selectedUserIndex" class="mention flex flesxItemsCenter" (mouseenter)="selectedUserIndex = i" (click)="addMention()">
-        <span>
-          <img src="{{ user.avatar_url }}" class="userAvatar">
-        </span>&nbsp;
-        <strong class="flexNowrap">{{ user.userName }}</strong>
+    <div *ngFor="let user of displayedUsers$ | async; let i = index" [class.selected]="i === selectedUserIndex" class="mention flex flexItemsCenter" (mouseenter)="selectedUserIndex = i" (click)="addMention()">
+        <img src="{{ user.avatar_url }}" class="userAvatar">
+        <span class="fw300 flexNowrap">
+          <strong>&nbsp;{{ user.userName }}</strong> {{ user.firstName }} {{ user.lastName }}
+        </span>
     </div>
   </span>
   <!-- TODO delete this -->

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -9,7 +9,4 @@
         </span>
     </div>
   </span>
-  <!-- TODO delete this -->
-  <p>{{ displayedUsers$ | async | json }}</p>
-  <p>{{ mentionTerm$ | async | json }}</p>
 </div>

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.html
@@ -1,3 +1,12 @@
 <div class="simpleMdeMentions">
-  <simplemde [(ngModel)]="value"></simplemde>
+  <simplemde [(ngModel)]="value" #mde></simplemde>
+
+  <span id="userMentions" #userMentions [style.display]="showUserMentions ? 'inline-block' : 'none'" class="mat-elevation-z6">
+    <div *ngFor="let user of displayedUsers$ | async; let i = index" [class.selected]="i === selectedUserIndex" class="mention flex flesxItemsCenter" (mouseenter)="selectedUserIndex = i" (click)="addMention()">
+        <span>
+          <img src="{{ user.avatar_url }}" class="userAvatar">
+        </span>&nbsp;
+        <strong class="flexNowrap">{{ user.userName }}</strong>
+    </div>
+  </span>
 </div>

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.scss
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.scss
@@ -1,0 +1,29 @@
+@import '../../../../styles/modules/mixins';
+
+#userMentions {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 950;
+  background: #fff;
+  display: none;
+}
+
+.mention {
+  padding: 3px 8px;
+  width: 150px;
+}
+
+.mention:not(:last-child) {
+  border-bottom: 1px solid #E0E0E0;
+}
+
+.selected {
+  @include themePrimaryColors('background-color');
+  @include themeAccentText();
+}
+
+.userAvatar {
+    border-radius: 15%;
+    height: 17px;
+}

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.scss
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.scss
@@ -10,8 +10,8 @@
 }
 
 .mention {
-  padding: 3px 8px;
-  width: 150px;
+  padding: 5px 10px;
+  width: 215px;
 }
 
 .mention:not(:last-child) {

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.spec.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SimplemdeMentionsComponent } from './simplemde-mentions.component';
+
+describe('SimplemdeMentionsComponent', () => {
+  let component: SimplemdeMentionsComponent;
+  let fixture: ComponentFixture<SimplemdeMentionsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SimplemdeMentionsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SimplemdeMentionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.spec.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.spec.ts
@@ -1,14 +1,28 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { StoreModule } from '@ngrx/store';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { SimplemdeMentionsComponent } from './simplemde-mentions.component';
+import { reducers } from '../../../root-store/app.reducers';
 
-describe('SimplemdeMentionsComponent', () => {
+/**
+ * TODO figure how to write a test for a ControlValueAccessor
+ */
+xdescribe('SimplemdeMentionsComponent', () => {
   let component: SimplemdeMentionsComponent;
   let fixture: ComponentFixture<SimplemdeMentionsComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SimplemdeMentionsComponent ]
+      declarations: [ SimplemdeMentionsComponent ],
+      imports: [
+        FormsModule,
+        ReactiveFormsModule,
+        StoreModule.forRoot(reducers),
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
     })
     .compileComponents();
   }));

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
@@ -1,5 +1,10 @@
-import { Component, forwardRef } from '@angular/core';
+import { Component, forwardRef, ViewChild, ElementRef, AfterViewInit, OnInit } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/forms';
+import { of as observableOf, BehaviorSubject, Observable, combineLatest } from 'rxjs';
+import { Simplemde } from 'ng2-simplemde';
+import { Key } from 'ts-keycode-enum';
+import { take, switchMap, combineAll, map } from 'rxjs/operators';
+import { UserHelpers } from '../../static/user-helpers';
 
 @Component({
   selector: 'simplemde-mentions',
@@ -13,36 +18,181 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/f
     }
   ]
 })
-export class SimplemdeMentionsComponent implements ControlValueAccessor {
+export class SimplemdeMentionsComponent implements ControlValueAccessor, AfterViewInit, OnInit {
 
-  private onTouchedCallback: () => {}
-  private onChangeCallback: (_: any) => {}
-  private _innerValue: any;
+  // TODO delete junk data
+  public user$ = observableOf([
+    {
+      userName: 'Bobby3',
+      _id: '1234'
+    },
+    {
+      userName: 'JiMMy4',
+      _id: '5678'
+    },
+    {
+      userName: 'todamaxxxxx',
+      _id: '5436'
+    },
+    {
+      userName: 'henryhenry',
+      _id: '978456'
+    }
+  ]);
+  public displayedUsers$: Observable<any>;
+  public selectedUserIndex = 0;
+  public showUserMentions = false;
+  @ViewChild('userMentions') public userMentions: ElementRef;
+  @ViewChild('mde') public mde: Simplemde | any;
 
-  constructor() { }
+  private codeMirror: any;
+  private mentionTerm$ = new BehaviorSubject('');
+  private onTouchedCallback: () => {};
+  private onChangeCallback: (_: any) => {};
+  private _innerValue: string;
 
-  set value(v: any) {
+  public ngOnInit() {
+    this.displayedUsers$ = combineLatest(this.user$, this.mentionTerm$)
+      .pipe(
+        map(([users, mentionTerm]) => {
+          return users
+            .filter((user) => {
+              return user.userName.toLowerCase().indexOf(mentionTerm.toLowerCase()) > -1
+            })
+            .map((user: any) => {
+              user.avatar_url = UserHelpers.getAvatarUrl(user);
+              return user;
+            });          
+        })
+      );
+  }
+
+  public ngAfterViewInit() {
+    this.codeMirror = this.mde.simplemde.codemirror;
+
+    this.codeMirror.on('keydown', (_, event: KeyboardEvent) => {
+      if (!this.showUserMentions) {
+        if (event.keyCode === Key.AtSign) {
+          this.mentionTerm$.next('');
+          this.showUserMentions = true;
+          const pos = this.codeMirror.cursorCoords();
+          const left = pos.left + 10, top = pos.bottom;
+          this.userMentions.nativeElement.style.left = left + 'px';
+          this.userMentions.nativeElement.style.top = top + 'px';
+        }
+      } else if (this.showUserMentions) {
+        switch (event.keyCode) {
+          case Key.UpArrow:
+            if (this.selectedUserIndex > 0) {
+              this.selectedUserIndex--;
+            }
+            event.preventDefault();
+            break;
+          case Key.DownArrow:            
+            this.user$.pipe(take(1)).subscribe((users) => {
+              if (this.selectedUserIndex + 1 < users.length) {
+                this.selectedUserIndex++;
+              }
+            });
+            event.preventDefault();
+            break;
+          case Key.Escape:
+            // case Key.Space:
+            this.showUserMentions = false;
+            break;
+          case Key.Backspace:
+            if (this.value.endsWith('@')) {
+              this.showUserMentions = false;
+            }
+            this.mentionTerm$.next(this.mentionTerm$.value.slice(0, -1));
+            break;
+          case Key.Enter:
+            event.preventDefault();
+            this.addMention();
+            break;
+          default:
+            if (event.keyCode >= 33 && event.keyCode <= 126) {
+              this.mentionTerm$.next(this.mentionTerm$.value.concat(event.key));
+            }
+            this.selectedUserIndex = 0;
+        }
+      }      
+    });
+  }
+
+  public addMention() {
+    const doc = this.codeMirror.getDoc();
+    const cursor = doc.getCursor();
+
+    const pos = {
+      line: cursor.line,
+      ch: cursor.ch
+    };
+
+    combineLatest(this.displayedUsers$, this.mentionTerm$)
+      .pipe(take(1))
+      .subscribe(([users, mentionTerm]) => {
+
+        // Delete the search string
+        if (mentionTerm && mentionTerm.length) {
+          pos.ch = pos.ch - mentionTerm.length;
+          this.codeMirror.replaceRange('', pos, { line: pos.line, ch: pos.ch + mentionTerm.length });
+        }
+
+        if (users[this.selectedUserIndex]) {
+          const newMention = `${users[this.selectedUserIndex].userName} `;
+
+          doc.replaceRange(newMention, pos);
+
+          requestAnimationFrame(() => {
+            this.codeMirror.focus();
+            this.codeMirror.setCursor(pos.line, pos.ch + newMention.length);
+            this.codeMirror.markText(
+              { line: pos.line, ch: pos.ch - 1 },
+              { line: pos.line, ch: pos.ch + newMention.length - 1 },
+              { className: 'mentionHighlight' }
+            );
+          });
+
+          this.showUserMentions = false;
+        }
+      });
+  }
+
+  set value(v: string) {
     if (v !== this._innerValue) {
-      this._innerValue = v
-      this.onChangeCallback(v)
+      this._innerValue = v;
+      this.onChangeCallback(v);
     }
   }
 
-  get value(): any {
-    return this._innerValue
+  get value(): string {
+    return this._innerValue;
   }
 
+  /**
+   * @override ControlValueAccessor
+   * @param fn
+   */
   registerOnChange(fn: any) {
     this.onChangeCallback = fn;
   }
 
+  /**
+   * @override ControlValueAccessor
+   * @param fn 
+   */
   registerOnTouched(fn: any) {
     this.onTouchedCallback = fn;
   }
 
-  writeValue(v: any) {
+  /**
+   * @override ControlValueAccessor
+   * @param v 
+   */
+  writeValue(v: string) {
     if (v !== this._innerValue) {
-      this._innerValue = v
+      this._innerValue = v;
     }
   }
 }

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
@@ -226,29 +226,31 @@ export class SimplemdeMentionsComponent implements ControlValueAccessor, AfterVi
         const doc = this.codeMirror.getDoc();
         
         // Delete the search string
+        const pos = mentionTerm.wordRange.anchor;
         if (mentionTerm && mentionTerm.term.length) {
           const rangeToReplace = this.codeMirrorHelpers.getMentionTermRange(mentionTerm.wordRange);
-          // TODO Update { start: number, end: number } in getMentionTermRange to user code mirror positions
-          // doc.replaceRange('', pos, { line: pos.line, ch: pos.ch + mentionTerm.term.length });
+          pos.ch = rangeToReplace.start;
+          const line = mentionTerm.wordRange.anchor.line;
+          doc.replaceRange('', { line, ch: rangeToReplace.start }, { line, ch: rangeToReplace.end + 1 });
         }
 
         // // Insert mention
-        // if (users[this.selectedUserIndex]) {
-        //   const newMention = `${users[this.selectedUserIndex].userName} `;
+        if (users[this.selectedUserIndex]) {
+          const newMention = `@${users[this.selectedUserIndex].userName} `;
 
-        //   doc.replaceRange(newMention, pos);
+          doc.replaceRange(newMention, pos);
 
-        //   requestAnimationFrame(() => {
-        //     this.codeMirror.focus();
-        //     doc.setCursor(pos.line, pos.ch + newMention.length);
-        //     doc.markText(
-        //       { line: pos.line, ch: pos.ch - 1 },
-        //       { line: pos.line, ch: pos.ch + newMention.length - 1 },
-        //       { className: 'mentionHighlight' }
-        //     );
-        //   });
-        //   this.showUserMentions = false;
-        // }
+          requestAnimationFrame(() => {
+            this.codeMirror.focus();
+            doc.setCursor(pos.line, pos.ch + newMention.length);
+            doc.markText(
+              { line: pos.line, ch: pos.ch - 1 },
+              { line: pos.line, ch: pos.ch + newMention.length - 1 },
+              { className: 'mentionHighlight' }
+            );
+          });
+          this.showUserMentions = false;
+        }
       });
   }
 

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
@@ -10,7 +10,7 @@ import { UserHelpers } from '../../static/user-helpers';
 import { SimpleMDEConfig } from '../../static/simplemde-config';
 import { HostListener } from '@angular/core';
 import { RxjsHelpers } from '../../static/rxjs-helpers';
-import { CodeMirrorHelpers, CursorPos } from '../../static/codemirror-helpers';
+import { CodeMirrorHelpers } from '../../static/codemirror-helpers';
 
 @Component({
   selector: 'simplemde-mentions',
@@ -67,7 +67,7 @@ export class SimplemdeMentionsComponent implements ControlValueAccessor, AfterVi
     }
   };
     
-  private atSignPosition: CursorPos;
+  private atSignPosition: CodeMirror.Position;
   private _showUserMentions = false;
   private codeMirror: any;
   private codeMirrorHelpers: CodeMirrorHelpers;
@@ -113,15 +113,17 @@ export class SimplemdeMentionsComponent implements ControlValueAccessor, AfterVi
     this.codeMirrorHelpers = new CodeMirrorHelpers(this.codeMirror);
 
     this.codeMirror.on('keydown', (_, event: KeyboardEvent) => {
-      const cursor: CodeMirror.Range | { from: any, to: any } = this.codeMirrorHelpers.getCursor();
-      const word = this.codeMirrorHelpers.getWordAt(cursor.to);         
+      const cursor = this.codeMirrorHelpers.getCursor();
+      const word = this.codeMirrorHelpers.getWordAt(cursor.to);        
       
       if (cursor.from.line !== cursor.to.line || cursor.from.ch !== cursor.to.ch) {
         // Stop if a multi selection occured
-        this.showUserMentions = false;      
+        this.showUserMentions = false;
+        this.atSignPosition = null;      
       } else if (!this.showUserMentions) {
         // Show mentions menu(s)
         if (event.keyCode === Key.AtSign) {
+          this.atSignPosition = cursor.to;
           this.mentionTerm$.next('');
           this.showUserMentions = true;
           this.codeMirrorHelpers.positionAtCursor(this.userMentions.nativeElement);

--- a/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
+++ b/src/app/global/components/simplemde-mentions/simplemde-mentions.component.ts
@@ -1,0 +1,48 @@
+import { Component, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'simplemde-mentions',
+  templateUrl: './simplemde-mentions.component.html',
+  styleUrls: ['./simplemde-mentions.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SimplemdeMentionsComponent),
+      multi: true
+    }
+  ]
+})
+export class SimplemdeMentionsComponent implements ControlValueAccessor {
+
+  private onTouchedCallback: () => {}
+  private onChangeCallback: (_: any) => {}
+  private _innerValue: any;
+
+  constructor() { }
+
+  set value(v: any) {
+    if (v !== this._innerValue) {
+      this._innerValue = v
+      this.onChangeCallback(v)
+    }
+  }
+
+  get value(): any {
+    return this._innerValue
+  }
+
+  registerOnChange(fn: any) {
+    this.onChangeCallback = fn;
+  }
+
+  registerOnTouched(fn: any) {
+    this.onTouchedCallback = fn;
+  }
+
+  writeValue(v: any) {
+    if (v !== this._innerValue) {
+      this._innerValue = v
+    }
+  }
+}

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -91,6 +91,7 @@ import { AuthService } from '../core/services/auth.service';
 import { ReadableBytesPipe } from './pipes/readable-bytes.pipe';
 import { UnfetterCarouselComponent, PrimedDirective } from './components/tactics-pane/tactics-carousel/unf-carousel.component';
 import { ScrollTrapDirective } from './directives/scroll-trap.directive';
+import { SimplemdeMentionsComponent } from './components/simplemde-mentions/simplemde-mentions.component';
 
 const matModules = [
     MatAutocompleteModule,
@@ -172,6 +173,7 @@ const unfetterComponents = [
     ExternalReferencesListComponent,
     ImplementationsListComponent,
     AddLabelAltComponent,
+    SimplemdeMentionsComponent,
 ];
 
 @NgModule({
@@ -206,7 +208,7 @@ const unfetterComponents = [
     ],
     declarations: [
         ...unfetterComponents,
-        ScrollTrapDirective,        
+        ScrollTrapDirective,      
     ],
     exports: [
         ...unfetterComponents,

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -92,6 +92,7 @@ import { ReadableBytesPipe } from './pipes/readable-bytes.pipe';
 import { UnfetterCarouselComponent, PrimedDirective } from './components/tactics-pane/tactics-carousel/unf-carousel.component';
 import { ScrollTrapDirective } from './directives/scroll-trap.directive';
 import { SimplemdeMentionsComponent } from './components/simplemde-mentions/simplemde-mentions.component';
+import { SimpleMDEConfig } from './static/simplemde-config';
 
 const matModules = [
     MatAutocompleteModule,
@@ -198,11 +199,7 @@ const unfetterComponents = [
         }),
         SimplemdeModule.forRoot({
             provide: SIMPLEMDE_CONFIG,
-            useValue: {
-                spellChecker: false,
-                autoDownloadFontAwesome: false,
-                status: false
-            }
+            useValue: SimpleMDEConfig.basicConfig
         }),
         ...matModules
     ],

--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -93,6 +93,7 @@ import { UnfetterCarouselComponent, PrimedDirective } from './components/tactics
 import { ScrollTrapDirective } from './directives/scroll-trap.directive';
 import { SimplemdeMentionsComponent } from './components/simplemde-mentions/simplemde-mentions.component';
 import { SimpleMDEConfig } from './static/simplemde-config';
+import { MarkdownMentionsComponent } from './components/markdown-mentions/markdown-mentions.component';
 
 const matModules = [
     MatAutocompleteModule,
@@ -175,6 +176,8 @@ const unfetterComponents = [
     ImplementationsListComponent,
     AddLabelAltComponent,
     SimplemdeMentionsComponent,
+    MarkdownMentionsComponent,
+    ScrollTrapDirective,
 ];
 
 @NgModule({
@@ -204,8 +207,7 @@ const unfetterComponents = [
         ...matModules
     ],
     declarations: [
-        ...unfetterComponents,
-        ScrollTrapDirective,      
+        ...unfetterComponents,        
     ],
     exports: [
         ...unfetterComponents,

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -59,7 +59,6 @@ export class CodeMirrorHelpers {
         if (range.anchor.line !== range.head.line) {
             console.log('Warning: Attempting to retrieve a multi-line word');
         }
-        const rangeDelta = range.head.ch - range.anchor.ch;
         let text = '';
         for (let i = range.anchor.ch; i <= range.head.ch; i++) {
             const pos: CodeMirror.Position = {

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -5,6 +5,10 @@ interface CodeMirrorWord {
     text: string
 }
 
+interface CursorGroup {
+    [index: string]: CodeMirror.Position
+}
+
 export type CursorTypes = 'anchor' | 'from' | 'head' | 'to';
 
 /**
@@ -21,7 +25,7 @@ export class CodeMirrorHelpers {
      * @param {CursorTypes} cursorTypes
      * @returns {CursorSelection}
      */
-    getCursor(...cursorTypes: CursorTypes[]): CodeMirror.Range {
+    getCursor(...cursorTypes: CursorTypes[]): CursorGroup {
         const doc = this.codeMirror.getDoc();
         const cursor = doc.getCursor();
 

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -54,7 +54,8 @@ export class CodeMirrorHelpers {
      *            it will be the state of the text is changed
      */
     getWordAt(cursorPos: CodeMirror.Position): CodeMirrorWord {
-        const range = this.codeMirror.findWordAt(cursorPos);
+        // NOTE this is unreliable for mentions in the middle of a sentence
+        const range = this.codeMirror.findWordAt(cursorPos);      
         if (range.anchor.line !== range.head.line) {
             console.log('Warning: Attempting to retrieve a multi-line word');
         }

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -1,4 +1,4 @@
-import * as CodeMirror from 'CodeMirror';
+import * as CodeMirror from 'codemirror';
 
 interface CodeMirrorWord {
     range: CodeMirror.Range,

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -1,20 +1,8 @@
-export interface CursorPos {
-    line: number,
-    ch: number
-}
+import * as CodeMirror from 'CodeMirror';
 
-/**
- * doc.getCursor(?start: string) → {line, ch}
- *    Retrieve one end of the primary selection. start is an optional string indicating which end of the selection to return. 
- *    It may be "from", "to", "head" (the side of the selection that moves when you press shift+arrow), 
- *    or "anchor" (the fixed side of the selection). Omitting the argument is the same as passing "head". 
- *    A {line, ch} object will be returned.
- */
-export interface CursorSelection {
-    anchor?: CursorPos,
-    from?: CursorPos,
-    head?: CursorPos
-    to?: CursorPos,
+interface CodeMirrorWord {
+    range: CodeMirror.Range,
+    text: string
 }
 
 export type CursorTypes = 'anchor' | 'from' | 'head' | 'to';
@@ -23,7 +11,7 @@ export type CursorTypes = 'anchor' | 'from' | 'head' | 'to';
  * @description Contains a set of functions that simplifies interaction with CodeMirror
  */
 export class CodeMirrorHelpers {
-    private codeMirror;
+    private codeMirror: CodeMirror.Editor;
 
     constructor(codeMirror) {
         this.codeMirror = codeMirror;
@@ -33,7 +21,7 @@ export class CodeMirrorHelpers {
      * @param {CursorTypes} cursorTypes
      * @returns {CursorSelection}
      */
-    getCursor(...cursorTypes: CursorTypes[]): CursorSelection {
+    getCursor(...cursorTypes: CursorTypes[]): CodeMirror.Range {
         const doc = this.codeMirror.getDoc();
         const cursor = doc.getCursor();
 
@@ -43,13 +31,74 @@ export class CodeMirrorHelpers {
                 from: doc.getCursor('from'),
                 head: doc.getCursor('head'),
                 to: doc.getCursor('to')
-            };
+            } as any;
         } else {
-            const retVal = {};
+            const retVal: any = {};
             cursorTypes.forEach((cursorType) => {
                 retVal[cursorType] = doc.getCursor(cursorType);
             });
             return retVal;
+        }
+    }
+
+    
+    /**
+     * @param  {CodeMirror.Position} cursorPos
+     * @returns {CodeMirrorWord}
+     * @description Helper function to help detect words at a given cursor
+     *      Note: Remember that when used in conjuction with a keydown event, 
+     *            it will be the state of the text is changed
+     */
+    getWordAt(cursorPos: CodeMirror.Position): CodeMirrorWord {
+        const range = this.codeMirror.findWordAt(cursorPos);
+        if (range.anchor.line !== range.head.line) {
+            console.log('Warning: Attempting to retrieve a multi-line word');
+        }
+        const rangeDelta = range.head.ch - range.anchor.ch;
+        let text = '';
+        for (let i = range.anchor.ch; i <= range.head.ch; i++) {
+            const pos: CodeMirror.Position = {
+                line: range.head.line,
+                ch: i
+            };
+            const token = this.codeMirror.getTokenAt(pos);
+            text += token.string;
+        }
+        return { range, text: text };
+    }
+
+    
+    /**
+     * @param  {CodeMirrorWord} word
+     * @param  {CodeMirror.Position} pos
+     * @param  {string} letter
+     * @returns string
+     * @description Predicts what a word will be after a letter is inserted at a position
+     */
+    predictWord(word: CodeMirrorWord, pos: CodeMirror.Position, letter: string): string {
+        if (letter.length !== 1) {
+            console.log('Warning: word prediction is supposed to take a single letter');
+        }
+        let retVal = word.text.substring(0, pos.ch - word.range.anchor.ch + 1);
+        retVal += letter;
+        if (word.range.head.ch > pos.ch) {
+            retVal += word.text.substring(pos.ch - word.range.anchor.ch + 1, word.range.head.ch - word.range.anchor.ch + 1);
+        }
+        return retVal;
+    }
+
+    /**
+     * @param {any} nativeElement
+     * @description Positions an absolute positioned HTML element at cursor
+     */
+    positionAtCursor(nativeElement: any) {
+        const pos = this.codeMirror.cursorCoords(false);
+        const left = pos.left + 10, top = pos.bottom;
+        if (!nativeElement.style) {
+            console.log('Warning: Attempt to style an object without a style property');
+        } else {
+            nativeElement.style.left = left + 'px';
+            nativeElement.style.top = top + 'px';
         }
     }
 }

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -1,0 +1,55 @@
+export interface CursorPos {
+    line: number,
+    ch: number
+}
+
+/**
+ * doc.getCursor(?start: string) → {line, ch}
+ *    Retrieve one end of the primary selection. start is an optional string indicating which end of the selection to return. 
+ *    It may be "from", "to", "head" (the side of the selection that moves when you press shift+arrow), 
+ *    or "anchor" (the fixed side of the selection). Omitting the argument is the same as passing "head". 
+ *    A {line, ch} object will be returned.
+ */
+export interface CursorSelection {
+    anchor?: CursorPos,
+    from?: CursorPos,
+    head?: CursorPos
+    to?: CursorPos,
+}
+
+export type CursorTypes = 'anchor' | 'from' | 'head' | 'to';
+
+/**
+ * @description Contains a set of functions that simplifies interaction with CodeMirror
+ */
+export class CodeMirrorHelpers {
+    private codeMirror;
+
+    constructor(codeMirror) {
+        this.codeMirror = codeMirror;
+    }
+
+    /**
+     * @param {CursorTypes} cursorTypes
+     * @returns {CursorSelection}
+     */
+    getCursor(...cursorTypes: CursorTypes[]): CursorSelection {
+        const doc = this.codeMirror.getDoc();
+        const cursor = doc.getCursor();
+
+        if (!cursorTypes.length) {
+            return {
+                anchor: doc.getCursor('anchor'),
+                from: doc.getCursor('from'),
+                head: doc.getCursor('head'),
+                to: doc.getCursor('to')
+            };
+        } else {
+            const retVal = {};
+            cursorTypes.forEach((cursorType) => {
+                retVal[cursorType] = doc.getCursor(cursorType);
+            });
+            return retVal;
+        }
+    }
+}

--- a/src/app/global/static/codemirror-helpers.ts
+++ b/src/app/global/static/codemirror-helpers.ts
@@ -158,7 +158,7 @@ export class CodeMirrorHelpers {
      */
     positionAtCursor(nativeElement: any) {
         const pos = this.codeMirror.cursorCoords(false);
-        const left = pos.left + 10, top = pos.bottom;
+        const left = pos.left + 13, top = pos.bottom + 2;
         if (!nativeElement.style) {
             console.log('Warning: Attempt to style an object without a style property');
         } else {

--- a/src/app/global/static/simplemde-config.ts
+++ b/src/app/global/static/simplemde-config.ts
@@ -1,0 +1,10 @@
+import * as SimpleMDE from 'simplemde';
+
+export class SimpleMDEConfig {
+    
+    public static basicConfig: SimpleMDE.Options = {
+        spellChecker: false,
+        autoDownloadFontAwesome: false,
+        status: false
+    };
+}

--- a/src/app/models/user/user-profile.ts
+++ b/src/app/models/user/user-profile.ts
@@ -24,3 +24,14 @@ export class UserProfile {
     public avatar_url?: string;
     organizations: OrganizationIdentity[] = [];
 }
+
+/**
+ * @description The portion of the UserProfile availible in the site-wide user list
+ */
+export class UserListItem implements Partial<UserProfile> {
+    public _id: string;
+    public userName: string;
+    public lastName: string;
+    public firstName: string;
+    public avatar_url?: string;
+}

--- a/src/app/root-store/users/user.actions.ts
+++ b/src/app/root-store/users/user.actions.ts
@@ -1,7 +1,11 @@
 import { Action } from '@ngrx/store';
 
+import { UserListItem } from '../../models/user/user-profile';
+
 export const FETCH_USER = '[User] Fetch User';
 export const FETCH_USER_ONLY = '[User] Fetch User Only';
+export const FETCH_USER_LIST = '[User] Fetch User List';
+export const SET_USER_LIST = '[User] Set User List';
 export const LOGIN_USER = '[User] Login User';
 export const UPDATE_USER_DATA = '[User] Add User Data';
 export const LOGOUT_USER = '[User] Logout User';
@@ -9,15 +13,30 @@ export const SET_TOKEN = '[User] Set Token';
 export const REFRESH_TOKEN = '[User] Refresh Token';
 export const START_USER_OBJECT_STREAM = '[User] Start User Object Stream';
 
+/**
+ * @description This version triggers multiple effects
+ */
 export class FetchUser implements Action {
     public readonly type = FETCH_USER;
 
     constructor(public payload: string) {}
 }
 
+/**
+ * @description This version does not trigger any other effects
+ */
 export class FetchUserOnly implements Action {
     public readonly type = FETCH_USER_ONLY;
+}
 
+export class FetchUserList implements Action {
+    public readonly type = FETCH_USER_LIST;
+}
+
+export class SetUserList implements Action {
+    public readonly type = SET_USER_LIST;
+
+    constructor(public payload: UserListItem[]) { }
 }
 
 export class LoginUser implements Action {
@@ -53,6 +72,8 @@ export class StartUserObjectStream implements Action {
 export type UserActions = 
     FetchUser |
     FetchUserOnly |
+    FetchUserList |
+    SetUserList |
     LoginUser |
     UpdateUserData |
     LogoutUser |

--- a/src/app/root-store/users/users.reducers.spec.ts
+++ b/src/app/root-store/users/users.reducers.spec.ts
@@ -14,7 +14,16 @@ describe('usersReducer', () => {
             approved: false,
             locked: false,
             role: 'STANDARD_USER',
-            avatar_url: '1234.com/img1'
+            avatar_url: '1234.com/img1',
+            userList: [
+                {
+                    _id: '5678',
+                    userName: 'bob',
+                    firstName: 'jim',
+                    lastName: 'bob',
+                    avatar_url: '5678.com/img1',
+                }
+            ]
         };
     });
 
@@ -43,7 +52,8 @@ describe('usersReducer', () => {
                 }
             },
             authenticated: true,
-            avatar_url: mockState.avatar_url
+            avatar_url: mockState.avatar_url,
+            userList: []
         };
         expect(usersReducer(undefined, new userActions.LoginUser(payload))).toEqual(expected);
     });

--- a/src/app/root-store/users/users.reducers.ts
+++ b/src/app/root-store/users/users.reducers.ts
@@ -1,5 +1,5 @@
 import * as userActions from './user.actions';
-import { UserProfile } from '../../models/user/user-profile';
+import { UserProfile, UserListItem } from '../../models/user/user-profile';
 import { UserHelpers } from '../../global/static/user-helpers';
 
 export interface UserState {
@@ -9,7 +9,8 @@ export interface UserState {
     approved: boolean,
     locked: boolean,
     role: string,
-    avatar_url: string
+    avatar_url: string,
+    userList: UserListItem[]
 }
 
 export const initialState: UserState = {
@@ -19,7 +20,8 @@ export const initialState: UserState = {
     approved: false,
     locked: false,
     role: null,
-    avatar_url: null
+    avatar_url: null,
+    userList: []
 }
 
 export function usersReducer(state = initialState, action: userActions.UserActions) {
@@ -45,6 +47,11 @@ export function usersReducer(state = initialState, action: userActions.UserActio
                 userProfile: {
                     ...action.payload
                 },
+            };
+        case userActions.SET_USER_LIST:
+            return {
+                ...state,
+                userList: action.payload
             };
         case userActions.LOGOUT_USER:
             return {

--- a/src/styles/partials/_styles.scss
+++ b/src/styles/partials/_styles.scss
@@ -387,3 +387,11 @@ code.codeBlock {
     white-space: pre;
     overflow-x: auto;
 }
+
+.mentionHighlight {
+    color: #337ab7;
+
+    .threatDashboardTheme & {
+        color: $threat-dashboard-primary;
+    }
+}


### PR DESCRIPTION
Requires `issue-1424` on `unfetter-ui` and `unfetter-store`

Associated PR: https://github.com/unfetter-discover/unfetter-store/pull/255

This is a _rough draft_ of user mentions.  The behavior of these is intended to mimic GitHub's user mentions.  I used CodeMirror's word detection functionality to detect the search string, which is going to have to be replaced in the future as it's only reliable if the search word is the last word in the line.  https://github.com/unfetter-discover/unfetter/issues/1455

Additionally, this does not place this version of simpleMDE into any existing components.

Instructions:

- Add additional users (these can be fake) - see `https://github.com/unfetter-discover/unfetter/issues/1424#issuecomment-422118305` 
- Copy the following into any component's HTML - even `unfetter-ui/src/app/app.component.html` would work

```
<div class="container mt-20 mb-20">
  <div class="row" #mentionsTestWrapper>
    <p>Test value: {{ mentionsTestWrapper.testVal }}</p>
    <simplemde-mentions [(ngModel)]="mentionsTestWrapper.testVal"></simplemde-mentions>
    <markdown-mentions [markDown]="mentionsTestWrapper.testVal"></markdown-mentions>
  </div>
</div>
```

SimpleMDE Mentions (the text box):

- Confirm use of `@` and `@substring` works similar to GitHub mentions
- For any unexpected behavior, test the same scenario in GitHub and report if it's different in this implementing
- As stated before, that this implementation only works correctly with end-of-line mentions

Markdown Mentions (the rendered content under the text box):

- Confirm that mentions of users in the DB create a working link to their profile
- Confirm that mentions of users not in the system, eg `@fakeuser`, are not rendered with a link

fixes unfetter-discover/unfetter#1424