### PR TITLE
Converts reports div to carousel view

### DIFF
--- a/src/app/global/global.module.ts
+++ b/src/app/global/global.module.ts
@@ -25,6 +25,7 @@ import {
     MatToolbarModule,
     MatTooltipModule,
     MatRadioModule,
+    MatBadgeModule,
 } from '@angular/material';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { SimplemdeModule, SIMPLEMDE_CONFIG } from 'ng2-simplemde';
@@ -99,6 +100,7 @@ import { TextHighlightComponent } from './components/text-highlight/text-highlig
 
 const matModules = [
     MatAutocompleteModule,
+    MatBadgeModule,
     MatButtonModule,
     MatButtonToggleModule,
     MatCardModule,

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -12,32 +12,45 @@
         <div id="feed-content" class="flex1">
 
             <div id="reports-carousel">
+
                 <div id="reports-label"><h4>Reports</h4></div>
-                <div id="reports-list" *ngIf="reportsLoaded; else loadingBlock">
-                    <div *ngFor="let report of reports; index as repidx" class="board-report"
-                            [style.background-image]="getReportBackground(report)"
-                            (mouseenter)="hoverIndex = repidx" (mouseleave)="hoverIndex = -1">
+
+                <div #reportsView id="reports-list" *ngIf="reportsLoaded; else loadingBlock"
+                        (mouseenter)="reportsHover = true" (mouseleave)="reportsHover = false">
+
+                    <button *ngIf="reportsHover" mat-icon-button mat-mini-fab class="carousel-button carousel-left"
+                            [disabled]="isFirstReport()" (click)="scrollReportsLeft()">
+                        <mat-icon aria-label="scroll reports left">keyboard_arrow_left</mat-icon>
+                    </button>
+
+                    <button *ngIf="reportsHover" mat-icon-button mat-mini-fab class="carousel-button carousel-right"
+                            [disabled]="isLastReport()" (click)="scrollReportsRight()">
+                        <mat-icon aria-label="scroll reports right">keyboard_arrow_right</mat-icon>
+                    </button>
+
+                    <div *ngFor="let report of reports; index as repidx" id="{{ report.id }}"
+                            class="board-report" [style.background-image]="getReportBackground(report)"
+                            matBadge="!" matBadgeDescription="new" matBadgeColor="warn"
+                            matBadgePosition="before" matBadgeHidden="{{ report.vetted }}"
+                            (mouseenter)="reportHoverIndex = repidx" (mouseleave)="reportHoverIndex = -1">
                         <div class='report-image' [style.background-image]="getReportBackgroundImage(report)">
-                            <div class='report-fabs' *ngIf="hoverIndex === repidx">
+                            <div class='report-fabs' *ngIf="reportHoverIndex === repidx">
                                 <div class="fab-row">
-                                    <button mat-mini-fab>
-                                        <mat-icon class="mat-24">done</mat-icon>
+                                    <button mat-mini-fab [disabled]="report.vetted">
+                                        <mat-icon class="mat-24" aria-label="approve report">done</mat-icon>
+                                    </button>
+                                </div>
+                                <div class="fab-row">
+                                    <button mat-mini-fab [style.margin-right]="'24px'">
+                                        <mat-icon class="mat-24" aria-label="report quick view">launch</mat-icon>
+                                    </button>
+                                    <button mat-mini-fab [style.margin-left]="'24px'" disabled>
+                                        <mat-icon class="mat-24" aria-label="share report">share</mat-icon>
                                     </button>
                                 </div>
                                 <div class="fab-row">
                                     <button mat-mini-fab>
-                                        <mat-icon class="mat-24">launch</mat-icon>
-                                    </button>
-                                    <button mat-mini-fab [style.background]="'transparent'">
-                                        <mat-icon class="mat-24"></mat-icon>
-                                    </button>
-                                    <button mat-mini-fab>
-                                        <mat-icon class="mat-24">share</mat-icon>
-                                    </button>
-                                </div>
-                                <div class="fab-row">
-                                    <button mat-mini-fab>
-                                        <mat-icon class="mat-24">delete</mat-icon>
+                                        <mat-icon class="mat-24" aria-label="reject report">delete</mat-icon>
                                     </button>
                                 </div>
                             </div>
@@ -47,11 +60,14 @@
                         </div>
                     </div>
                 </div>
+
             </div>
 
             <div id="related-boards-carousel">
+
                 <div id="related-boards-label"><h4>Related Boards</h4></div>
-                <div id="related-boards-list" *ngIf="boardsLoaded; else loadingBlock">
+
+                <div #boardsView id="related-boards-list" *ngIf="boardsLoaded; else loadingBlock">
                     <div *ngFor="let board of boards" class="related-board"
                             [style.background]="getBoardBackground(board)">
                         <div class='board-title'>{{ board.name }}</div>
@@ -59,6 +75,7 @@
                         <div class='board-options'>FOLLOW</div>
                     </div>
                 </div>
+
             </div>
 
             <div id="activities-list">
@@ -95,6 +112,10 @@
                     <div class="contributor-userid flex1">John Smith</div>
                 </div>
             </div>
+        </div>
+
+        <div id="last-polled" *ngIf="boardLoaded">
+            <i>Board was updated on {{ boardUpdateTime }}</i>
         </div>
 
     </mat-sidenav>

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -30,13 +30,54 @@
 
     #reports-carousel, #related-boards-carousel {
         margin-bottom: 20px;
+
+        .carousel-button {
+            position: absolute;
+            width: 48px;
+            height: 48px;
+            top: 16%;
+            z-index: 100;
+            margin: 0 16px;
+            background: rgba(127, 127, 127, .4);
+            border: 2px solid white;
+            border-radius: 50%;
+            color: rgba(255, 255, 255, .4);
+
+            mat-icon {
+                font-size: 36px;
+                margin-left: -12px;
+            }
+        }
+        .carousel-button:hover {
+            // border-color: white;
+            background: rgba(255, 255, 255, .3);
+            color: white;
+        }
+        .carousel-button[disabled] {
+            border-color: rgba(0, 0, 0, .6);
+            background: rgba(0, 0, 0, .4);
+            // color: rgba(0, 0, 0, .7);
+            color: gray;
+        }
+        .carousel-button.carousel-left {
+            left: 0;
+        }
+        .carousel-button.carousel-right {
+            right: 0;
+        }
+
+        h4 {
+            display: inline-block;
+        }
     }
 
     #reports-list, #related-boards-list {
         display: flex;
         flex-direction: row;
-        overflow-x: auto;
-        overflow-y: hidden;
+        margin-top: -11px;
+        padding-top: 11px;
+        overflow-x: hidden;
+        transition: margin-left 0.5s ease;
     }
 
     .board-report, .related-board {
@@ -59,6 +100,10 @@
                     button[mat-mini-fab] {
                         color: black;
                         background: white;
+                    }
+                    button[mat-mini-fab][disabled] {
+                        color: white;
+                        background: gray;
                     }
                 }
             }
@@ -131,6 +176,8 @@
 
 #trends-trench {
 
+    display: flex;
+    flex-direction: column;
     width: 380px;
     margin-left: 10px;
     padding: 15px;
@@ -138,6 +185,8 @@
     box-shadow: 1px 0 8px 0 rgba(0, 0, 0, .8);
 
     #contributors {
+        flex: 1;
+
         .contributor {
             margin-left: 16px;
             margin-bottom: 12px;
@@ -147,7 +196,7 @@
             width: 40px;
             height: 40px;
             margin-right: 8px;
-            border-radius: 20px;
+            border-radius: 50%;
             line-height: 40px;
             text-align: center;
             color: white;


### PR DESCRIPTION
Supports unfetter-discover/unfetter#1362.

Updates the threatboard feed page.

Previous version: the Reports section was a left-right scrollable div.

New version: Scrollbar is replaced with carousel buttons.

Known issues:
  - If the div is not "full" of reports, the right scroll button is after the last item, not all the way to the right.
  - Scrolling left starts off with some funky movement.

Future:
  - Will be adding page "dots" centered over the top of the reports carousel for faster "jumping"
  - Will hide the carousel buttons altogether if there is only one page to view
  - Will be duplicating the changes in the related boards