### PR TITLE
Issue 1485

### DIFF
--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -33,12 +33,16 @@
 
         <div *ngIf="!(blockAttachments$ | async)" class="mb-6">
           <h4>Attachments</h4>
-          <file-list></file-list>
+          <file-list (filesChange)="files = $event"></file-list>
         </div>
 
       </mat-card-content>
     </mat-card>
     <div class="articleControlWrapper">
+      <div *ngIf="uploadProgress > 0">
+        <mat-progress-bar mode="determinate" [value]="uploadProgress" *ngIf="uploadProgress < 100"></mat-progress-bar>
+        <mat-progress-bar mode="indeterminate" *ngIf="uploadProgress === 100"></mat-progress-bar>
+      </div>
       <div class="max-card-width text-right">
         <button type="button" mat-button (click)="location.back()">CLOSE</button>
         <span>&nbsp;</span>

--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -19,7 +19,7 @@
         <div class="mb-6">          
           <h4 [class.textWarn]="form.get('content').dirty && form.get('content').hasError('required')">Content<sup>*</sup></h4>
           <simplemde-mentions formControlName="content" [class.mdeError]="form.get('content').dirty && form.get('content').hasError('required')" ngDefaultControl></simplemde-mentions>
-          <mat-error [style.visibility]="form.get('content').dirty && form.get('content').hasError('required') ? 'visible' : 'hidden'">
+          <mat-error [class.showUfMatError]="form.get('content').dirty && form.get('content').hasError('required')" class="ufMatError">
             Content is <strong>required</strong>
           </mat-error>
         </div>

--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -1,5 +1,5 @@
 <div id="articleEditorComponent">
-  <form [formGroup]="form">
+  <form [formGroup]="form" (ngSubmit)="submitArticle()">
     <mat-card class="uf-mat-card card">
       <mat-card-content class="cardContent">
         <br>
@@ -44,7 +44,7 @@
         <span>&nbsp;</span>
         <button type="button" mat-button color="primary">DELETE</button>
         <span>&nbsp;</span>
-        <button type="button" mat-raised-button color="primary">SAVE</button>
+        <button type="submit" mat-raised-button color="primary" [disabled]="form.status !== 'VALID'">SAVE</button>
       </div>
     </div>
   </form>

--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -33,7 +33,7 @@
 
         <div *ngIf="!(blockAttachments$ | async)" class="mb-6">
           <h4>Attachments</h4>
-          <file-list (filesChange)="files = $event"></file-list>
+          <file-list [existingFiles]="articleToEdit && articleToEdit.metaProperties && articleToEdit.metaProperties.attachments" (filesChange)="files = $event"></file-list>
         </div>
 
       </mat-card-content>

--- a/src/app/threat-beta/article/article-editor/article-editor.component.spec.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.spec.ts
@@ -4,23 +4,51 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule, MatButtonModule, MatIconModule, MatCardModule, MatChipsModule } from '@angular/material';
 import { Location } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { StoreModule } from '@ngrx/store';
+import { of as observableOf } from 'rxjs';
 
 import { ArticleEditorComponent } from './article-editor.component';
-import { StoreModule } from '@ngrx/store';
-import { reducers } from '../../../root-store/app.reducers';
 import { ArticleForm } from '../../../global/form-models/article';
 import { SimplemdeMentionsComponent } from '../../../global/components/simplemde-mentions/simplemde-mentions.component';
+import { ThreatDashboardBetaService } from '../../threat-beta.service';
+import MockThreatDashboardBetaService from '../../testing/mock-threat.service';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import mockThreatReducer from '../../testing/mock-reducer';
 
 describe('ArticleEditorComponent', () => {
   let component: ArticleEditorComponent;
   let fixture: ComponentFixture<ArticleEditorComponent>;
+
+  const mockRoute: any = {
+    snapshot: {
+      url: [ '_', 'new' ],
+      parent: {
+        params: {
+          boardId: 'x-unfetter-threat-board-1'
+        }
+      }
+    }    
+  };
+
+  const mockGenericApi: any = {
+    uploadAttachments: () => observableOf([{
+      _id: '5bb663378bc599007684cde0',
+      length: 172002,
+      chunkSize: 261120,
+      uploadDate: '2018-10-04T15:00:07.165-04:00',
+      md5: '12f4f9bc01837d3426dade0181e59b67',
+      filename: 'bootstrap.zip',
+      contentType: 'application/zip'
+    }])
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         ReactiveFormsModule,
-        StoreModule.forRoot(reducers),
+        StoreModule.forRoot(mockThreatReducer),
         MatIconModule,
         MatButtonModule,
         MatInputModule,
@@ -29,6 +57,10 @@ describe('ArticleEditorComponent', () => {
       ],
       providers: [
         { provide: Location, useValue: { back: () => { } } },
+        { provide: ThreatDashboardBetaService, useValue: MockThreatDashboardBetaService },
+        { provide: ActivatedRoute, useValue: mockRoute },
+        { provide: Router, useValue: { navigate: () => { } } },
+        { provide: GenericApi, useValue: mockGenericApi }
       ],
       declarations: [
         ArticleEditorComponent

--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -93,6 +93,7 @@ export class ArticleEditorComponent implements OnInit {
         .pipe(
           take(1),
           switchMap((board) => {
+            // Add article
             // TODO handle edge case - article doesnt have created_by_ref
             tempArticle.created_by_ref = board.created_by_ref;
             return observableForkJoin(
@@ -101,6 +102,7 @@ export class ArticleEditorComponent implements OnInit {
             );
           }),
           switchMap(([newArticle, board]) => {
+            // Add article reference to board
             if (!board.articles) {
               board.articles = [];
             }

--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -1,12 +1,19 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Location } from '@angular/common';
 import { FormGroup } from '@angular/forms';
-import { Observable } from 'rxjs';
-import { pluck, distinctUntilChanged, map, startWith } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
+import { pluck, distinctUntilChanged, map, startWith, finalize, take, switchMap } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
+import { Article } from 'stix/unfetter/index';
 
-import { AppState } from '../../../root-store/app.reducers';
 import { MasterConfig } from '../../../core/services/run-config.service';
+import { ThreatFeatureState } from '../../store/threat.reducers';
+import { ThreatDashboardBetaService } from '../../threat-beta.service';
+import { cleanObjectProperties } from '../../../global/static/clean-object-properties';
+import { getSelectedBoard } from '../../store/threat.selectors';
+import * as threatActions from '../../store/threat.actions';
+import * as utilityActions from '../../../root-store/utility/utility.actions';
 
 @Component({
   selector: 'article-editor',
@@ -19,21 +26,36 @@ export class ArticleEditorComponent implements OnInit {
   public form: FormGroup;
   public blockAttachments$: Observable<boolean>;
   public sourceNames$: Observable<string[]>;
+  public editMode: boolean;
+
+  private boardId: string;
+  private editArticleId: string;
 
   constructor(
     public location: Location,
-    // TODO update state to feature state when ngrx is added
-    private store: Store<AppState>
+    private store: Store<ThreatFeatureState>,
+    private threatService: ThreatDashboardBetaService,
+    private route: ActivatedRoute,
+    private router: Router
   ) { }
 
   ngOnInit() {
+    this.boardId = this.route.snapshot.parent.params.boardId;
+    this.editMode = this.route.snapshot.url[1] && this.route.snapshot.url[1].path === 'edit' || false;
+    
+    if (this.editMode) {
+      this.editArticleId = this.route.snapshot.params.articleId;
+      // TODO populate form
+    }
+
     this.blockAttachments$ = this.store
       .select('config')
       .pipe(
         pluck('runConfig'),
         distinctUntilChanged<MasterConfig>(),
         map((cfg) => cfg.blockAttachments)
-      );    
+      );
+    
     this.sourceNames$ = this.form.get('sources').valueChanges
       .pipe(
         startWith(this.form.get('sources').value),
@@ -43,5 +65,72 @@ export class ArticleEditorComponent implements OnInit {
             .map((sourceId) => 'A placeholder name');
         })
       );
+  }
+
+  public async submitArticle(): Promise<void> {
+    const submitErrorMsg = '';
+    const tempArticle = new Article(cleanObjectProperties({}, this.form.value));
+
+    let success;
+    if (this.editMode) {
+      success = await this.editArticle(tempArticle);
+    } else {
+      success = await this.createNewArticle(tempArticle);
+      if (success) {
+        this.router.navigate(['/threat-beta', this.boardId, 'feed']);
+        return;
+      }
+    }
+
+    if (!success) {
+      this.store.dispatch(new utilityActions.OpenSnackbar('An Error Occured While Saving'));
+    }
+  }
+
+  private async createNewArticle(tempArticle: Article): Promise<boolean> {
+    return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
+      const addArticle$ = this.store.select(getSelectedBoard)
+        .pipe(
+          take(1),
+          switchMap((board) => {
+            // TODO handle edge case - article doesnt have created_by_ref
+            tempArticle.created_by_ref = board.created_by_ref;
+            return observableForkJoin(
+              this.threatService.addArticle(tempArticle),
+              observableOf(board)
+            );
+          }),
+          switchMap(([newArticle, board]) => {
+            if (!board.articles) {
+              board.articles = [];
+            }
+            board.articles.push(newArticle.id);
+            return observableForkJoin(
+              observableOf(newArticle),
+              this.threatService.updateBoard(board),
+            );
+          }),      
+          finalize(() => addArticle$ && addArticle$.unsubscribe())
+        )
+        .subscribe(
+          ([newArticle, updatedBoard]) => {
+            this.store.dispatch(new threatActions.UpdateBoard(updatedBoard));
+            this.store.dispatch(new threatActions.AddArticle(newArticle));
+            this.store.dispatch(new utilityActions.OpenSnackbar('Article Successfully Added'));
+            resolve(true);
+          },
+          (err) => {
+            console.log(err);
+            reject(false);
+          }
+        );
+    });    
+  }
+
+  private async editArticle(tempArticle: Article): Promise<boolean> {
+    // TODO
+    return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
+
+    });
   }
 }

--- a/src/app/threat-beta/store/threat.actions.ts
+++ b/src/app/threat-beta/store/threat.actions.ts
@@ -18,6 +18,14 @@ export enum ThreatActionTypes {
     SetSelectedReportId = '[Threat] Set Selected Report Id',
     SetDashboardLoadingComplete = '[Threat] Set Dashboard Loading Complete',
     SetThreatboardLoadingComplete = '[Threat] Set Threatboard Loading Complete',
+    
+    AddArticle = '[Threat] Add Article',
+    UpdateArticle = '[Threat] Update Article',
+    DeleteArticle = '[Threat] Delete Article',
+    AddBoard = '[Threat] Add Board',
+    UpdateBoard = '[Threat] Update Board',
+    DeleteBoard = '[Threat] Delete Board',
+
     ClearData = '[Threat] Clear Data'
 }
 
@@ -93,6 +101,42 @@ export class SetThreatboardLoadingComplete implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class AddArticle implements Action {
+    public readonly type = ThreatActionTypes.AddArticle;
+
+    constructor(public payload: Article) { }
+}
+
+export class UpdateArticle implements Action {
+    public readonly type = ThreatActionTypes.UpdateArticle;
+
+    constructor(public payload: Article) { }
+}
+
+export class DeleteArticle implements Action {
+    public readonly type = ThreatActionTypes.DeleteArticle;
+
+    constructor(public payload: string) { }
+}
+
+export class AddBoard implements Action {
+    public readonly type = ThreatActionTypes.AddBoard;
+
+    constructor(public payload: ThreatBoard) { }
+}
+
+export class UpdateBoard implements Action {
+    public readonly type = ThreatActionTypes.UpdateBoard;
+
+    constructor(public payload: ThreatBoard) { }
+}
+
+export class DeleteBoard implements Action {
+    public readonly type = ThreatActionTypes.DeleteBoard;
+
+    constructor(public payload: string) { }
+}
+
 export class ClearData implements Action {
     public readonly type = ThreatActionTypes.ClearData;
 
@@ -112,4 +156,10 @@ export type threatActions =
     | SetSelectedReportId
     | SetDashboardLoadingComplete 
     | SetThreatboardLoadingComplete
+    | AddArticle
+    | UpdateArticle
+    | DeleteArticle
+    | AddBoard
+    | UpdateBoard
+    | DeleteBoard
     | ClearData;

--- a/src/app/threat-beta/store/threat.reducers.ts
+++ b/src/app/threat-beta/store/threat.reducers.ts
@@ -112,6 +112,76 @@ export function threatReducer(state = initialState, action: threatActions): Thre
                 ...state,
                 dashboardLoadingComplete: action.payload
             };
+        case ThreatActionTypes.AddArticle:
+            return {
+                ...state,
+                articles: [...state.articles, action.payload]
+            }
+        case ThreatActionTypes.UpdateArticle: {
+            const articleIndex = state.articles.findIndex(
+                (article) => article.id === action.payload.id
+            );
+            if (articleIndex > -1) {
+                const articlesCopy = [...state.articles];
+                articlesCopy[articleIndex] = action.payload;
+                return {
+                    ...state,
+                    articles: articlesCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.DeleteArticle: {
+            const articleIndex = state.articles.findIndex(
+                (article) => article.id === action.payload
+            );
+            if (articleIndex > -1) {
+                const articlesCopy = [...state.articles];
+                articlesCopy.splice(articleIndex, 1);
+                return {
+                    ...state,
+                    articles: articlesCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.AddBoard:
+            return {
+                ...state,
+                boardList: [...state.boardList, action.payload]
+            }
+        case ThreatActionTypes.UpdateBoard: {
+            const boardIndex = state.boardList.findIndex(
+                (board) => board.id === action.payload.id
+            );
+            if (boardIndex > -1) {
+                const boardsCopy = [...state.boardList];
+                boardsCopy[boardIndex] = action.payload;
+                return {
+                    ...state,
+                    boardList: boardsCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.DeleteBoard: {
+            const boardIndex = state.boardList.findIndex(
+                (board) => board.id === action.payload
+            );
+            if (boardIndex > -1) {
+                const boardsCopy = [...state.boardList];
+                boardsCopy.splice(boardIndex, 1);
+                return {
+                    ...state,
+                    boardList: boardsCopy
+                };
+            } else {
+                return state;
+            }
+        }
         case ThreatActionTypes.ClearData:
             return initialState;
         default:

--- a/src/app/threat-beta/testing/mock-threat.service.ts
+++ b/src/app/threat-beta/testing/mock-threat.service.ts
@@ -1,0 +1,12 @@
+import { of as observableOf } from 'rxjs';
+import * as UUID from 'uuid';
+
+const MockThreatDashboardBetaService = {
+    addArticle(article) {
+        article.id = `x-unfetter-article--${UUID.v4()}`;
+        return observableOf(article);
+    },
+    updateBoard: (board) => observableOf(board)
+};
+
+export default MockThreatDashboardBetaService;

--- a/src/app/threat-beta/threat-beta.module.ts
+++ b/src/app/threat-beta/threat-beta.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
+import { MatProgressBarModule } from '@angular/material';
 
 import { ThreatDashboardBetaComponent } from './threat-dashboard-beta.component';
 import { FeedComponent } from './feed/feed.component';
@@ -27,6 +28,7 @@ import { ThreatEffects } from './store/threat.effects';
     CommonModule,
     GlobalModule,
     FormsModule,
+    MatProgressBarModule,
     ReactiveFormsModule,
     routing,
     StoreModule.forFeature('threat', threatReducer),

--- a/src/app/threat-beta/threat-beta.routing.ts
+++ b/src/app/threat-beta/threat-beta.routing.ts
@@ -19,7 +19,8 @@ const routes: Routes = [
         path: ':boardId',
         component: BoardLayoutComponent,
         children: [
-          { path: 'article', component: ArticleComponent },
+          { path: 'article/new', component: ArticleComponent },
+          { path: 'article/edit/:articleId', component: ArticleComponent },
           { path: 'board', component: BoardComponent },
           { path: 'feed', component: FeedComponent },
         ]

--- a/src/app/threat-beta/threat-beta.service.ts
+++ b/src/app/threat-beta/threat-beta.service.ts
@@ -1,6 +1,29 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map, pluck } from 'rxjs/operators';
+import { Article, ThreatBoard } from 'stix/unfetter/index';
+
+import { GenericApi } from '../core/services/genericapi.service';
+import { StixUrls } from '../global/enums/stix-urls.enum';
+import { RxjsHelpers } from '../global/static/rxjs-helpers';
 
 @Injectable()
 export class ThreatDashboardBetaService {
+    constructor(private genericApi: GenericApi) { }
 
+    public addArticle(article: Article): Observable<Article> {
+        return this.genericApi.post(StixUrls.X_UNFETTER_ARTICLE, { data: { attributes: article } })
+            .pipe(
+                RxjsHelpers.unwrapJsonApi(),
+                map((articles) => articles[0])
+            );
+    }
+
+    public updateBoard(board: ThreatBoard): Observable<ThreatBoard> {
+        return this.genericApi.patch(
+            `${StixUrls.X_UNFETTER_THREAT_BOARD}/${board.id}`, 
+            { data: { attributes: board } }
+        )
+        .pipe(pluck('attributes'));
+    }
 }

--- a/src/app/threat-beta/threat-beta.service.ts
+++ b/src/app/threat-beta/threat-beta.service.ts
@@ -19,6 +19,11 @@ export class ThreatDashboardBetaService {
             );
     }
 
+    public editArticle(article: Article): Observable<Article> {
+        return this.genericApi.patch(`${StixUrls.X_UNFETTER_ARTICLE}/${article.id}`, { data: { attributes: article } })
+            .pipe(pluck('attributes'));
+    }
+
     public updateBoard(board: ThreatBoard): Observable<ThreatBoard> {
         return this.genericApi.patch(
             `${StixUrls.X_UNFETTER_THREAT_BOARD}/${board.id}`, 

--- a/src/app/threat-beta/threat-header/threat-header.component.ts
+++ b/src/app/threat-beta/threat-header/threat-header.component.ts
@@ -21,7 +21,7 @@ export class ThreatHeaderComponent {
     this._boardId = v;
     this.feedLink = `${this.BASE_URL}/${this._boardId}/feed`;
     this.boardLink = `${this.BASE_URL}/${this._boardId}/board`;
-    this.articleLink = `${this.BASE_URL}/${this._boardId}/article`;
+    this.articleLink = `${this.BASE_URL}/${this._boardId}/article/new`;
   }
 
   public get boardId () { return this._boardId; }

--- a/src/styles/partials/_angular_material_config.scss
+++ b/src/styles/partials/_angular_material_config.scss
@@ -199,6 +199,16 @@ a.mat-button {
   text-decoration: none;
 }
 
+.ufMatError {
+  font-size: 75%;
+  transition: 300ms cubic-bezier(0.55, 0, 0.55, 0.2);
+  opacity: 1;
+
+  &:not(.showUfMatError) {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+}
 
 // Polyfill for browser compatibility
 .sidenavContentPolyfill250 {


### PR DESCRIPTION
This PR adds support for article create and edit functionality to the UI, but there is no navigation for it yet.

- Create a threat board
- Go to `/threat-beta/**new threat board id here**/article/new`
- Create an article, look at the network tab when it saves - Confirm both the article is created and that an articles reference was added to the threat board
- Confirm NGRX was updated
- Go to `/threat-beta/**new threat board id here**/article/edit/**new article id here**` (I recommend doing a browser refresh after entering this URL)
- Edit the article, confirm the article saves in the network tab and NGRX as expected

fixes unfetter-discover/unfetter#1485
