### PR TITLE
Threatboard feed likes and comments

### DIFF
--- a/src/app/global/components/footer/footer.component.scss
+++ b/src/app/global/components/footer/footer.component.scss
@@ -24,5 +24,3 @@ ul,
 .largeLink {
     font-size: 21px;
 }
-
-

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -125,19 +125,41 @@
             </div><!-- ends related boards carousel -->
 
             <div id="activities-list">
+
                 <div id="activities-nav-bar" class="flex">
                     <h4>Activity</h4>
                     <div class="flex1 activity-sort-options">
                         Sort by:
-                        <mat-radio-group>
-                            <mat-radio-button *ngFor="let opt of sorts; index as optidx" value="{{ optidx }}"
-                                    (disabled)="true" checked="{{ optidx === 0 }}">{{ opt.name }}</mat-radio-button>
+                        <mat-radio-group [(ngModel)]="activitySort">
+                            <mat-radio-button *ngFor="let sort of sorts; index as sidx"
+                                    value="{{ sidx }}">{{ sort.name }}</mat-radio-button>
                         </mat-radio-group>
                     </div>
                 </div>
-                <div id="activity-feed" *ngIf="boardLoaded; else loadingBlock">
-                    Latests comments / article go here.
+
+                <div id="activity-feed" *ngIf="activityLoaded; else loadingBlock">
+
+                    <mat-card>
+                        <mat-card-content>
+                            <button mat-button *ngIf="addNewComment !== true"
+                                    (click)="startActivityComment()">Add a comment</button>
+                            <ng-container *ngIf="addNewComment === true">
+                                <ng-container *ngTemplateOutlet="commentInput"></ng-container>
+                            </ng-container>
+                        </mat-card-content>
+                    </mat-card>
+
+                    <ng-container *ngFor="let item of activity">
+                        <ng-container *ngIf="item.type === 'x-unfetter-article'">
+                            <ng-container *ngTemplateOutlet="articleTemplate;context:wrap(item)"></ng-container>
+                        </ng-container>
+                        <ng-container *ngIf="item.type === 'x-unfetter-comment'">
+                            <ng-container *ngTemplateOutlet="commentTemplate;context:wrap(item)"></ng-container>
+                        </ng-container>
+                    </ng-container>
+
                 </div>
+
             </div>
 
         </div>
@@ -148,7 +170,7 @@
 
         <div id="contributors">
             <div id="contributors-label"><h4>Contributors</h4></div>
-            <div id="contributors-list" *ngIf="boardLoaded; else loadingBlock">
+            <div id="contributors-list" *ngIf="threatboardLoaded; else loadingBlock">
                 <div class="flex contributor">
                     <div class="contributor-avatar" [style.background-color]="'darkorange'">JD</div>
                     <div class="contributor-userid flex1">Jane Doe</div>
@@ -160,7 +182,7 @@
             </div>
         </div>
 
-        <div id="last-polled" *ngIf="boardLoaded">
+        <div id="last-polled" *ngIf="threatboardLoaded">
             <i>Board was updated on {{ boardUpdateTime }}</i>
         </div>
 
@@ -170,4 +192,92 @@
 
 <ng-template #loadingBlock>
     <loading-spinner height="250px"></loading-spinner>
+</ng-template>
+
+<ng-template #commentInput>
+    <div class="mt-20 overFlowHidden">
+        <div class="mb-6">
+            <simplemde [(ngModel)]="commentData.text"></simplemde>
+        </div>
+        <div class="text-right">
+            <button mat-button
+                    (click)="addNewComment = false; commentData.text = ''">CANCEL</button>
+            <button mat-raised-button color="primary" [disabled]="commentData.text === ''"
+                    (click)="submitActivityComment(commentData.text, commentData.source)">SAVE</button>
+        </div>
+    </div>
+</ng-template>
+
+<ng-template #commentTemplate let-item="item">
+    <mat-card class="uf-mat-card">
+        <mat-card-header>
+            <div mat-card-avatar class="activity-avatar" [style.background-image]="getActivityAvatar(item)"></div>
+            <mat-card-title>{{ item.user.userName }}</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+            <markdown [data]="item.content"></markdown>
+            <hr>
+            <div>
+                <button mat-button>Like</button>
+                <button mat-button *ngIf="addNewComment !== item.id"
+                        (click)="startActivityComment(null, item)">Reply</button>
+            </div>
+            <ng-container *ngIf="addNewComment === item.id">
+                <ng-container *ngTemplateOutlet="commentInput"></ng-container>
+            </ng-container>
+            <div *ngFor="let reply of item.replies | sortByField: 'submitted'" class="comment">
+                <hr>
+                <div class="flex flexItemsCenter mb-12">
+                    <span *ngIf="reply.user.avatar_url">
+                        <img src="{{ reply.user.avatar_url }}" class="smallAvatar"
+                                alt="{{ reply.user.userName }} avatar">&nbsp;
+                    </span>
+                    <span>
+                        <a routerLink="/users/profile/{{reply.user.id}}">{{ reply.user.userName }}</a>
+                        <small class="text-muted"> &bull; {{ reply.submitted | timeAgo }}</small>
+                    </span>
+                </div>
+                <markdown [data]="reply.content"></markdown>
+            </div>
+        </mat-card-content>
+    </mat-card>
+</ng-template>
+
+<ng-template #articleTemplate let-item="item">
+    <mat-card class="uf-mat-card">
+        <mat-card-header>
+            <div mat-card-avatar class="activity-avatar" [style.background-image]="getActivityAvatar(item)"></div>
+            <mat-card-title>{{ item.name }}</mat-card-title>
+            <mat-card-subtitle>{{ item.created_by_ref }}</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+            <markdown [data]="item.content"></markdown>
+            <img *ngIf="item.image" mat-card-image src="{{ getActivityImage(item.image) }}">
+            <hr>
+            <div>
+                <button mat-button>Like</button>
+                <button mat-button *ngIf="addNewComment !== item.id"
+                        (click)="startActivityComment(null, item)">Add a comment</button>
+            </div>
+            <ng-container *ngIf="addNewComment === item.id">
+                <ng-container *ngTemplateOutlet="commentInput"></ng-container>
+            </ng-container>
+            <div label="Comments" *ngIf="hasActivityComments(item)">
+                <hr>
+                <div *ngFor="let comment of item.metaProperties.comments | sortByField: 'submitted'" class="comment">
+                    <div class="flex flexItemsCenter">
+                        <span *ngIf="comment.user.avatar_url">
+                            <img src="{{ comment.user.avatar_url }}" class="smallAvatar"
+                                    alt="{{ comment.user.userName }} avatar">&nbsp;
+                        </span>
+                        <span>
+                            <a routerLink="/users/profile/{{comment.user.id}}">{{ comment.user.userName }}</a>
+                            <small class="text-muted"> &bull; {{ comment.submitted | timeAgo }}</small>
+                        </span>
+                    </div>
+                    <markdown [data]="comment.content"></markdown>
+                </div>
+            </div>
+        </mat-card-content>
+    </mat-card>
 </ng-template>

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -5,7 +5,7 @@
     </mat-form-field>
 </div>
 
-<mat-sidenav-container class="flex">
+<mat-sidenav-container class="flex" (resize)="recalculateWindows()">
         
     <mat-sidenav-content class="min-tab-height">
 
@@ -131,8 +131,8 @@
                     <div class="flex1 activity-sort-options">
                         Sort by:
                         <mat-radio-group [(ngModel)]="activitySort">
-                            <mat-radio-button *ngFor="let sort of sorts; index as sidx"
-                                    value="{{ sidx }}">{{ sort.name }}</mat-radio-button>
+                            <mat-radio-button *ngFor="let sort of activitySorts" value="{{ sort }}"
+                                    [disabled]="!sorts[sort].enabled">{{ sort }}</mat-radio-button>
                         </mat-radio-group>
                     </div>
                 </div>
@@ -141,8 +141,9 @@
 
                     <mat-card>
                         <mat-card-content>
-                            <button mat-button *ngIf="addNewComment !== true"
-                                    (click)="startActivityComment()">Add a comment</button>
+                            <button mat-button *ngIf="addNewComment !== true" (click)="startActivityComment()">
+                                <i class="material-icons comment-button">chat_bubble</i> Add a comment
+                            </button>
                             <ng-container *ngIf="addNewComment === true">
                                 <ng-container *ngTemplateOutlet="commentInput"></ng-container>
                             </ng-container>
@@ -209,75 +210,144 @@
 </ng-template>
 
 <ng-template #commentTemplate let-item="item">
+
     <mat-card class="uf-mat-card">
-        <mat-card-header>
+
+        <div class="flex">
             <div mat-card-avatar class="activity-avatar" [style.background-image]="getActivityAvatar(item)"></div>
-            <mat-card-title>{{ item.user.userName }}</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
-            <markdown [data]="item.content"></markdown>
-            <hr>
-            <div>
-                <button mat-button>Like</button>
-                <button mat-button *ngIf="addNewComment !== item.id"
-                        (click)="startActivityComment(null, item)">Reply</button>
+            <div class="flex1 activity-content">
+                <mat-card-header>
+                    <mat-card-title>{{ getUserName(item) }}</mat-card-title>
+                </mat-card-header>
+                <mat-card-content>
+                    <markdown [data]="item.content"></markdown>
+                </mat-card-content>
             </div>
+        </div>
+
+        <mat-card-actions [style.padding]="0" [style.text-align]="'left'">
+            <button mat-button class="like-button" [style.color]="hasLikedActivity(item) ? 'blue' : 'inherit'"
+                    (click)="clickActivityLike(item)">
+                <i class="material-icons">thumb_up</i>
+                <span [style.margin]="'0 6px'">Like</span>
+                <span *ngIf="hasActivityLikes(item)">({{ item.likes.length }})</span>
+            </button>
+            <button mat-button *ngIf="addNewComment !== item.id" class="comment-button"
+                    (click)="startActivityComment(null, item)">
+                <i class="material-icons">chat_bubble</i> Reply
+            </button>
+        </mat-card-actions>
+
+        <mat-card-footer [style.padding]="'0 24px 24px 24px'">
             <ng-container *ngIf="addNewComment === item.id">
                 <ng-container *ngTemplateOutlet="commentInput"></ng-container>
             </ng-container>
-            <div *ngFor="let reply of item.replies | sortByField: 'submitted'" class="comment">
-                <hr>
-                <div class="flex flexItemsCenter mb-12">
-                    <span *ngIf="reply.user.avatar_url">
-                        <img src="{{ reply.user.avatar_url }}" class="smallAvatar"
-                                alt="{{ reply.user.userName }} avatar">&nbsp;
-                    </span>
-                    <span>
-                        <a routerLink="/users/profile/{{reply.user.id}}">{{ reply.user.userName }}</a>
-                        <small class="text-muted"> &bull; {{ reply.submitted | timeAgo }}</small>
-                    </span>
+            <div *ngIf="hasActivityComments(item)">
+                <div *ngFor="let reply of item.replies | sortByField: 'submitted'" class="flex">
+                    <div mat-card-avatar class="subactivity-avatar"
+                            [style.background-image]="getActivityAvatar(reply)"></div>
+                    <div class="flex1 activity-content">
+                        <mat-card-header>
+                            <mat-card-title>{{ getUserName(reply) }}</mat-card-title>
+                            <mat-card-subtitle> &bull; {{ reply.submitted | timeAgo }}</mat-card-subtitle>
+                        </mat-card-header>
+                        <mat-card-content>
+                            <markdown [data]="reply.content"></markdown>
+                        </mat-card-content>
+                    </div>
                 </div>
-                <markdown [data]="reply.content"></markdown>
             </div>
-        </mat-card-content>
+        </mat-card-footer>
+
     </mat-card>
+
 </ng-template>
 
 <ng-template #articleTemplate let-item="item">
+
     <mat-card class="uf-mat-card">
-        <mat-card-header>
+
+        <div class="flex">
             <div mat-card-avatar class="activity-avatar" [style.background-image]="getActivityAvatar(item)"></div>
-            <mat-card-title>{{ item.name }}</mat-card-title>
-            <mat-card-subtitle>{{ item.created_by_ref }}</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-            <markdown [data]="item.content"></markdown>
-            <img *ngIf="item.image" mat-card-image src="{{ getActivityImage(item.image) }}">
-            <hr>
-            <div>
-                <button mat-button>Like</button>
-                <button mat-button *ngIf="addNewComment !== item.id"
-                        (click)="startActivityComment(null, item)">Add a comment</button>
+            <div class="flex1 activity-content">
+                <mat-card-header>
+                    <mat-card-title>{{ item.name }}</mat-card-title>
+                    <mat-card-subtitle>{{ item.created_by_ref }}</mat-card-subtitle>
+                </mat-card-header>
+                <mat-card-content>
+                    <markdown [data]="item.content"></markdown>
+                    <img *ngIf="item.image" mat-card-image src="{{ getActivityImage(item.image) }}">
+                </mat-card-content>
             </div>
+        </div>
+
+        <mat-card-actions [style.padding]="0" [style.text-align]="'left'">
+            <button mat-button class="like-button" [style.color]="hasLikedActivity(item) ? 'blue' : 'inherit'"
+                    (click)="clickActivityLike(item)">
+                <i class="material-icons">thumb_up</i>
+                <span [style.margin]="'0 6px'">Like</span>
+                <span *ngIf="hasActivityLikes(item)">({{ item.metaProperties.likes.length }})</span>
+            </button>
+            <button mat-button *ngIf="addNewComment !== item.id" class="comment-button"
+                    (click)="startActivityComment(null, item)">
+                <i class="material-icons">chat_bubble</i> Add a comment
+            </button>
+        </mat-card-actions>
+
+        <mat-card-footer [style.padding]="'0 24px 24px 24px'">
             <ng-container *ngIf="addNewComment === item.id">
                 <ng-container *ngTemplateOutlet="commentInput"></ng-container>
             </ng-container>
             <div label="Comments" *ngIf="hasActivityComments(item)">
-                <hr>
-                <div *ngFor="let comment of item.metaProperties.comments | sortByField: 'submitted'" class="comment">
-                    <div class="flex flexItemsCenter">
-                        <span *ngIf="comment.user.avatar_url">
-                            <img src="{{ comment.user.avatar_url }}" class="smallAvatar"
-                                    alt="{{ comment.user.userName }} avatar">&nbsp;
-                        </span>
-                        <span>
-                            <a routerLink="/users/profile/{{comment.user.id}}">{{ comment.user.userName }}</a>
-                            <small class="text-muted"> &bull; {{ comment.submitted | timeAgo }}</small>
-                        </span>
+                <div *ngFor="let comment of item.metaProperties.comments | sortByField: 'submitted'" class="flex">
+                    <div mat-card-avatar class="subactivity-avatar"
+                            [style.background-image]="getActivityAvatar(comment)"></div>
+                    <div class="flex1 activity-content">
+                        <mat-card-header>
+                            <mat-card-title>{{ getUserName(comment) }}</mat-card-title>
+                            <mat-card-subtitle> &bull; {{ comment.submitted | timeAgo }}</mat-card-subtitle>
+                        </mat-card-header>
+                        <mat-card-content>
+                            <markdown [data]="comment.content"></markdown>
+                        </mat-card-content>
+                        <mat-card-actions [style.padding]="0" [style.text-align]="'left'">
+                            <button mat-button class="like-button"
+                                    [style.color]="hasLikedActivity(comment) ? 'blue' : 'inherit'"
+                                    (click)="clickActivityLike(comment)">
+                                <i class="material-icons">thumb_up</i>
+                                <span [style.margin]="'0 6px'">Like</span>
+                                <span *ngIf="hasActivityLikes(comment)">({{ comment.likes.length }})</span>
+                            </button>
+                            <button mat-button *ngIf="addNewComment !== comment.id" class="comment-button"
+                                    (click)="startActivityComment(null, comment)">
+                                <i class="material-icons">chat_bubble</i> Reply
+                            </button>
+                        </mat-card-actions>
+                        <mat-card-footer [style.padding]="'0 24px 24px 24px'">
+                            <ng-container *ngIf="addNewComment === comment.id">
+                                <ng-container *ngTemplateOutlet="commentInput"></ng-container>
+                            </ng-container>
+                            <div *ngIf="hasActivityComments(comment)">
+                                <div *ngFor="let reply of comment.replies | sortByField: 'submitted'" class="flex">
+                                    <div mat-card-avatar class="subactivity-avatar"
+                                            [style.background-image]="getActivityAvatar(reply)"></div>
+                                    <div class="flex1 activity-content">
+                                        <mat-card-header>
+                                            <mat-card-title>{{ getUserName(reply) }}</mat-card-title>
+                                            <mat-card-subtitle> &bull; {{ reply.submitted | timeAgo }}</mat-card-subtitle>
+                                        </mat-card-header>
+                                        <mat-card-content>
+                                            <markdown [data]="reply.content"></markdown>
+                                        </mat-card-content>
+                                    </div>
+                                </div>
+                            </div>
+                        </mat-card-footer>
                     </div>
-                    <markdown [data]="comment.content"></markdown>
                 </div>
             </div>
-        </mat-card-content>
+        </mat-card-footer>
+
     </mat-card>
+
 </ng-template>

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -248,6 +248,7 @@ mat-sidenav-content {
     }
 
 }
+
 :host ::ng-deep #activities-list {
     mat-card-header {
         margin-bottom: 8px;
@@ -257,6 +258,7 @@ mat-sidenav-content {
         margin-bottom: 8px;
         font-size: 14px;
     }
+
     mat-card-title {
         font-weight: bold;
         letter-spacing: .1px;

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -230,7 +230,20 @@ mat-sidenav-content {
         }
 
         .activity-avatar {
+            margin-right: 8px;
             background-size: cover;
+        }
+
+        .subactivity-avatar {
+            width: 30px;
+            height: 30px;
+            margin-left: 6px;
+            margin-right: 12px;
+            background-size: cover;
+        }
+
+        .comment-button, .like-button {
+            font-size: 14px;
         }
     }
 
@@ -242,6 +255,11 @@ mat-sidenav-content {
 
     mat-card-title, mat-card-subtitle {
         margin-bottom: 8px;
+        font-size: 14px;
+    }
+    mat-card-title {
+        font-weight: bold;
+        letter-spacing: .1px;
     }
 
     .CodeMirror, .CodeMirror-scroll {

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -224,8 +224,29 @@ mat-sidenav-content {
                 padding: 0 12px;
             }
         }
+
+        mat-card {
+            margin-bottom: 16px;
+        }
+
+        .activity-avatar {
+            background-size: cover;
+        }
     }
 
+}
+:host ::ng-deep #activities-list {
+    mat-card-header {
+        margin-bottom: 8px;
+    }
+
+    mat-card-title, mat-card-subtitle {
+        margin-bottom: 8px;
+    }
+
+    .CodeMirror, .CodeMirror-scroll {
+        min-height: 100px;
+    }
 }
 
 #trends-trench {

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -159,6 +159,12 @@ export class FeedComponent implements OnInit {
     public recalculateWindows() {
         this.calculateReportsWindow();
         this.calculateBoardsWindow();
+        if (this.reportsPage > this._reportsPages) {
+            this.reportsPage = this._reportsPages - 1;
+        }
+        if (this.boardsPage > this._boardsPages) {
+            this.boardsPage = this._boardsPages - 1;
+        }
     }
 
     private calculateReportsWindow() {

--- a/src/app/threat-beta/store/threat.actions.ts
+++ b/src/app/threat-beta/store/threat.actions.ts
@@ -14,6 +14,7 @@ export enum ThreatActionTypes {
     SetBoardList = '[Threat] Set Board List',
     SetFeedReports = '[Threat] Set Feed Reports',
     SetAttachedReports = '[Threat] Set Attached Reports',
+    SetPotentialReports = '[Threat] Set Potential Reports',
     SetSelectedBoardId = '[Threat] Set Selected Board Id',
     SetSelectedReportId = '[Threat] Set Selected Report Id',
     SetDashboardLoadingComplete = '[Threat] Set Dashboard Loading Complete',
@@ -73,6 +74,12 @@ export class SetFeedReports implements Action {
 
 export class SetAttachedReports implements Action {
     public readonly type = ThreatActionTypes.SetAttachedReports;
+
+    constructor(public payload: Report[]) { }
+}
+
+export class SetPotentialReports implements Action {
+    public readonly type = ThreatActionTypes.SetPotentialReports;
 
     constructor(public payload: Report[]) { }
 }
@@ -152,6 +159,7 @@ export type threatActions =
     | SetBoardList
     | SetFeedReports
     | SetAttachedReports
+    | SetPotentialReports
     | SetSelectedBoardId
     | SetSelectedReportId
     | SetDashboardLoadingComplete 

--- a/src/app/threat-beta/store/threat.reducers.ts
+++ b/src/app/threat-beta/store/threat.reducers.ts
@@ -17,6 +17,7 @@ export interface ThreatState {
     feedReports: Report[],
     // Reports attached to a threat board
     attachedReports: Report[],
+    potentialReports: Report[],
     selectedBoardId: string,
     selectedReportId: string,
     dashboardLoadingComplete: boolean,
@@ -30,6 +31,7 @@ export const initialState: ThreatState = {
     articles: [],
     feedReports: [],
     attachedReports: [],
+    potentialReports: [],
     selectedBoardId: null,
     selectedReportId: null,
     dashboardLoadingComplete: false,
@@ -90,6 +92,19 @@ export function threatReducer(state = initialState, action: threatActions): Thre
                     ...state,
                     selectedReportId: null,
                     attachedReports: []
+                };
+            }
+        case ThreatActionTypes.SetPotentialReports:
+            const { payload: potentials } = action;
+            if (potentials && potentials.length) {
+                return {
+                    ...state,
+                    potentialReports: potentials
+                };
+            } else {
+                return {
+                    ...state,
+                    potentialReports: []
                 };
             }
         case ThreatActionTypes.SetSelectedBoardId:

--- a/src/app/threat-beta/store/threat.selectors.ts
+++ b/src/app/threat-beta/store/threat.selectors.ts
@@ -25,6 +25,11 @@ export const getAttachedReports = createSelector(
     (state) => state.attachedReports
 );
 
+export const getThreatBoardReports = createSelector(
+    selectThreatState,
+    (state) => [...state.attachedReports, ...state.potentialReports]
+);
+
 export const getSelectedReportId = createSelector(
     selectThreatState,
     (state) => state.selectedReportId


### PR DESCRIPTION
More threatboard feed page "stuff"

- Reports carousel should now display actual reports on the board, not the latest reports in the database.

- Should now be able to "vet" and "reject" reports. Not persisted.

- Can now add comments. They are not persisted. Can also add replies to those comments.

- Can now "like" comments and article. Again, not persisted.

- TODO (besides persisting): need to associate user ids with user names. Pieces are there, just need to add them. Probably other things I forgot to mention here, too.