### PR TITLE
Feature 1483/threat board feed

### DIFF
--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -24,6 +24,7 @@ import {
     MatTabsModule,
     MatToolbarModule,
     MatTooltipModule,
+    MatRadioModule,
 } from '@angular/material';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { SimplemdeModule, SIMPLEMDE_CONFIG } from 'ng2-simplemde';
@@ -111,6 +112,7 @@ const matModules = [
     MatMenuModule,
     MatPaginatorModule,
     MatProgressSpinnerModule,
+    MatRadioModule,
     MatSelectModule,
     MatSidenavModule,
     MatTableModule,

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -1,5 +1,65 @@
-<div id="feedComponenet">
-  <div class="main-panel min-tab-height">
-    Feed for a specific board here.
-  </div>
+<div id="search-bar" class="">
+    <mat-form-field class="search-input">
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput type="text" placeholder="Search this board">
+    </mat-form-field>
 </div>
+
+<mat-sidenav-container class="flex">
+        
+    <mat-sidenav-content class="min-tab-height">
+
+        <div id="feed-content" class="flex1">
+
+            <div id="reports-carousel">
+                <div id="reports-label"><h4>Reports</h4></div>
+                <div id="reports-list" *ngIf="reportsLoaded; else loadingBlock">
+                    <div *ngFor="let report of reports" class="board-report"
+                            [style.background]="getReportBackground(report)">
+                        <div class='report-image' [style.background-image]="getReportBackgroundImage(report)"></div>
+                        <div class="report-info">
+                            <div class='report-title'>{{ report.name }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="related-boards-carousel">
+                <div id="related-boards-label"><h4>Related Boards</h4></div>
+                <div id="related-boards-list" *ngIf="boardsLoaded; else loadingBlock">
+                    <div *ngFor="let board of boards" class="related-board"
+                            [style.background]="getBoardBackground(board)">
+                        <div class='board-title'>{{ board.name }}</div>
+                        <div class='board-owner'>Owner Name</div>
+                        <div class='board-options'>FOLLOW</div>
+                    </div>
+                </div>
+            </div>
+
+            <div id="activities-list">
+                <div id="activities-nav-bar"><h4>Activity</h4></div>
+                <div id="activity-feed" *ngIf="boardLoaded; else loadingBlock">
+                    Latests comments / article go here.
+                </div>
+            </div>
+
+        </div>
+
+    </mat-sidenav-content>
+
+    <mat-sidenav id="trends-trench" opened mode="side" position="end">
+
+        <div id="contributors">
+            <div id="contributors-label"><h4>Contributors</h4></div>
+            <div id="contributors-list" *ngIf="boardLoaded; else loadingBlock">
+                Contributors list goes here.
+            </div>
+        </div>
+
+    </mat-sidenav>
+
+</mat-sidenav-container>
+
+<ng-template #loadingBlock>
+    <loading-spinner height="250px"></loading-spinner>
+</ng-template>

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -14,9 +14,34 @@
             <div id="reports-carousel">
                 <div id="reports-label"><h4>Reports</h4></div>
                 <div id="reports-list" *ngIf="reportsLoaded; else loadingBlock">
-                    <div *ngFor="let report of reports" class="board-report"
-                            [style.background]="getReportBackground(report)">
-                        <div class='report-image' [style.background-image]="getReportBackgroundImage(report)"></div>
+                    <div *ngFor="let report of reports; index as repidx" class="board-report"
+                            [style.background-image]="getReportBackground(report)"
+                            (mouseenter)="hoverIndex = repidx" (mouseleave)="hoverIndex = -1">
+                        <div class='report-image' [style.background-image]="getReportBackgroundImage(report)">
+                            <div class='report-fabs' *ngIf="hoverIndex === repidx">
+                                <div class="fab-row">
+                                    <button mat-mini-fab>
+                                        <mat-icon class="mat-24">done</mat-icon>
+                                    </button>
+                                </div>
+                                <div class="fab-row">
+                                    <button mat-mini-fab>
+                                        <mat-icon class="mat-24">launch</mat-icon>
+                                    </button>
+                                    <button mat-mini-fab [style.background]="'transparent'">
+                                        <mat-icon class="mat-24"></mat-icon>
+                                    </button>
+                                    <button mat-mini-fab>
+                                        <mat-icon class="mat-24">share</mat-icon>
+                                    </button>
+                                </div>
+                                <div class="fab-row">
+                                    <button mat-mini-fab>
+                                        <mat-icon class="mat-24">delete</mat-icon>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
                         <div class="report-info">
                             <div class='report-title'>{{ report.name }}</div>
                         </div>
@@ -37,7 +62,16 @@
             </div>
 
             <div id="activities-list">
-                <div id="activities-nav-bar"><h4>Activity</h4></div>
+                <div id="activities-nav-bar" class="flex">
+                    <h4>Activity</h4>
+                    <div class="flex1 activity-sort-options">
+                        Sort by:
+                        <mat-radio-group>
+                            <mat-radio-button *ngFor="let opt of sorts; index as optidx" value="{{ optidx }}"
+                                    (disabled)="true" checked="{{ optidx === 0 }}">{{ opt.name }}</mat-radio-button>
+                        </mat-radio-group>
+                    </div>
+                </div>
                 <div id="activity-feed" *ngIf="boardLoaded; else loadingBlock">
                     Latests comments / article go here.
                 </div>
@@ -52,7 +86,14 @@
         <div id="contributors">
             <div id="contributors-label"><h4>Contributors</h4></div>
             <div id="contributors-list" *ngIf="boardLoaded; else loadingBlock">
-                Contributors list goes here.
+                <div class="flex contributor">
+                    <div class="contributor-avatar" [style.background-color]="'darkorange'">JD</div>
+                    <div class="contributor-userid flex1">Jane Doe</div>
+                </div>
+                <div class="flex contributor">
+                    <div class="contributor-avatar" [style.background-color]="'teal'">JS</div>
+                    <div class="contributor-userid flex1">John Smith</div>
+                </div>
             </div>
         </div>
 

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -45,25 +45,86 @@
         margin-right: 20px;
     }
 
-    .report-image {
-        height: 100px;
-        background-size: 200px 100px;
+    .board-report {
+        .report-image {
+            height: 100px;
+            background-size: 200px 100px;
+
+            .report-fabs {
+                text-align: center;
+
+                .fab-row {
+                    padding-top: 10px;
+
+                    button[mat-mini-fab] {
+                        color: black;
+                        background: white;
+                    }
+                }
+            }
+        }
+    
+        .report-info {
+            width: 200px;
+            height: 150px;
+            padding: 16px;
+        }
+    
+        .report-title {
+            font-size: 16px;
+            color: white;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .report-badge {
+            position: absolute;
+            top: 44px;
+            height: 26px;
+            background: transparent;
+            font-size: 20px;
+            color:  blue;
+        }
     }
 
-    .report-info {
-        width: 200px;
-        height: 150px;
+    .related-board {
         padding: 16px;
-    }
 
-    .report-title {
-        font-size: 16px;
-        color: white;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        .board-title {
+            width: 168px;
+            height: 150px;
+            font-size: 16px;
+            color: white;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .board-owner {
+            width: 168px;
+            height: 30px;
+            font-size: 14px;
+            color: lightgray;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .board-options {
+            width: 168px;
+            height: 30px;
+            font-size: 16px;
+            color: white;
+        }
     }
 
     #activities-list {
+        .activity-sort-options {
+            margin: 10px;
+            text-align: right;
+
+            mat-radio-button {
+                padding: 0 12px;
+            }
+        }
     }
 
 }
@@ -77,6 +138,25 @@
     box-shadow: 1px 0 8px 0 rgba(0, 0, 0, .8);
 
     #contributors {
+        .contributor {
+            margin-left: 16px;
+            margin-bottom: 12px;
+        }
+
+        .contributor-avatar {
+            width: 40px;
+            height: 40px;
+            margin-right: 8px;
+            border-radius: 20px;
+            line-height: 40px;
+            text-align: center;
+            color: white;
+        }
+
+        .contributor-userid {
+            height: 40px;
+            line-height: 40px;
+        }
     }
 
 }

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -1,2 +1,82 @@
 @import '../../../styles/_variables.scss';
 @import '../threat-beta.common';
+
+#search-bar {
+
+    .search-input {
+        width: 100%;
+        margin-bottom: 5px;
+        background: white;
+        box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .4);
+
+        mat-icon {
+            margin-left: 15px;
+            margin-right: 15px;
+        }
+    }
+
+}
+
+:host ::ng-deep #search-bar .mat-form-field-wrapper {
+    padding-bottom: 0;
+    .mat-form-field-underline {
+        display: none;
+    }
+}
+
+#feed-content {
+
+    padding: 15px;
+
+    #reports-carousel, #related-boards-carousel {
+        margin-bottom: 20px;
+    }
+
+    #reports-list, #related-boards-list {
+        display: flex;
+        flex-direction: row;
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
+
+    .board-report, .related-board {
+        width: 200px;
+        height: 250px;
+        margin-right: 20px;
+    }
+
+    .report-image {
+        height: 100px;
+        background-size: 200px 100px;
+    }
+
+    .report-info {
+        width: 200px;
+        height: 150px;
+        padding: 16px;
+    }
+
+    .report-title {
+        font-size: 16px;
+        color: white;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    #activities-list {
+    }
+
+}
+
+#trends-trench {
+
+    width: 380px;
+    margin-left: 10px;
+    padding: 15px;
+    background: white;
+    box-shadow: 1px 0 8px 0 rgba(0, 0, 0, .8);
+
+    #contributors {
+    }
+
+}

--- a/src/app/threat-beta/feed/feed.component.spec.ts
+++ b/src/app/threat-beta/feed/feed.component.spec.ts
@@ -1,40 +1,49 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatIconModule, MatTabsModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
-import { GlobalModule } from '../../global/global.module';
+import { StoreModule } from '@ngrx/store';
+
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconModule, MatTabsModule } from '@angular/material';
+
+import { FeedComponent } from './feed.component';
 import { SideBoardComponent } from '../side-board/side-board.component';
 import { ThreatHeaderComponent } from '../threat-header/threat-header.component';
-import { FeedComponent } from './feed.component';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-
+import { GlobalModule } from '../../global/global.module';
+import { threatReducer } from '../store/threat.reducers';
 
 describe('FeedComponent', () => {
-  let component: FeedComponent;
-  let fixture: ComponentFixture<FeedComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [FeedComponent,
-        ThreatHeaderComponent,
-        SideBoardComponent,
-      ],
-      imports: [RouterTestingModule,
-        MatTabsModule,
-        MatIconModule,
-        GlobalModule,
-        NoopAnimationsModule,
-      ],
-    })
-      .compileComponents();
-  }));
+    let component: FeedComponent;
+    let fixture: ComponentFixture<FeedComponent>;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(FeedComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(async(() => {
+        TestBed
+            .configureTestingModule({
+                imports: [
+                    RouterTestingModule,
+                    MatTabsModule,
+                    MatIconModule,
+                    GlobalModule,
+                    NoopAnimationsModule,
+                    StoreModule.forRoot(threatReducer),
+                ],
+                declarations: [
+                    FeedComponent,
+                    ThreatHeaderComponent,
+                    SideBoardComponent,
+                ],
+            })
+            .compileComponents();
+    }));
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(FeedComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
 });

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -5,7 +5,7 @@ import { pluck, map, filter } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
 import { Report } from 'stix';
-import { ThreatBoard } from 'stix/unfetter';
+import { ThreatBoard } from 'stix/unfetter/index';
 
 import { ThreatFeatureState } from '../store/threat.reducers';
 import { getSelectedBoard } from '../store/threat.selectors';

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -1,15 +1,108 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { Observable } from 'rxjs';
+import { pluck, map, filter } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
+
+import { Report } from 'stix';
+import { ThreatBoard } from 'stix/unfetter';
+
+import { ThreatFeatureState } from '../store/threat.reducers';
+import { getSelectedBoard } from '../store/threat.selectors';
+import * as fromThreat from '../store/threat.actions';
 
 @Component({
-  selector: 'feed',
-  templateUrl: './feed.component.html',
-  styleUrls: ['./feed.component.scss']
+    selector: 'feed',
+    templateUrl: './feed.component.html',
+    styleUrls: ['./feed.component.scss']
 })
 export class FeedComponent implements OnInit {
-  
-  constructor() { }
 
-  ngOnInit() {
-  }
+    public threatBoard: ThreatBoard;
+    private _boardLoaded = false;
+
+    public reports = {};
+    private _reportsLoaded = false;
+
+    public boards = {};
+    private _boardsLoaded = false;
+
+    constructor(
+        private store: Store<ThreatFeatureState>,
+        private sanitizer: DomSanitizer,
+    ) {
+    }
+
+    public get boardLoaded() { return this._boardLoaded; }
+
+    public get reportsLoaded() { return this._reportsLoaded; }
+
+    public get boardsLoaded() { return this._boardsLoaded; }
+
+    ngOnInit() {
+        this.store.select(getSelectedBoard)
+            .subscribe(
+                (board) => {
+                    console.log('retrieved threat board:', board);
+                    this.threatBoard = board;
+                    this._boardLoaded = true;
+
+                    this.store.select('threat')
+                        .pipe(
+                            pluck('boardList'),
+                            filter((b: any) => b.id !== board.id)
+                        )
+                        .subscribe(
+                            (boards) => {
+                                console.log(`(${new Date().toISOString()}) board list`, boards);
+                                this.boards = boards;
+                                this._boardsLoaded = true;
+                            },
+                            (err) => console.log(`(${new Date().toISOString()}) Error loading boards:`, err)
+                        );
+
+                    this.store.select('threat')
+                        .pipe(
+                            pluck('attachedReports')
+                        )
+                        .subscribe(
+                            (reports) => {
+                                this.reports = reports;
+                                this._reportsLoaded = true;
+                            },
+                            (err) => console.log(`(${new Date().toISOString()}) Error loading reports:`, err)
+                        );
+                },
+                (err) => console.log(`(${new Date().toISOString()}) Error loading threat board:`, err)
+            )
+    }
+
+    public getReportBackground(report: any) {
+        const colors = [
+            ['darkred', 'rosybrown'],
+            ['lightblue', 'darkblue'],
+            ['lightgreen', 'darkgreen'],
+            ['orchid', 'darkorchid'],
+            ['palevioletred', 'mediumvioletred'],
+        ];
+        const n = report.name.charCodeAt(0) % colors.length;
+        return `linear-gradient(${colors[n][0]}, ${colors[n][1]})`;
+    }
+
+    public getReportBackgroundImage(report: any) {
+        return this.sanitizer.bypassSecurityTrustStyle(
+                `url(${report.metaProperties.image}), linear-gradient(transparent, transparent)`);
+    }
+
+    public getBoardBackground(board: any) {
+        const colors = [
+            ['slateblue'],
+            ['brown'],
+            ['forestgreen'],
+            ['deeppurple'],
+        ];
+        const n = board.name.charCodeAt(0) % colors.length;
+        return colors[n];
+    }
 
 }

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -21,11 +21,19 @@ export class FeedComponent implements OnInit {
     public threatBoard: ThreatBoard;
     private _boardLoaded = false;
 
-    public reports = {};
+    public reports = [];
     private _reportsLoaded = false;
+    public hoverIndex = -1;
 
     public boards = {};
     private _boardsLoaded = false;
+
+    public readonly sorts = [
+        { name: 'Newest', sorter: this.sortByLastModified },
+        { name: 'Oldest', sorter: this.sortByFirstCreated },
+        { name: 'Likes', sorter: this.sortByMostLikes },
+        { name: 'Comments', sorter: this.sortByMostComments },
+    ];
 
     constructor(
         private store: Store<ThreatFeatureState>,
@@ -49,13 +57,12 @@ export class FeedComponent implements OnInit {
 
                     this.store.select('threat')
                         .pipe(
-                            pluck('boardList'),
-                            filter((b: any) => b.id !== board.id)
+                            pluck('boardList')
                         )
                         .subscribe(
-                            (boards) => {
-                                console.log(`(${new Date().toISOString()}) board list`, boards);
-                                this.boards = boards;
+                            (boards: any[]) => {
+                                this.boards = boards.filter(b => b.id !== board.id);
+                                console.log(`(${new Date().toISOString()}) board list`, this.boards);
                                 this._boardsLoaded = true;
                             },
                             (err) => console.log(`(${new Date().toISOString()}) Error loading boards:`, err)
@@ -63,11 +70,13 @@ export class FeedComponent implements OnInit {
 
                     this.store.select('threat')
                         .pipe(
-                            pluck('attachedReports')
+                            pluck('feedReports')
                         )
                         .subscribe(
-                            (reports) => {
-                                this.reports = reports;
+                            (reports: any[]) => {
+                                console.log('feed reports', reports);
+                                this.reports = reports.sort(this.sortByLastModified);
+                                console.log('full reports', this.reports);
                                 this._reportsLoaded = true;
                             },
                             (err) => console.log(`(${new Date().toISOString()}) Error loading reports:`, err)
@@ -96,13 +105,30 @@ export class FeedComponent implements OnInit {
 
     public getBoardBackground(board: any) {
         const colors = [
-            ['slateblue'],
-            ['brown'],
-            ['forestgreen'],
-            ['deeppurple'],
+            ['indianred', 'firebrick'],
+            ['rebeccapurple', 'indigo'],
+            ['olivedrab', 'olive'],
+            ['slateblue', 'darkslateblue'],
+            ['cadetblue', 'darkslategray'],
         ];
         const n = board.name.charCodeAt(0) % colors.length;
-        return colors[n];
+        return `linear-gradient(${colors[n][0]}, ${colors[n][1]})`;
+    }
+
+    public sortByFirstCreated(a: any, b: any) {
+        return a.created.localeCompare(b.created);
+    }
+
+    public sortByLastModified(a: any, b: any) {
+        return b.modified.localeCompare(a.modified);
+    }
+
+    public sortByMostLikes(a: any, b: any) {
+        return b.modified.localeCompare(a.modified);
+    }
+
+    public sortByMostComments(a: any, b: any) {
+        return b.modified.localeCompare(a.modified);
     }
 
 }

--- a/src/app/threat-beta/store/threat.effects.ts
+++ b/src/app/threat-beta/store/threat.effects.ts
@@ -27,9 +27,11 @@ export class ThreatEffects {
             switchMap(() => {                
                 const options: StixApiOptions = {
                     project: {
+                        'stix.id': 1,
                         'stix.name': 1,
                         'stix.description': 1,
                         'stix.external_references': 1,
+                        'stix.modified': 1,
                         'metaProperties': 1
                     },
                     sort: { 


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1483 (for this sprint?).

- Create a threat board, if you have not already.

- Go to the feed page for that board: `https://localhost:9443/#/threat-beta/<board-id>/feed`

- Hopefully, you have reports listed for it, will see other, related boards.

- Contributors list is, obviously, sample data for now

- Activities list will be empty at this time.

- Hovering over a report should show the fab buttons. They currently do nothing.