### PR TITLE
Issue 1060: Baselines: Support addition of capabilities within capability selector 

### DIFF
--- a/src/app/baseline/store/baseline.actions.ts
+++ b/src/app/baseline/store/baseline.actions.ts
@@ -23,6 +23,7 @@ export const REMOVE_OBJECT_ASSESSMENTS_FROM_BASELINE = '[Baseline] REMOVE_OBJECT
 export const SET_CURRENT_BASELINE_CAPABILITY = '[Baseline] SET_CURRENT_BASELINE_CAPABILITY';
 export const SET_BASELINE = '[Baseline] SET_BASELINE';
 export const ADD_CAPABILITY_GROUP = '[Baseline] ADD_CAPABILITY_GROUP';
+export const ADD_CAPABILITY = '[Baseline] ADD_CAPABILITY';
 export const REMOVE_CAPABILITY_GROUP_FROM_BASELINE = '[Baseline] REMOVE_CAPABILITY_GROUP_FROM_BASELINE'
 export const SAVE_OBJECT_ASSESSMENTS = '[Baseline] SAVE_OBJECT_ASSESSMENTS';
 export const FAILED_TO_LOAD = '[Baseline] FAILED_TO_LOAD';
@@ -157,6 +158,12 @@ export class SetCapabilities implements Action {
     public readonly type = SET_CAPABILITIES;
 
     constructor(public payload: Capability[]) { }
+}
+
+export class AddCapability implements Action {
+    public readonly type = ADD_CAPABILITY;
+
+    constructor(public payload: Capability) { }
 }
 
 export class SetBaselineCapabilities implements Action {

--- a/src/app/baseline/store/baseline.effects.ts
+++ b/src/app/baseline/store/baseline.effects.ts
@@ -277,6 +277,30 @@ export class BaselineEffects {
         )
 
     @Effect()
+    public addCapability = this.actions$
+        .ofType(baselineActions.ADD_CAPABILITY)
+        .pipe(
+            pluck('payload'),
+            switchMap(( capability: Capability) => {
+                const json = {
+                    data: { attributes: capability }
+                } as JsonApi<JsonApiData<Capability>>;
+                let url = Constance.X_UNFETTER_CAPABILITY_URL;
+                if (capability.id) {
+                    url = `${url}/${capability.id}`;
+                    return this.genericServiceApi
+                    .patchAs<Capability>(url, json);
+                } else {
+                    return this.genericServiceApi
+                    .postAs<Capability>(url, json);
+                }
+            }),
+            map((capability) => {
+                return new baselineActions.FetchCapabilities();
+            })
+        )
+
+    @Effect()
     public removeCapabilityGroupFromBaseline = this.actions$
         .ofType(baselineActions.REMOVE_CAPABILITY_GROUP_FROM_BASELINE)
         .pipe(

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.html
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.html
@@ -5,6 +5,24 @@
             {{ currentCapabilityGroup.name }} Capabilities
           </mat-card-title>
         </div>
+        <div class="col-sm-3">
+          <div *ngIf="!isAddCapability" class="button-row">
+            <button mat-raised-button (click)="createNewCapability()"><i class="material-icons">add</i>ADD CAPABILITY</button>
+          </div>          
+        </div>
+      </div>
+      <div *ngIf="isAddCapability">
+        <div class="row margin-bottom flex-sm flexItemsCenter">
+          <div class="col-sm-9">
+            <div class="form-group">
+              <mat-form-field class="full-width">
+                <input matInput class="form-control" required placeholder="Capability Name" value="addCapability.name" [(ngModel)]="addCapability.name">
+              </mat-form-field>
+            </div>
+            <button type="submit"  class="mat-primary" mat-raised-button [disabled]="!addCapability.name" (click)="addNewCapability(addCapability)"><i class="material-icons">save</i> SAVE {{ addCapability.name }}</button>
+            <button type="submit"  class="mat-primary" mat-raised-button (click)="cancelAddNewCapability()">CANCEL</button>
+          </div>
+        </div>
       </div>
       <div class="row margin-bottom" *ngFor="let selCapability of selectedCapabilities; index as i; trackBy: trackByFn">
         <div class="col-xs-12">

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.spec.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { MatButtonModule, MatCardModule, MatIconModule, MatSelectModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule, combineReducers } from '@ngrx/store';
@@ -23,6 +24,7 @@ describe('CapabilitySelectorComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ CapabilitySelectorComponent, FieldSortPipe ],
       imports: [
+        FormsModule,
         RouterTestingModule,
         NoopAnimationsModule,
         ...matModules,

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.ts
@@ -108,7 +108,7 @@ export class CapabilitySelectorComponent implements OnInit, AfterViewInit, OnDes
   private createNewCapability(): void {
     this.isAddCapability = true;
     this.addCapability = new Capability();
-    this.addCapability.category = this.currentCapabilityGroup.name;
+    this.addCapability.category = this.currentCapabilityGroup.id;
     this.addCapability.created_by_ref = this.allCapabilities[0].created_by_ref;
   }
   

--- a/src/app/threat-beta/article/article.component.html
+++ b/src/app/threat-beta/article/article.component.html
@@ -1,4 +1,30 @@
-<threat-header></threat-header> <!-- TODO [threat]="article" [boardId]="threatBoardId" [created]="board?.created"></threat-header>-->
-<div class="main-panel">
-    Article about individual board here.
+<ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
+  <div #layout class="layout" *ngIf="(failedToLoad|async) === false; else failedToLoadBlock">
+    <mat-sidenav-container>
+      <mat-sidenav class="side-panel" mode="side" opened="true">
+        <side-board></side-board>
+      </mat-sidenav>
+      <mat-sidenav-content class="sidenavContentPolyfill320">
+        <threat-header></threat-header>
+        <!-- TODO [threat]="feed" [boardId]="threatBoardId" [created]="board?.created"> </threat-header> -->
+        <div class="main-panel">
+          Article about individual board here.
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
   </div>
+</ng-container>
+
+<ng-template #loadingBlock>
+  <loading-spinner></loading-spinner>
+</ng-template>
+
+<ng-template #failedToLoadBlock>
+  <div class="container fadeIn">
+    <div class="row mt-15">
+      <div class="col-xs-10 col-xs-offset-1">
+        <error-card errorTitle="Threat Dashboard" errorBody="Failed to load. Check the network and URL."></error-card>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/threat-beta/article/article.component.scss
+++ b/src/app/threat-beta/article/article.component.scss
@@ -1,0 +1,29 @@
+@import '../../../styles/_variables.scss';
+
+.side-panel {
+    width: 320px;
+    background-color: white;
+
+    markings-chips {
+        ::ng-deep div.flex {
+            margin-bottom: 4px;
+
+            mat-chip-list {
+                margin: 0 auto;
+            }
+
+            mat-chip {
+                margin: 0 auto 4px;
+            }
+
+            mat-chip:first-of-type {
+                margin-top: -8px;
+            }
+        }
+    }
+}
+
+.main-panel {
+    min-height: calc(100vh - #{$navbar-height}px);
+    background-color: #F1F1F1;
+}

--- a/src/app/threat-beta/article/article.component.spec.ts
+++ b/src/app/threat-beta/article/article.component.spec.ts
@@ -1,7 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule, MatTabsModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalModule } from '../../global/global.module';
+import { SideBoardComponent } from '../side-board/side-board.component';
 import { ThreatHeaderComponent } from '../threat-header/threat-header.component';
 import { ArticleComponent } from './article.component';
 
@@ -12,15 +14,18 @@ describe('ArticleComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ArticleComponent,
-                      ThreatHeaderComponent,
-                    ],
-      imports: [ RouterTestingModule,
-                 MatTabsModule,
-                 MatIconModule,
-                  GlobalModule],
+      declarations: [ArticleComponent,
+        ThreatHeaderComponent,
+        SideBoardComponent,
+      ],
+      imports: [RouterTestingModule,
+        MatTabsModule,
+        MatIconModule,
+        GlobalModule,
+        NoopAnimationsModule,
+      ],
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/threat-beta/article/article.component.ts
+++ b/src/app/threat-beta/article/article.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable, BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'article',
@@ -6,7 +7,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./article.component.scss']
 })
 export class ArticleComponent implements OnInit {
+  public finishedLoadingAll$: Observable<boolean> = new BehaviorSubject(true).asObservable(); // TODO
 
+  public failedToLoad = new BehaviorSubject(false).asObservable();
   constructor() { }
 
   ngOnInit() {

--- a/src/app/threat-beta/board/board.component.html
+++ b/src/app/threat-beta/board/board.component.html
@@ -1,4 +1,30 @@
-<threat-header></threat-header> <!-- TODO [threat]="board" [boardId]="threatBoardId" [created]="board?.created"></threat-header>-->
-    <div class="main-panel">
-      Info about an individual board here.
+<ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
+  <div #layout class="layout" *ngIf="(failedToLoad|async) === false; else failedToLoadBlock">
+    <mat-sidenav-container>
+      <mat-sidenav class="side-panel" mode="side" opened="true">
+        <side-board></side-board>
+      </mat-sidenav>
+      <mat-sidenav-content class="sidenavContentPolyfill320">
+        <threat-header></threat-header>
+        <!-- TODO [threat]="feed" [boardId]="threatBoardId" [created]="board?.created"> </threat-header> -->
+        <div class="main-panel">
+          Info about an individual board here.
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
+  </div>
+</ng-container>
+
+<ng-template #loadingBlock>
+  <loading-spinner></loading-spinner>
+</ng-template>
+
+<ng-template #failedToLoadBlock>
+  <div class="container fadeIn">
+    <div class="row mt-15">
+      <div class="col-xs-10 col-xs-offset-1">
+        <error-card errorTitle="Threat Dashboard" errorBody="Failed to load. Check the network and URL."></error-card>
+      </div>
     </div>
+  </div>
+</ng-template>

--- a/src/app/threat-beta/board/board.component.scss
+++ b/src/app/threat-beta/board/board.component.scss
@@ -1,0 +1,29 @@
+@import '../../../styles/_variables.scss';
+
+.side-panel {
+    width: 320px;
+    background-color: white;
+
+    markings-chips {
+        ::ng-deep div.flex {
+            margin-bottom: 4px;
+
+            mat-chip-list {
+                margin: 0 auto;
+            }
+
+            mat-chip {
+                margin: 0 auto 4px;
+            }
+
+            mat-chip:first-of-type {
+                margin-top: -8px;
+            }
+        }
+    }
+}
+
+.main-panel {
+    min-height: calc(100vh - #{$navbar-height}px);
+    background-color: #F1F1F1;
+}

--- a/src/app/threat-beta/board/board.component.spec.ts
+++ b/src/app/threat-beta/board/board.component.spec.ts
@@ -1,7 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule, MatTabsModule } from '@angular/material';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { GlobalModule } from '../../global/global.module';
+import { SideBoardComponent } from '../side-board/side-board.component';
 import { ThreatHeaderComponent } from '../threat-header/threat-header.component';
 import { BoardComponent } from './board.component';
 
@@ -14,11 +16,14 @@ describe('BoardComponent', () => {
     TestBed.configureTestingModule({
       declarations: [BoardComponent,
         ThreatHeaderComponent,
+        SideBoardComponent
       ],
       imports: [RouterTestingModule,
         MatTabsModule,
         MatIconModule,
-        GlobalModule],
+        GlobalModule,
+        NoopAnimationsModule,
+      ],
     })
       .compileComponents();
   }));

--- a/src/app/threat-beta/board/board.component.ts
+++ b/src/app/threat-beta/board/board.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable, BehaviorSubject } from 'rxjs';
 
 @Component({
   selector: 'board',
@@ -6,7 +7,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./board.component.scss']
 })
 export class BoardComponent implements OnInit {
+  public finishedLoadingAll$: Observable<boolean> = new BehaviorSubject(true).asObservable(); // TODO
 
+  public failedToLoad = new BehaviorSubject(false).asObservable();
   constructor() { }
 
   ngOnInit() {

--- a/src/app/threat-beta/create/create.component.scss
+++ b/src/app/threat-beta/create/create.component.scss
@@ -1,0 +1,6 @@
+@import '../../../styles/_variables.scss';
+
+.main-panel {
+    min-height: calc(100vh - #{$navbar-height}px);
+    background-color: #F1F1F1;
+}

--- a/src/app/threat-beta/create/create.component.ts
+++ b/src/app/threat-beta/create/create.component.ts
@@ -6,6 +6,7 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./create.component.scss']
 })
 export class CreateComponent implements OnInit {
+  
 
   constructor() { }
 

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -1,4 +1,30 @@
-<threat-header></threat-header> <!-- TODO [threat]="feed" [boardId]="threatBoardId" [created]="board?.created"> </threat-header> -->
-    <div class="main-panel">
-      Feed for a specific board here.
+<ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
+  <div #layout class="layout" *ngIf="(failedToLoad|async) === false; else failedToLoadBlock">
+    <mat-sidenav-container>
+      <mat-sidenav class="side-panel" mode="side" opened="true">
+        <side-board></side-board>
+      </mat-sidenav>
+      <mat-sidenav-content class="sidenavContentPolyfill320">
+        <threat-header></threat-header>
+        <!-- TODO [threat]="feed" [boardId]="threatBoardId" [created]="board?.created"> </threat-header> -->
+        <div class="main-panel">
+          Feed for a specific board here.
+        </div>
+      </mat-sidenav-content>
+    </mat-sidenav-container>
+  </div>
+</ng-container>
+
+<ng-template #loadingBlock>
+  <loading-spinner></loading-spinner>
+</ng-template>
+
+<ng-template #failedToLoadBlock>
+  <div class="container fadeIn">
+    <div class="row mt-15">
+      <div class="col-xs-10 col-xs-offset-1">
+        <error-card errorTitle="Threat Dashboard" errorBody="Failed to load. Check the network and URL."></error-card>
+      </div>
     </div>
+  </div>
+</ng-template>

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -1,0 +1,29 @@
+@import '../../../styles/_variables.scss';
+
+.side-panel {
+    width: 320px;
+    background-color: white;
+
+    markings-chips {
+        ::ng-deep div.flex {
+            margin-bottom: 4px;
+
+            mat-chip-list {
+                margin: 0 auto;
+            }
+
+            mat-chip {
+                margin: 0 auto 4px;
+            }
+
+            mat-chip:first-of-type {
+                margin-top: -8px;
+            }
+        }
+    }
+}
+
+.main-panel {
+    min-height: calc(100vh - #{$navbar-height}px);
+    background-color: #F1F1F1;
+}

--- a/src/app/threat-beta/feed/feed.component.spec.ts
+++ b/src/app/threat-beta/feed/feed.component.spec.ts
@@ -1,9 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FeedComponent } from './feed.component';
-import { ThreatHeaderComponent } from '../threat-header/threat-header.component';
+import { MatIconModule, MatTabsModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MatTabsModule, MatIconModule } from '@angular/material';
 import { GlobalModule } from '../../global/global.module';
+import { SideBoardComponent } from '../side-board/side-board.component';
+import { ThreatHeaderComponent } from '../threat-header/threat-header.component';
+import { FeedComponent } from './feed.component';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 
 describe('FeedComponent', () => {
@@ -14,11 +16,14 @@ describe('FeedComponent', () => {
     TestBed.configureTestingModule({
       declarations: [FeedComponent,
         ThreatHeaderComponent,
+        SideBoardComponent,
       ],
       imports: [RouterTestingModule,
         MatTabsModule,
         MatIconModule,
-        GlobalModule],
+        GlobalModule,
+        NoopAnimationsModule,
+      ],
     })
       .compileComponents();
   }));

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Component({
   selector: 'feed',
@@ -7,6 +8,9 @@ import { Component, OnInit } from '@angular/core';
 })
 export class FeedComponent implements OnInit {
 
+  public finishedLoadingAll$: Observable<boolean> = new BehaviorSubject(true).asObservable(); // TODO
+
+  public failedToLoad = new BehaviorSubject(false).asObservable();
   constructor() { }
 
   ngOnInit() {

--- a/src/app/threat-beta/side-board/side-board.component.html
+++ b/src/app/threat-beta/side-board/side-board.component.html
@@ -1,0 +1,52 @@
+<unfetter-side-panel class="side-panel" [item]="{ name: threatBoardName$ | async }" collapsible="false" width="320">
+
+  <sidepanel-option-item label="Edit" icon="mode_edit" (click)="onEdit($event)"></sidepanel-option-item>
+  <sidepanel-option-item label="Share" icon="share" disabled="true" (click)="onShare($event)"></sidepanel-option-item>
+  <sidepanel-option-item label="Delete" icon="delete" (click)="onDeleteCurrent($event)"></sidepanel-option-item>
+
+  <master-list-dialog-trigger title="Threat Boards" width="750px" height="400px" [dataSource]="masterListOptions.dataSource"
+    [columns]="masterListOptions.columns" (tabChange)="onFilterTabChanged($event)" (create)="onCreate($event)" (select)="onCellSelected($event)"
+    (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
+
+  <!-- <markings-chips [model]="summary"></markings-chips> -->
+  <sidepanel-list-item label="Threat Report 1" expandable="false" showCount="false">
+    <!-- <mat-list-item *ngFor="let report of threatBoard?.reports; trackBy:trackByFn" class="list-divider"
+      [@slideInOutAnimation]>
+      <h4 mat-line *ngIf="getReportURL(report) as url">
+        <a *ngIf="url; else noLink" href="{{url}}" target="_blank">
+          {{report?.attributes.name}}
+        </a>
+        <mat-icon aria-label="visit report">open_in_new</mat-icon>
+        <ng-template #noLink>{{report?.attributes.name}}</ng-template>
+      </h4>
+      <div mat-line class="mat-caption"> {{report?.attributes.description}} </div>
+    </mat-list-item> -->
+  </sidepanel-list-item>
+  <sidepanel-list-item label="Threat Report 2" expandable="false" showCount="false">
+      <!-- <mat-list-item *ngFor="let report of threatBoard?.reports; trackBy:trackByFn" class="list-divider"
+        [@slideInOutAnimation]>
+        <h4 mat-line *ngIf="getReportURL(report) as url">
+          <a *ngIf="url; else noLink" href="{{url}}" target="_blank">
+            {{report?.attributes.name}}
+          </a>
+          <mat-icon aria-label="visit report">open_in_new</mat-icon>
+          <ng-template #noLink>{{report?.attributes.name}}</ng-template>
+        </h4>
+        <div mat-line class="mat-caption"> {{report?.attributes.description}} </div>
+      </mat-list-item> -->
+    </sidepanel-list-item>
+    <sidepanel-list-item label="Threat Report 3" expandable="false" showCount="false">
+        <!-- <mat-list-item *ngFor="let report of threatBoard?.reports; trackBy:trackByFn" class="list-divider"
+          [@slideInOutAnimation]>
+          <h4 mat-line *ngIf="getReportURL(report) as url">
+            <a *ngIf="url; else noLink" href="{{url}}" target="_blank">
+              {{report?.attributes.name}}
+            </a>
+            <mat-icon aria-label="visit report">open_in_new</mat-icon>
+            <ng-template #noLink>{{report?.attributes.name}}</ng-template>
+          </h4>
+          <div mat-line class="mat-caption"> {{report?.attributes.description}} </div>
+        </mat-list-item> -->
+      </sidepanel-list-item>
+
+</unfetter-side-panel>

--- a/src/app/threat-beta/side-board/side-board.component.spec.ts
+++ b/src/app/threat-beta/side-board/side-board.component.spec.ts
@@ -1,0 +1,32 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { GlobalModule } from '../../global/global.module';
+import { SideBoardComponent } from './side-board.component';
+
+
+describe('SideBoardComponent', () => {
+  let component: SideBoardComponent;
+  let fixture: ComponentFixture<SideBoardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SideBoardComponent],
+      imports: [GlobalModule,
+        RouterTestingModule,
+        NoopAnimationsModule,
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SideBoardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/threat-beta/side-board/side-board.component.ts
+++ b/src/app/threat-beta/side-board/side-board.component.ts
@@ -1,44 +1,31 @@
-import { Location } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
-import { fadeInOut } from '../global/animations/fade-in-out';
 import { Router } from '@angular/router';
-import { MasterListDialogTableHeaders } from '../global/components/master-list-dialog/master-list-dialog.component';
 import { ThreatBoard } from 'stix/unfetter/threat-board';
+import { MasterListDialogTableHeaders } from '../../global/components/master-list-dialog/master-list-dialog.component';
+import { Observable } from 'rxjs';
 
 @Component({
-  selector: 'threat-dashboard-beta',
-  templateUrl: './threat-dashboard-beta.component.html',
-  styleUrls: ['./threat-dashboard-beta.component.scss'],
-  animations: [fadeInOut],
+  selector: 'side-board',
+  templateUrl: './side-board.component.html',
+  styleUrls: ['./side-board.component.scss']
 })
-export class ThreatDashboardBetaComponent implements OnInit {
+export class SideBoardComponent implements OnInit {
 
-  public showBackButton = new BehaviorSubject(false).asObservable();
+  readonly baseThreatUrl = '/threat-beta';
+
+  threatBoardName$: Observable<string>;
 
   public threatBoardId: string;
-
-  public finishedLoadingAll$: Observable<boolean> = new BehaviorSubject(true).asObservable(); // TODO
-
-  public failedToLoad = new BehaviorSubject(false).asObservable();
-
-  public title = new BehaviorSubject('').asObservable();
-
-  private location: Location;
-
-  readonly baseAssessUrl = '/threat-beta';
 
   masterListOptions = {
     dataSource: null,
     columns: new MasterListDialogTableHeaders('modified', 'Modified'),
-    displayRoute: this.baseAssessUrl + '/result/summary',
-    modifyRoute: this.baseAssessUrl + '/wizard/edit',
-    createRoute: this.baseAssessUrl + '/create',
+    displayRoute: this.baseThreatUrl + '/board',
+    modifyRoute: this.baseThreatUrl + '/wizard/edit',
+    createRoute: this.baseThreatUrl + '/create',
   };
 
-  constructor(private router: Router) { // private location: Location) {
-
-   }
+  constructor(private router: Router) { }
 
   ngOnInit() {
   }
@@ -57,15 +44,6 @@ export class ThreatDashboardBetaComponent implements OnInit {
 
     routePromise.catch((e) => console.log(e));
     return routePromise;
-  }
-
-
-  /**
-   * @description go back
-   * @param event
-   */
-  onBack(event: UIEvent): void {
-    this.location.back();
   }
 
   /**
@@ -88,17 +66,21 @@ export class ThreatDashboardBetaComponent implements OnInit {
   }
 
   /**
-   * @description clicked currently viewed assessment, confirm delete
+   * @description clicked currently viewed threatBoard, confirm delete
    * @return {void}
    */
-  public onDeleteCurrent(): void {
+  public onDeleteCurrent(event: Event): void {
+    if (event && (event instanceof UIEvent)) {
+      event.preventDefault();
+    }
+
     console.log('noop');
     // const boardId = this.boardId;
     // const name = this.boardName;
-    // this.confirmDelete({ name, rollupId });
+    // this.confirmDelete({ name, boardId });
   }
 
-    /**
+  /**
    * @description noop
    * @return {Promise<boolean>}
    */
@@ -122,7 +104,7 @@ export class ThreatDashboardBetaComponent implements OnInit {
    * @return {Promise<boolean>}
    */
   public onCellSelected(threatBoard: ThreatBoard): Promise<boolean> {
-    if (!threatBoard || !threatBoard.id ) {
+    if (!threatBoard || !threatBoard.id) {
       return Promise.resolve(false);
     }
     // TODO this.store.dispatch(new CleanAssessmentResultData());

--- a/src/app/threat-beta/threat-beta.module.ts
+++ b/src/app/threat-beta/threat-beta.module.ts
@@ -9,6 +9,7 @@ import { ThreatBetaGuard } from './threat-beta.guard';
 import { routing } from './threat-beta.routing';
 import { GlobalModule } from '../global/global.module';
 import { ThreatHeaderComponent } from './threat-header/threat-header.component';
+import { SideBoardComponent } from './side-board/side-board.component';
 
 @NgModule({
   imports: [
@@ -16,7 +17,7 @@ import { ThreatHeaderComponent } from './threat-header/threat-header.component';
     GlobalModule,
     routing
   ],
-  declarations: [ThreatDashboardBetaComponent, FeedComponent, BoardComponent, ArticleComponent, CreateComponent, ThreatHeaderComponent],
+  declarations: [ThreatDashboardBetaComponent, FeedComponent, BoardComponent, ArticleComponent, CreateComponent, ThreatHeaderComponent, SideBoardComponent],
   providers: [
     ThreatBetaGuard,
   ],

--- a/src/app/threat-beta/threat-header/threat-header.component.html
+++ b/src/app/threat-beta/threat-header/threat-header.component.html
@@ -1,7 +1,7 @@
 <div id="tabWrapper" class="flex flexColumn">
     <div class="flex flexRow">
       <div class="flex">
-        <uf-info-bar></uf-info-bar> <!-- *ngIf="percentCompletedMsg" isWarningMsg="true" [message]="percentCompletedMsg"> [completeActionUrl]="editUrl||''"></uf-info-bar> -->
+          <uf-info-bar shouldShow="false" shouldCenter="true" isWarningMsg="false" message=""></uf-info-bar>
       </div>
     </div>
     <div class="flex1"></div>


### PR DESCRIPTION
Enable the creation of a new capability within the capability selector panel. When creating a baseline or editing an existing baseline and are adding capabilities to a capability group, we want to be able to create a new capability within the capability group.

To test:
Pull this branch
Create a baseline or open an existing baseline
Go to capability group page where capabilities are added to the group
Click "Add Capability" button
Enter the name of the new capability that you want to add.
Click "Save" button, should only be available after the name has been entered.
The new capability will appear in the drop-down box for capabilities to be added to the group.