### PR TITLE
Set min width for risk column

### DIFF
--- a/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
+++ b/src/app/assess/v3/result/full/group/add-assessed-object/add-assessed-object.component.ts
@@ -485,9 +485,9 @@ export class AddAssessedObjectComponent implements OnInit, OnDestroy {
             assessmentRisk: new FormControl('', [Validators.required]),
             category: new FormControl('', [Validators.required]),
             // attackPattern: new FormControl(this.currentAttackPattern, [Validators.required]),
-            protectWeight: new FormControl('', [Validators.required]),
-            detectWeight: new FormControl('', [Validators.required]),
-            respondWeight: new FormControl('', [Validators.required])
+            protectWeight: new FormControl(''),
+            detectWeight: new FormControl(''),
+            respondWeight: new FormControl('')
         });
 
         return group;

--- a/src/app/assess/v3/result/summary/summary-report/summary-report.component.scss
+++ b/src/app/assess/v3/result/summary/summary-report/summary-report.component.scss
@@ -127,7 +127,11 @@ $min-card-fullwidth: ($min-card-width * 2 + $padding-between-cards + $padding-be
     min-height: 10px;
 
     .mat-cell {
-      font-size: 11px;
+      font-size: 11px
+    }
+
+    .mat-column-risk {
+      min-width: 40px;
     }
   }
 }

--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -1,5 +1,5 @@
 <div id="articleEditorComponent">
-  <form [formGroup]="form">
+  <form [formGroup]="form" (ngSubmit)="submitArticle()">
     <mat-card class="uf-mat-card card">
       <mat-card-content class="cardContent">
         <br>
@@ -19,7 +19,7 @@
         <div class="mb-6">          
           <h4 [class.textWarn]="form.get('content').dirty && form.get('content').hasError('required')">Content<sup>*</sup></h4>
           <simplemde-mentions formControlName="content" [class.mdeError]="form.get('content').dirty && form.get('content').hasError('required')" ngDefaultControl></simplemde-mentions>
-          <mat-error [style.visibility]="form.get('content').dirty && form.get('content').hasError('required') ? 'visible' : 'hidden'">
+          <mat-error [class.showUfMatError]="form.get('content').dirty && form.get('content').hasError('required')" class="ufMatError">
             Content is <strong>required</strong>
           </mat-error>
         </div>
@@ -33,18 +33,22 @@
 
         <div *ngIf="!(blockAttachments$ | async)" class="mb-6">
           <h4>Attachments</h4>
-          <file-list></file-list>
+          <file-list [existingFiles]="articleToEdit && articleToEdit.metaProperties && articleToEdit.metaProperties.attachments" (filesChange)="files = $event"></file-list>
         </div>
 
       </mat-card-content>
     </mat-card>
     <div class="articleControlWrapper">
+      <div *ngIf="uploadProgress > 0">
+        <mat-progress-bar mode="determinate" [value]="uploadProgress" *ngIf="uploadProgress < 100"></mat-progress-bar>
+        <mat-progress-bar mode="indeterminate" *ngIf="uploadProgress === 100"></mat-progress-bar>
+      </div>
       <div class="max-card-width text-right">
         <button type="button" mat-button (click)="location.back()">CLOSE</button>
         <span>&nbsp;</span>
         <button type="button" mat-button color="primary">DELETE</button>
         <span>&nbsp;</span>
-        <button type="button" mat-raised-button color="primary">SAVE</button>
+        <button type="submit" mat-raised-button color="primary" [disabled]="form.status !== 'VALID'">SAVE</button>
       </div>
     </div>
   </form>

--- a/src/app/threat-beta/article/article-editor/article-editor.component.spec.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.spec.ts
@@ -4,23 +4,51 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule, MatButtonModule, MatIconModule, MatCardModule, MatChipsModule } from '@angular/material';
 import { Location } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { StoreModule } from '@ngrx/store';
+import { of as observableOf } from 'rxjs';
 
 import { ArticleEditorComponent } from './article-editor.component';
-import { StoreModule } from '@ngrx/store';
-import { reducers } from '../../../root-store/app.reducers';
 import { ArticleForm } from '../../../global/form-models/article';
 import { SimplemdeMentionsComponent } from '../../../global/components/simplemde-mentions/simplemde-mentions.component';
+import { ThreatDashboardBetaService } from '../../threat-beta.service';
+import MockThreatDashboardBetaService from '../../testing/mock-threat.service';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import mockThreatReducer from '../../testing/mock-reducer';
 
 describe('ArticleEditorComponent', () => {
   let component: ArticleEditorComponent;
   let fixture: ComponentFixture<ArticleEditorComponent>;
+
+  const mockRoute: any = {
+    snapshot: {
+      url: [ '_', 'new' ],
+      parent: {
+        params: {
+          boardId: 'x-unfetter-threat-board-1'
+        }
+      }
+    }    
+  };
+
+  const mockGenericApi: any = {
+    uploadAttachments: () => observableOf([{
+      _id: '5bb663378bc599007684cde0',
+      length: 172002,
+      chunkSize: 261120,
+      uploadDate: '2018-10-04T15:00:07.165-04:00',
+      md5: '12f4f9bc01837d3426dade0181e59b67',
+      filename: 'bootstrap.zip',
+      contentType: 'application/zip'
+    }])
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
         NoopAnimationsModule,
         ReactiveFormsModule,
-        StoreModule.forRoot(reducers),
+        StoreModule.forRoot(mockThreatReducer),
         MatIconModule,
         MatButtonModule,
         MatInputModule,
@@ -29,6 +57,10 @@ describe('ArticleEditorComponent', () => {
       ],
       providers: [
         { provide: Location, useValue: { back: () => { } } },
+        { provide: ThreatDashboardBetaService, useValue: MockThreatDashboardBetaService },
+        { provide: ActivatedRoute, useValue: mockRoute },
+        { provide: Router, useValue: { navigate: () => { } } },
+        { provide: GenericApi, useValue: mockGenericApi }
       ],
       declarations: [
         ArticleEditorComponent

--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -1,12 +1,23 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Location } from '@angular/common';
 import { FormGroup } from '@angular/forms';
-import { Observable } from 'rxjs';
-import { pluck, distinctUntilChanged, map, startWith } from 'rxjs/operators';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
+import { pluck, distinctUntilChanged, map, startWith, finalize, take, switchMap, withLatestFrom } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
+import { Article } from 'stix/unfetter/index';
+import { Report } from 'stix';
 
-import { AppState } from '../../../root-store/app.reducers';
+
 import { MasterConfig } from '../../../core/services/run-config.service';
+import { ThreatFeatureState } from '../../store/threat.reducers';
+import { ThreatDashboardBetaService } from '../../threat-beta.service';
+import { cleanObjectProperties } from '../../../global/static/clean-object-properties';
+import { getSelectedBoard } from '../../store/threat.selectors';
+import * as threatActions from '../../store/threat.actions';
+import * as utilityActions from '../../../root-store/utility/utility.actions';
+import { GenericApi } from '../../../core/services/genericapi.service';
+import { GridFSFile } from '../../../global/models/grid-fs-file';
 
 @Component({
   selector: 'article-editor',
@@ -19,29 +30,232 @@ export class ArticleEditorComponent implements OnInit {
   public form: FormGroup;
   public blockAttachments$: Observable<boolean>;
   public sourceNames$: Observable<string[]>;
+  public editMode: boolean;
+  public uploadProgress: number;
+  public files: File[];
+  public blockAttachments: boolean;
+
+  private boardId: string;
+  private editArticleId: string;
+  private articleToEdit: Article;
 
   constructor(
     public location: Location,
-    // TODO update state to feature state when ngrx is added
-    private store: Store<AppState>
+    private store: Store<ThreatFeatureState>,
+    private threatService: ThreatDashboardBetaService,
+    private genericApi: GenericApi,
+    private route: ActivatedRoute,
+    private router: Router
   ) { }
 
   ngOnInit() {
+    this.boardId = this.route.snapshot.parent.params.boardId;
+    this.editMode = this.route.snapshot.url[1] && this.route.snapshot.url[1].path === 'edit' || false;
+    
+    if (this.editMode) {
+      this.editArticleId = this.route.snapshot.params.articleId;
+      this.store.select('threat')
+        .pipe(
+          take(1)
+        )
+        .subscribe((threatState) => {
+          const found = threatState.articles.length && threatState.articles.find((art) => art.id === this.editArticleId);
+          if (found) {
+            this.articleToEdit = found;
+            this.setEditValues();
+          } else {
+            this.store.dispatch(new utilityActions.NavigateToErrorPage(404));
+          }                    
+        });
+    }
+
     this.blockAttachments$ = this.store
       .select('config')
       .pipe(
         pluck('runConfig'),
         distinctUntilChanged<MasterConfig>(),
         map((cfg) => cfg.blockAttachments)
-      );    
+      );
+    
     this.sourceNames$ = this.form.get('sources').valueChanges
       .pipe(
         startWith(this.form.get('sources').value),
-        map((sourceIds: string[]) => {
-          // TODO get real source names
-          return sourceIds
-            .map((sourceId) => 'A placeholder name');
+        withLatestFrom(this.store.select('threat').pipe(pluck('attachedReports'))),
+        map(([sourceIds, reports]: [string[], Report[]]) => {
+          return sourceIds.map((sourceId) => {
+            const foundReport = reports.find((report) => report.id === sourceId);
+            if (foundReport) {
+              return foundReport.name;
+            } else {
+              return 'Unknown';
+            }
+          });
         })
       );
+
+    this.store
+      .select('config')
+      .pipe(
+        pluck('runConfig'),
+        distinctUntilChanged(),
+      )
+      .subscribe(
+        (cfg: MasterConfig) => {
+          this.blockAttachments = cfg.blockAttachments;
+        }
+      );
+  }
+
+  private setEditValues(): void {
+    if (this.articleToEdit.name) {
+      this.form.get('name').patchValue(this.articleToEdit.name);
+    }
+    if (this.articleToEdit.content) {      
+      this.form.get('content').patchValue(this.articleToEdit.content);
+    }
+    if (this.articleToEdit.sources && this.articleToEdit.sources.length) {      
+      this.form.get('sources').patchValue(this.articleToEdit.sources);
+    }
+    // TODO handle attachments
+  }
+
+  public async submitArticle(): Promise<void> {
+    const submitErrorMsg = '';
+    const tempArticle = new Article(cleanObjectProperties({}, this.form.value));
+
+    const [uploadError, filesToUpload] = await this.uploadFiles();
+    if (uploadError) {
+      this.store.dispatch(new utilityActions.OpenSnackbar('Unable to upload attachments'));
+    } else if (filesToUpload && filesToUpload.length) {
+      if (!tempArticle.metaProperties) {
+        (tempArticle.metaProperties as any) = {};
+      }
+      if (this.editMode && this.articleToEdit.metaProperties && this.articleToEdit.metaProperties.attachments && this.articleToEdit.metaProperties.attachments.length) {
+        const attachmentsToKeep = this.articleToEdit.metaProperties.attachments
+          .filter((att) => {
+            return this.files
+              .filter((file) => (file as any)._id)
+              .find((file) => (file as any)._id === att._id)
+          });
+        tempArticle.metaProperties.attachments = attachmentsToKeep.concat(filesToUpload);
+      } else {
+        tempArticle.metaProperties.attachments = filesToUpload;
+      }
+    } else if (this.editMode && this.articleToEdit.metaProperties && this.articleToEdit.metaProperties.attachments) {
+      if (!tempArticle.metaProperties) {
+        (tempArticle.metaProperties as any) = {};
+      }
+      const attachmentsToKeep = this.articleToEdit.metaProperties.attachments
+        .filter((att) => {
+          return this.files
+            .filter((file) => (file as any)._id)
+            .find((file) => (file as any)._id === att._id)
+        });
+      tempArticle.metaProperties.attachments = attachmentsToKeep;
+    }
+
+    let success;
+    if (this.editMode) {
+      success = await this.editArticle(tempArticle);
+    } else {
+      success = await this.createNewArticle(tempArticle);
+      if (success) {
+        this.router.navigate(['/threat-beta', this.boardId, 'feed']);
+        return;
+      }
+    }
+
+    if (!success) {
+      this.store.dispatch(new utilityActions.OpenSnackbar('An Error Occured While Saving'));
+    }
+  }
+
+  private uploadFiles(): Promise<[any, GridFSFile[]]> {
+    this.uploadProgress = 0;
+    return new Promise((resolve) => {
+      if (this.blockAttachments) {
+        console.log('Attachments are blocked');
+        resolve([null, null]);
+        return;
+      }
+      const newFiles = this.files && this.files.length ? this.files.filter((file) => !(file as any).existingFile) : [];
+      if (newFiles.length) {
+        const uploadFile$ = this.genericApi.uploadAttachments(newFiles, (prog) => this.uploadProgress = prog)
+          .pipe(
+            finalize(() => this.uploadProgress = 0 || uploadFile$ && uploadFile$.unsubscribe())
+          )
+          .subscribe(
+            (response) => {
+              resolve([null, response]);
+            },
+            (err) => {
+              resolve([err, null]);
+            }
+          );
+      } else {
+        resolve([null, null]);
+      }
+    });
+  }
+
+  private async createNewArticle(tempArticle: Article): Promise<boolean> {
+    return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
+      const addArticle$ = this.store.select(getSelectedBoard)
+        .pipe(
+          take(1),
+          switchMap((board) => {
+            // Add article
+            // TODO handle edge case - article doesnt have created_by_ref
+            tempArticle.created_by_ref = board.created_by_ref;
+            return observableForkJoin(
+              this.threatService.addArticle(tempArticle),
+              observableOf(board)
+            );
+          }),
+          switchMap(([newArticle, board]) => {
+            // Add article reference to board
+            if (!board.articles) {
+              board.articles = [];
+            }
+            board.articles.push(newArticle.id);
+            return observableForkJoin(
+              observableOf(newArticle),
+              this.threatService.updateBoard(board),
+            );
+          }),      
+          finalize(() => addArticle$ && addArticle$.unsubscribe())
+        )
+        .subscribe(
+          ([newArticle, updatedBoard]) => {
+            this.store.dispatch(new threatActions.UpdateBoard(updatedBoard));
+            this.store.dispatch(new threatActions.AddArticle(newArticle));
+            this.store.dispatch(new utilityActions.OpenSnackbar('Article Successfully Added'));
+            resolve(true);
+          },
+          (err) => {
+            console.log(err);
+            reject(false);
+          }
+        );
+    });    
+  }
+
+  private async editArticle(tempArticle: Article): Promise<boolean> {
+    return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
+      tempArticle.id = this.articleToEdit.id;
+      const editArticle$ = this.threatService.editArticle(tempArticle)
+        .pipe(finalize(() => editArticle$ && editArticle$.unsubscribe()))
+        .subscribe(
+          (updatedArticle) => {
+            this.store.dispatch(new threatActions.UpdateArticle(updatedArticle));
+            this.store.dispatch(new utilityActions.OpenSnackbar('Article Successfully Updated'));
+            resolve(true);
+          },
+          (err) => {
+            console.log(err);
+            reject(false);
+          }
+        );
+    });
   }
 }

--- a/src/app/threat-beta/store/threat.actions.ts
+++ b/src/app/threat-beta/store/threat.actions.ts
@@ -18,6 +18,14 @@ export enum ThreatActionTypes {
     SetSelectedReportId = '[Threat] Set Selected Report Id',
     SetDashboardLoadingComplete = '[Threat] Set Dashboard Loading Complete',
     SetThreatboardLoadingComplete = '[Threat] Set Threatboard Loading Complete',
+    
+    AddArticle = '[Threat] Add Article',
+    UpdateArticle = '[Threat] Update Article',
+    DeleteArticle = '[Threat] Delete Article',
+    AddBoard = '[Threat] Add Board',
+    UpdateBoard = '[Threat] Update Board',
+    DeleteBoard = '[Threat] Delete Board',
+
     ClearData = '[Threat] Clear Data'
 }
 
@@ -93,6 +101,42 @@ export class SetThreatboardLoadingComplete implements Action {
     constructor(public payload: boolean) { }
 }
 
+export class AddArticle implements Action {
+    public readonly type = ThreatActionTypes.AddArticle;
+
+    constructor(public payload: Article) { }
+}
+
+export class UpdateArticle implements Action {
+    public readonly type = ThreatActionTypes.UpdateArticle;
+
+    constructor(public payload: Article) { }
+}
+
+export class DeleteArticle implements Action {
+    public readonly type = ThreatActionTypes.DeleteArticle;
+
+    constructor(public payload: string) { }
+}
+
+export class AddBoard implements Action {
+    public readonly type = ThreatActionTypes.AddBoard;
+
+    constructor(public payload: ThreatBoard) { }
+}
+
+export class UpdateBoard implements Action {
+    public readonly type = ThreatActionTypes.UpdateBoard;
+
+    constructor(public payload: ThreatBoard) { }
+}
+
+export class DeleteBoard implements Action {
+    public readonly type = ThreatActionTypes.DeleteBoard;
+
+    constructor(public payload: string) { }
+}
+
 export class ClearData implements Action {
     public readonly type = ThreatActionTypes.ClearData;
 
@@ -112,4 +156,10 @@ export type threatActions =
     | SetSelectedReportId
     | SetDashboardLoadingComplete 
     | SetThreatboardLoadingComplete
+    | AddArticle
+    | UpdateArticle
+    | DeleteArticle
+    | AddBoard
+    | UpdateBoard
+    | DeleteBoard
     | ClearData;

--- a/src/app/threat-beta/store/threat.reducers.ts
+++ b/src/app/threat-beta/store/threat.reducers.ts
@@ -112,6 +112,76 @@ export function threatReducer(state = initialState, action: threatActions): Thre
                 ...state,
                 dashboardLoadingComplete: action.payload
             };
+        case ThreatActionTypes.AddArticle:
+            return {
+                ...state,
+                articles: [...state.articles, action.payload]
+            }
+        case ThreatActionTypes.UpdateArticle: {
+            const articleIndex = state.articles.findIndex(
+                (article) => article.id === action.payload.id
+            );
+            if (articleIndex > -1) {
+                const articlesCopy = [...state.articles];
+                articlesCopy[articleIndex] = action.payload;
+                return {
+                    ...state,
+                    articles: articlesCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.DeleteArticle: {
+            const articleIndex = state.articles.findIndex(
+                (article) => article.id === action.payload
+            );
+            if (articleIndex > -1) {
+                const articlesCopy = [...state.articles];
+                articlesCopy.splice(articleIndex, 1);
+                return {
+                    ...state,
+                    articles: articlesCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.AddBoard:
+            return {
+                ...state,
+                boardList: [...state.boardList, action.payload]
+            }
+        case ThreatActionTypes.UpdateBoard: {
+            const boardIndex = state.boardList.findIndex(
+                (board) => board.id === action.payload.id
+            );
+            if (boardIndex > -1) {
+                const boardsCopy = [...state.boardList];
+                boardsCopy[boardIndex] = action.payload;
+                return {
+                    ...state,
+                    boardList: boardsCopy
+                };
+            } else {
+                return state;
+            }
+        }
+        case ThreatActionTypes.DeleteBoard: {
+            const boardIndex = state.boardList.findIndex(
+                (board) => board.id === action.payload
+            );
+            if (boardIndex > -1) {
+                const boardsCopy = [...state.boardList];
+                boardsCopy.splice(boardIndex, 1);
+                return {
+                    ...state,
+                    boardList: boardsCopy
+                };
+            } else {
+                return state;
+            }
+        }
         case ThreatActionTypes.ClearData:
             return initialState;
         default:

--- a/src/app/threat-beta/testing/mock-threat.service.ts
+++ b/src/app/threat-beta/testing/mock-threat.service.ts
@@ -1,0 +1,12 @@
+import { of as observableOf } from 'rxjs';
+import * as UUID from 'uuid';
+
+const MockThreatDashboardBetaService = {
+    addArticle(article) {
+        article.id = `x-unfetter-article--${UUID.v4()}`;
+        return observableOf(article);
+    },
+    updateBoard: (board) => observableOf(board)
+};
+
+export default MockThreatDashboardBetaService;

--- a/src/app/threat-beta/threat-beta.module.ts
+++ b/src/app/threat-beta/threat-beta.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
+import { MatProgressBarModule } from '@angular/material';
 
 import { ThreatDashboardBetaComponent } from './threat-dashboard-beta.component';
 import { FeedComponent } from './feed/feed.component';
@@ -27,6 +28,7 @@ import { ThreatEffects } from './store/threat.effects';
     CommonModule,
     GlobalModule,
     FormsModule,
+    MatProgressBarModule,
     ReactiveFormsModule,
     routing,
     StoreModule.forFeature('threat', threatReducer),

--- a/src/app/threat-beta/threat-beta.routing.ts
+++ b/src/app/threat-beta/threat-beta.routing.ts
@@ -19,7 +19,8 @@ const routes: Routes = [
         path: ':boardId',
         component: BoardLayoutComponent,
         children: [
-          { path: 'article', component: ArticleComponent },
+          { path: 'article/new', component: ArticleComponent },
+          { path: 'article/edit/:articleId', component: ArticleComponent },
           { path: 'board', component: BoardComponent },
           { path: 'feed', component: FeedComponent },
         ]

--- a/src/app/threat-beta/threat-beta.service.ts
+++ b/src/app/threat-beta/threat-beta.service.ts
@@ -1,6 +1,34 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map, pluck } from 'rxjs/operators';
+import { Article, ThreatBoard } from 'stix/unfetter/index';
+
+import { GenericApi } from '../core/services/genericapi.service';
+import { StixUrls } from '../global/enums/stix-urls.enum';
+import { RxjsHelpers } from '../global/static/rxjs-helpers';
 
 @Injectable()
 export class ThreatDashboardBetaService {
+    constructor(private genericApi: GenericApi) { }
 
+    public addArticle(article: Article): Observable<Article> {
+        return this.genericApi.post(StixUrls.X_UNFETTER_ARTICLE, { data: { attributes: article } })
+            .pipe(
+                RxjsHelpers.unwrapJsonApi(),
+                map((articles) => articles[0])
+            );
+    }
+
+    public editArticle(article: Article): Observable<Article> {
+        return this.genericApi.patch(`${StixUrls.X_UNFETTER_ARTICLE}/${article.id}`, { data: { attributes: article } })
+            .pipe(pluck('attributes'));
+    }
+
+    public updateBoard(board: ThreatBoard): Observable<ThreatBoard> {
+        return this.genericApi.patch(
+            `${StixUrls.X_UNFETTER_THREAT_BOARD}/${board.id}`, 
+            { data: { attributes: board } }
+        )
+        .pipe(pluck('attributes'));
+    }
 }

--- a/src/app/threat-beta/threat-header/threat-header.component.ts
+++ b/src/app/threat-beta/threat-header/threat-header.component.ts
@@ -21,7 +21,7 @@ export class ThreatHeaderComponent {
     this._boardId = v;
     this.feedLink = `${this.BASE_URL}/${this._boardId}/feed`;
     this.boardLink = `${this.BASE_URL}/${this._boardId}/board`;
-    this.articleLink = `${this.BASE_URL}/${this._boardId}/article`;
+    this.articleLink = `${this.BASE_URL}/${this._boardId}/article/new`;
   }
 
   public get boardId () { return this._boardId; }

--- a/src/styles/partials/_angular_material_config.scss
+++ b/src/styles/partials/_angular_material_config.scss
@@ -199,6 +199,16 @@ a.mat-button {
   text-decoration: none;
 }
 
+.ufMatError {
+  font-size: 75%;
+  transition: 300ms cubic-bezier(0.55, 0, 0.55, 0.2);
+  opacity: 1;
+
+  &:not(.showUfMatError) {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+}
 
 // Polyfill for browser compatibility
 .sidenavContentPolyfill250 {


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1238

Minimum width of risk column needed to be slightly larger to prevent cut-off when browser width is narrow.

### To test:
1. Pull this branch
2. View any assessment summary
3. In latest Chrome and Firefox, and Firefox 31, make sure Risk column under "Where are you most vulnerable" card is wide enough to prevent cut-off when browser width is reduced.  