### PR TITLE
Threat board tweaks

### DIFF
--- a/src/app/threat-beta/article/article-editor/article-editor.component.html
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.html
@@ -27,7 +27,11 @@
         <div *ngIf="sourceNames$ | async as sourceNames" class="mb-6">
           <h4 *ngIf="sourceNames.length">Sources</h4>
           <mat-chip-list>
-            <mat-chip *ngFor="let source of sourceNames" class="cursor-pointer chipListChip">{{ source }}</mat-chip>
+            <mat-chip *ngFor="let source of sourceNames; let i = index" class="cursor-pointer chipListChip" removable="true">
+              <span>{{ source }}</span>
+              <span class="flex1">&nbsp;</span>
+              <mat-icon class="material-icons" matChipRemove (click)="removeSource(i)">cancel</mat-icon>
+            </mat-chip>
           </mat-chip-list>
         </div>
 

--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -96,7 +96,7 @@ export class ArticleEditorComponent implements OnInit {
     this.store
       .select('config')
       .pipe(
-        pluck('runConfig'),
+        pluck('runCofig'),
         distinctUntilChanged(),
       )
       .subscribe(
@@ -104,6 +104,12 @@ export class ArticleEditorComponent implements OnInit {
           this.blockAttachments = cfg.blockAttachments;
         }
       );
+  }
+
+  public removeSource(index: number): void {
+    const sourcesVal: any[] = this.form.get('sources').value;
+    sourcesVal.splice(index, 1);
+    this.form.get('sources').patchValue(sourcesVal);
   }
 
   private setEditValues(): void {
@@ -156,6 +162,9 @@ export class ArticleEditorComponent implements OnInit {
 
     let success;
     if (this.editMode) {
+      if (!this.form.get('sources').value.length) {
+        tempArticle.sources = [];
+      }
       success = await this.editArticle(tempArticle);
     } else {
       success = await this.createNewArticle(tempArticle);

--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -96,7 +96,7 @@ export class ArticleEditorComponent implements OnInit {
     this.store
       .select('config')
       .pipe(
-        pluck('runCofig'),
+        pluck('runConfig'),
         distinctUntilChanged(),
       )
       .subscribe(

--- a/src/app/threat-beta/board-layout/board-layout.component.html
+++ b/src/app/threat-beta/board-layout/board-layout.component.html
@@ -1,10 +1,10 @@
 <ng-container *ngIf="(finishedLoadingAll$|async)===true; else loadingBlock">
   <div id="boardLayoutComponent">
     <mat-sidenav-container class="fixed-page-height">
-      <mat-sidenav class="side-panel fixed-page-height zIndex1" mode="side" opened="true">
+      <mat-sidenav class="side-panel fixed-page-height mat-elevation-z8" mode="side" opened="true">
         <side-board [boardId]="boardId$ | async"></side-board>
       </mat-sidenav>
-      <mat-sidenav-content class="sidenavContentPolyfill320 fixed-page-height">
+      <mat-sidenav-content class="sidenavContentPolyfill320 fixed-page-height zIndexAuto">
         <threat-header [boardId]="boardId$ | async"></threat-header>
         <router-outlet></router-outlet>
       </mat-sidenav-content>

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -1,5 +1,5 @@
 <div id="search-bar" class="">
-    <mat-form-field class="search-input">
+    <mat-form-field class="search-input mat-elevation-z3">
         <mat-icon matPrefix>search</mat-icon>
         <input matInput type="text" placeholder="Search this board">
     </mat-form-field>
@@ -21,7 +21,7 @@
 
     </mat-sidenav-content>
 
-    <mat-sidenav id="trends-trench" opened mode="side" position="end">
+    <mat-sidenav id="trends-trench" class="mat-elevation-z8" opened mode="side" position="end">
 
         <contributor-list [threatBoard]="threatBoard"></contributor-list>
 

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -6,7 +6,6 @@
         width: 100%;
         margin-bottom: 5px;
         background: white;
-        box-shadow: 0 2px 5px 0 rgba(0, 0, 0, .4);
 
         mat-icon {
             margin-left: 15px;
@@ -39,7 +38,6 @@ mat-sidenav-content {
     margin-left: 10px;
     padding: 15px;
     background: white;
-    box-shadow: 1px 0 8px 0 rgba(0, 0, 0, .8);
 
     contributor-list {
         flex: 1;

--- a/src/app/threat-beta/side-board/side-board.component.html
+++ b/src/app/threat-beta/side-board/side-board.component.html
@@ -75,15 +75,6 @@
               </mat-list>
             </mat-expansion-panel>
 
-            <!-- TODO we curretly don't record External references in threat boards, should probably remove this -->
-            <sidepanel-list-item label="External References" [items]="selectedBoard?.external_references" expandable="true">
-              <mat-list-item *ngFor="let extRef of selectedBoard?.external_references" class="list-divider">
-                <div mat-line>
-                  <a href="{{ extRef.url }}" target="_blank">{{ extRef.source_name }}</a>
-                </div>
-              </mat-list-item>
-            </sidepanel-list-item>
-
           </mat-accordion>
           <br>
         </mat-tab>

--- a/src/app/threat-beta/threat-dashboard-beta.component.html
+++ b/src/app/threat-beta/threat-dashboard-beta.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
   <div #layout class="layout" *ngIf="(failedToLoad|async) === false; else failedToLoadBlock">
     <mat-sidenav-container>
-      <mat-sidenav class="side-panel mat-elevation-z16" mode="side" opened="true">
+      <mat-sidenav class="side-panel mat-elevation-z8" mode="side" opened="true">
         <div class="flex flex-cols side-nav-top">
         </div>
         <mat-tab-group>
@@ -54,7 +54,7 @@
           <global-feed></global-feed>
         </div>
       </mat-sidenav-content>
-      <mat-sidenav opened mode="side" position="end" class="right-side-panel mat-elevation-z16">
+      <mat-sidenav opened mode="side" position="end" class="right-side-panel mat-elevation-z8">
         <div id="recentTitle" class="flexItemsCenter">
           <div class="side-panel-header">
             <div class="height-100-percent">

--- a/src/styles/partials/_simplemde_overrides.scss
+++ b/src/styles/partials/_simplemde_overrides.scss
@@ -2,7 +2,6 @@
 
 simplemde {
   // Import simple mde seperately so it doesnt interfere with codemirror
-  color: red !important;
   @import 'simplemde/dist/simplemde.min.css';
 
   .CodeMirror {
@@ -22,6 +21,15 @@ simplemde {
 
     .CodeMirror {
         border-left: 1px solid $warn-color;
+        border-right: 1px solid $warn-color;
+        border-bottom: 1px solid $warn-color;
+    }
+
+    .CodeMirror-sided {
+        border-right: none !important;
+    }
+
+    .editor-preview-active-side {
         border-right: 1px solid $warn-color;
         border-bottom: 1px solid $warn-color;
     }

--- a/src/styles/partials/_styles.scss
+++ b/src/styles/partials/_styles.scss
@@ -358,3 +358,7 @@ code.codeBlock {
 .zIndex1 {
     z-index: 1 !important;
 }
+
+.zIndexAuto {
+    z-index: auto !important;
+}


### PR DESCRIPTION
- Made box shadows more consistent across all pages in threat dashboard (eg sidebars and feed cards)
- Removed external references from sidebar in threat board
- Added ability to remove source chips in edit article
- Fixed issues with simplemde when the orange warning border is applied when in full screen mode