### PR TITLE
Allow create only if title present and one assessment type selected

### DIFF
--- a/src/app/assess/v3/create/create.component.html
+++ b/src/app/assess/v3/create/create.component.html
@@ -16,9 +16,11 @@
                     <created-by-ref (orgSelected)="orgSelected($event)"></created-by-ref>
                     <div class="flex-cols">
                         <span class="mat-title">Compile Categories to Assess*</span>
-                        <mat-checkbox class="" [value]="assessMeta.includesIndicators" color="primary" formControlName="includesIndicators">Indicators</mat-checkbox>
-                        <mat-checkbox class="" [value]="assessMeta.includesMitigations" color="primary" formControlName="includesMitigations">Mitigations</mat-checkbox>
-                        <mat-checkbox class="" [value]="showToSelectBaselines" color="primary" (change)="showToSelectBaselines = !showToSelectBaselines">Capabilities</mat-checkbox>
+                        <mat-checkbox class="" [value]="assessMeta.includesIndicators" color="primary"
+                                      formControlName="includesIndicators" (change)="indChange($event)">Indicators</mat-checkbox>
+                        <mat-checkbox class="" [value]="assessMeta.includesMitigations" color="primary"
+                                      formControlName="includesMitigations" (change)="mitChange($event)">Mitigations</mat-checkbox>
+                        <mat-checkbox class="" [value]="showToSelectBaselines" color="primary" (change)="baselineChange($event)">Capabilities</mat-checkbox>
                         <span *ngIf="showToSelectBaselines">
                             <mat-radio-group formControlName="baselineRef" *ngIf="(baselines | async); else createNewBaseline">
                                 <mat-radio-button color="primary" *ngFor="let baseline of (baselines | async); trackBy: trackByFn" [value]="baseline.id">
@@ -53,7 +55,7 @@
                 </mat-card-content>
                 <mat-card-actions>
                     <button mat-button (click)="onCancel($event)">CANCEL</button>
-                    <button mat-raised-button color="primary" [disabled]="form.status === 'INVALID'" type="submit">CONTINUE</button>
+                    <button mat-raised-button color="primary" [disabled]="disableContinue()" type="submit">CONTINUE</button>
                 </mat-card-actions>
             </form>
         </mat-card>

--- a/src/app/assess/v3/create/create.component.ts
+++ b/src/app/assess/v3/create/create.component.ts
@@ -67,12 +67,17 @@ export class CreateComponent implements OnInit {
     this.form = Assess3Form();
   }
 
+  public disableContinue(): boolean {
+    const assessmentTypeSelected = (this.assessMeta.includesIndicators || this.assessMeta.includesMitigations || this.form.get('baselineRef').value);
+    return !this.form.get('title').value || !assessmentTypeSelected;
+  }
+
   /**
    * @description
    * @return {void}
    */
   public submitForm(): void {
-    this.assessMeta = this.formToAssessment(this.form);
+    this.updateMeta();
     this.store.dispatch(new assessActions.StartAssessment(this.assessMeta as any));
   }
 
@@ -80,7 +85,15 @@ export class CreateComponent implements OnInit {
    * @description
    * @param form 
    */
-  public formToAssessment(form: FormGroup): Assess3Meta {
+  private updateMeta() {
+    this.assessMeta = this.formToAssessment(this.form);
+  }
+
+  /**
+   * @description
+   * @param form 
+   */
+  private formToAssessment(form: FormGroup): Assess3Meta {
     const assessment = Object.assign(new Assess3Meta(), form.value);
     return assessment;
   }
@@ -110,6 +123,31 @@ export class CreateComponent implements OnInit {
    */
   public orgSelected(orgId: string): void {
     this.form.get('created_by_ref').patchValue(orgId);
+  }
+
+  /**
+   * @description updates assessMeta upon selection of Indicators checkbox
+   * @param {event} event
+   * @return {void}
+   */
+  public indChange(event): void {
+    this.updateMeta();
+  }
+
+  /**
+   * @description updates assessMeta upon selection of Mitigations checkbox
+   * @param {event} event
+   * @return {void}
+   */
+  public mitChange(event): void {
+    this.updateMeta();
+  }
+
+  public baselineChange(event): void {
+    this.showToSelectBaselines = !this.showToSelectBaselines;
+    if (!this.showToSelectBaselines) {
+      this.form.get('baselineRef').patchValue(null);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1423

When creating an assessment, one of the assessment types (indicators, mitigations, baselines) must be selected in addition to entering a valid title.  Further, when baselines ("Capabilities") is selected, one of the baseline options must also be selected.

### To test:
1. Pull this branch
2. Click "Create" to open the creation wizard for an assessment
3. Enter a title - the Continue button should remain disabled.
4. Click "Indicators" - the Continue button should become enabled.
5. Click "Indicators" again - the Continue button should become disabled.
6. Click "Mitigations" - the Continue button should become enabled.
7. Click "Mitigations" again - the Continue button should become disabled.
8. Click "Capabilities" - the Continue button should remain disabled.
9. Click one of the baselines - the Continue button should become enabled.
10. Click "Capabilities" again - the Continue button should become disabled.
11. Click "Mitigations" and clear the title - the Continue button should be disabled.



