### PR TITLE
Dereferences created_by_ref

### DIFF
--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -113,7 +113,7 @@
                                 class="related-board" [style.background]="getBoardBackground(board)"
                                 (mouseenter)="boardHoverIndex = bidx" (mouseleave)="boardHoverIndex = -1">
                             <div class='board-title'>{{ board.name }}</div>
-                            <div class='board-owner'>Owner Name</div>
+                            <div class='board-owner'>{{ getUserName(board) }}</div>
                             <div class='board-options'>
                                 <button mat-button disabled (click)="followBoard(board.id)">FOLLOW</button>
                             </div>
@@ -272,7 +272,7 @@
             <div class="flex1 activity-content">
                 <mat-card-header>
                     <mat-card-title>{{ item.name }}</mat-card-title>
-                    <mat-card-subtitle>{{ item.created_by_ref }}</mat-card-subtitle>
+                    <mat-card-subtitle>{{ getUserName(item) }}</mat-card-subtitle>
                 </mat-card-header>
                 <mat-card-content>
                     <markdown [data]="item.content"></markdown>


### PR DESCRIPTION
Supports unfetter-discover/unfetter#1490.

See related store PR https://github.com/unfetter-discover/unfetter-store/pull/267.

Dereferences created_by_ref for displays on related threatboards, comments and articles.

Bring up your favorite threatboard feed. See that related boards should now show board owner (assuming you have any other boards to display), that any article on the board shows any actual user name instead of their identity UUID.