### PR TITLE
global feed sidebar visually complete

### DIFF
--- a/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.scss
+++ b/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.scss
@@ -53,6 +53,8 @@
     }
 }
 
-.mat-badge-content {
-    left: 8px !important;
+:host ::ng-deep .mat-badge-small.mat-badge-overlap.mat-badge-before {
+    .mat-badge-content {
+        left: 8px;
+    }
 }

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
@@ -81,8 +81,8 @@
     padding-top: 11px;
     padding-left: 11px;
 
-    // hides the horizontal scrollbar for the carousel
-    overflow-x: hidden;
+    // hides the scrollbars for the carousel
+    overflow: hidden;
 
     // the transition allows left-right scrolling to go smoothly
     transition: margin-left 0.5s ease;

--- a/src/app/threat-beta/threat-dashboard-beta.component.html
+++ b/src/app/threat-beta/threat-dashboard-beta.component.html
@@ -3,19 +3,51 @@
     <mat-sidenav-container>
       <mat-sidenav class="side-panel mat-elevation-z16" mode="side" opened="true">
         <div class="flex flex-cols side-nav-top">
-          <div class="flex1"></div>
-          <div class="flex flex-row">
-            <nav mat-tab-nav-bar class="indent uf-tabs-borderless">
-              <a class="noUnderline tabs" mat-tab-link [routerLink]="myBoardsLink" routerLinkActive #myboards="routerLinkActive"
-                [active]="myboards.isActive">MY BOARDS</a>
-              <a class="noUnderline tabs" mat-tab-link [routerLink]="followingBoardsLink" routerLinkActive #followingboards="routerLinkActive"
-                [active]="followingboards.isActive">FOLLOWING</a>
-            </nav>
-          </div>
         </div>
-        <div class="side-nav-item header-text" *ngFor="let board of boards$ | async" (click)="boardClicked(board.id)">
-          {{board.name}}
-        </div>
+        <mat-tab-group>
+            <mat-tab label="MY BOARDS">
+              <div class="side-nav-item header-text" *ngFor="let board of boards$ | async">
+                <div>
+                {{board.name}}
+                </div>
+                <div class="flex1"></div>
+                <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
+                  <mat-icon>more_vert</mat-icon>
+              </button>
+              <mat-menu #menu="matMenu">
+                  <button mat-menu-item (click)="boardView(board.id)" *ngIf="!canCrud"> <!-- TODO reverse & fix "canCrud" check -->
+                    <mat-icon>details</mat-icon>
+                    <span>View</span>
+                  </button>
+                  <button mat-menu-item (click)="editBoard(board.id)" *ngIf="!canCrud">
+                    <mat-icon>edit</mat-icon>
+                    <span>Edit</span>
+                  </button>
+                  <button mat-menu-item (click)="deleteBoard(board.id)" *ngIf="!canCrud">
+                      <mat-icon>delete</mat-icon>
+                      <span>Delete</span>
+                  </button>
+              </mat-menu>
+              </div>
+            </mat-tab>
+            <mat-tab label="FOLLOWING">
+              <div class="side-nav-item header-text" *ngFor="let board of boards$ | async"> <!-- TODO use different list of boards -->
+                <div>
+                {{board.name}}
+                </div>
+                <div class="flex1"></div>
+                <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
+                  <mat-icon>more_vert</mat-icon>
+              </button>
+              <mat-menu #menu="matMenu">
+                  <button mat-menu-item (click)="boardClicked(board.id)" *ngIf="!canCrud">
+                    <mat-icon>details</mat-icon>
+                    <span>View</span>
+                  </button>
+              </mat-menu>
+              </div>
+            </mat-tab>
+          </mat-tab-group>
       </mat-sidenav>
       <mat-sidenav-content class="sidenavContentPolyfill320">
         <div class="main-panel">

--- a/src/app/threat-beta/threat-dashboard-beta.component.scss
+++ b/src/app/threat-beta/threat-dashboard-beta.component.scss
@@ -1,25 +1,40 @@
 @import '_threat-beta.common.scss';
 
 .main-panel {
-    min-height: $page-height;
+  min-height: $page-height;
 }
 
 .side-nav-top {
-    height: calc(193px - #{$navbar-height}px);
-    background-color: $threat-dashboard-primary-light; 
+  height: calc(145px - #{$navbar-height}px);
+  background-color: $threat-dashboard-primary-light;
 }
 
 .side-nav-item {
-    height: 48px;
-    padding: 12px 16px;
+  height: 48px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  padding-right: 0px;
+  border-bottom-color: #d8d8d8;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+  display: flex;
 }
 
-.tabs {
+.align {
+  margin-top: -11px;
+}
+
+:host ::ng-deep .mat-tab-labels {
+  background-color: $threat-dashboard-primary-light;
+
+  .mat-tab-label-content {
     color: $threat-dashboard-primary-text;
-    font-weight: 300;
+    font-weight: 100;
     letter-spacing: .75px;
+  }
 }
 
 .right-side-panel {
-    min-width: 384px;
+  min-width: 384px;
 }

--- a/src/app/threat-beta/threat-dashboard-beta.component.ts
+++ b/src/app/threat-beta/threat-dashboard-beta.component.ts
@@ -52,9 +52,9 @@ export class ThreatDashboardBetaComponent implements OnInit {
     this.boards$ = this.store.select('threat').pipe(pluck('boardList'));
   }
 
-  public boardClicked(reportId): Promise<boolean> {
+  public boardView(boardId): Promise<boolean> {
     let routePromise: Promise<boolean>;
-    routePromise = this.router.navigate([this.baseAssessUrl, reportId, this.boardFeedRoute]);
+    routePromise = this.router.navigate([this.baseAssessUrl, boardId, this.boardFeedRoute]);
     routePromise.catch((e) => console.log(e));
     return routePromise;
   }


### PR DESCRIPTION
### To Test:

- Verify ability to switch between followed and myboards tabs
- Verify that clicking vertical 3-dot more button shows view, edit, delete for myboards tab; but just view for followed
- Verify that view for myboards or followed takes you to that board's feed view
- Verify that styling of left sidenav matches: https://gallery.io/projects/MCHbtQVoQ2HCZZu3AN2eGfqc/files/MCHtA7U1iMGr6--pOiqA4MiSkXH8md5tb7Y

### Still do do in sidebar:
- "Followed" boards concept is not yet implemented (just showing same list from myboards for now)
- Edit & Delete boards that are "mine" not yet implemented