### PR TITLE
Put back percent complete message for Assessments

### DIFF
--- a/src/app/assess/v3/result/full/group/assessments-group.component.ts
+++ b/src/app/assess/v3/result/full/group/assessments-group.component.ts
@@ -210,6 +210,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     // match the assessed ids with assessed objects to populate the grouping section cards
     const displayedAssessedObjects = assessedObjects
       .filter((assessedObj) => stixIdSet.has(assessedObj.stix.id))
+      .filter((assessedObj) => assessedObj.risk >= 0 && assessedObj.risk <= 100)
       .map((assessedObj) => {
         const retObj = Object.assign(new DisplayedAssessmentObject(), assessedObj);
         retObj.risk = this.getRisk(assessedObj.stix.id);
@@ -370,6 +371,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
       .assessedByAttackPattern
       .filter((ap) => ap._id === attackPatternId)
       .filter((ap) => ap && !Number.isNaN(ap.risk))
+      .filter((ap) => ap.risk >= 0 && ap.risk <= 1)
       .map((ap) => ap.risk)[0];
     return (risk !== undefined && !Number.isNaN(risk) ? risk : 1);
   }
@@ -391,6 +393,7 @@ export class AssessGroupComponent implements OnInit, OnDestroy, AfterViewInit {
     let count = 0;
     const sum = phaseObj.assessedObjects
       .map((ao) => ao.risk)
+      .filter((risk) => risk >= 0 && risk <= 1)
       .reduce((currentSum, risk) => {
         count++;
         return currentSum + risk;

--- a/src/app/assess/v3/result/full/group/assessments-groups.component.spec.ts
+++ b/src/app/assess/v3/result/full/group/assessments-groups.component.spec.ts
@@ -153,13 +153,13 @@ describe('AssessGroupComponent', () => {
     phase.assessedObjects = AssessmentObjectMockFactory
       .mockMany(5)
       .map((ao) => {
-        ao.risk = 50;
+        ao.risk = .50;
         return ao;
       });
-    phase.assessedObjects[4].risk = 25;
+    phase.assessedObjects[4].risk = .25;
     const risk = component.getRiskByPhase(phaseId);
     expect(risk).toBeDefined();
-    expect(risk).toEqual(45);
+    expect(risk).toEqual(.45);
   });
 
   it('should return risk by phase, edge case', () => {

--- a/src/app/assess/v3/result/full/group/models/assessed-by-attack-pattern.mock.ts
+++ b/src/app/assess/v3/result/full/group/models/assessed-by-attack-pattern.mock.ts
@@ -6,7 +6,7 @@ export class AssessedByAttackPatternMock extends Mock<AssessedByAttackPattern> {
         const tmp = new AssessedByAttackPattern();
         tmp._id = this.genId();
         tmp.assessedObjects = [];
-        tmp.risk = Math.random() * 100;
+        tmp.risk = Math.random();
         return tmp;
     }
 }

--- a/src/app/assess/v3/result/result-header/result-header.component.html
+++ b/src/app/assess/v3/result/result-header/result-header.component.html
@@ -1,7 +1,7 @@
 <div id="tabWrapper" class="flex flexColumn">
   <div class="flex flexRow">
     <div class="flex">
-      <uf-info-bar *ngIf="percentCompletedMsg" isWarningMsg="true" [message]="percentCompletedMsg"></uf-info-bar> <!-- [completeActionUrl]="editUrl||''"></uf-info-bar> -->
+      <uf-info-bar *ngIf="infoBarMsg" isWarningMsg="true" [message]="infoBarMsg" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>
   </div>
   <div class="flex1"></div>

--- a/src/app/assess/v3/result/result-header/result-header.component.ts
+++ b/src/app/assess/v3/result/result-header/result-header.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { Assessment } from 'stix/assess/v3/assessment';
+import { SummaryCalculationService } from '../summary/summary-calculation.service';
 
 @Component({
   selector: 'result-header',
@@ -23,9 +24,12 @@ export class ResultHeaderComponent implements OnInit {
   protected readonly TOTAL_INDICATORS = 45;
   protected readonly TOTAL_SENSORS = 7;
 
-  protected editUrl: string;
+  infoBarMsg: string;
+  public editUrl: string;
 
-  constructor() { }
+  constructor(
+    public calculationService: SummaryCalculationService
+  ) { }
 
   /**
    * @description on init
@@ -38,10 +42,10 @@ export class ResultHeaderComponent implements OnInit {
     this.resultsLink = `${resultBase}/full/${this.rollupId}/${this.assessmentId}`;
     const editBase = `${base}/wizard/edit/`;
     this.editUrl = `${editBase}/${this.rollupId}`;
-    // TODO: initialize the correct total questions, by calling the server, may need a count endpoint
-    this.percentCompleted = this.calcPercentCompleted(this.assessment);
-    this.percentCompletedMsg = ``; // `Assessments BETA, some features do not work!`
-    // TODO: this.percentCompletedMsg += ` ${this.percentCompleted}% of your assessment is complete.`;
+    this.percentCompleted = this.calculationService.percentComplete;
+    if (this.percentCompleted < 100) {
+      this.infoBarMsg = `${this.percentCompleted.toFixed(2)}% of your baseline is complete.`;
+    }
   }
 
   /**

--- a/src/app/assess/v3/result/result-header/result-header.component.ts
+++ b/src/app/assess/v3/result/result-header/result-header.component.ts
@@ -44,7 +44,7 @@ export class ResultHeaderComponent implements OnInit {
     this.editUrl = `${editBase}/${this.rollupId}`;
     this.percentCompleted = this.calculationService.percentComplete;
     if (this.percentCompleted < 100) {
-      this.infoBarMsg = `${this.percentCompleted.toFixed(2)}% of your baseline is complete.`;
+      this.infoBarMsg = `${this.percentCompleted.toFixed(2)}% of your assessment is complete.`;
     }
   }
 

--- a/src/app/assess/v3/result/summary/summary-calculation.service.spec.ts
+++ b/src/app/assess/v3/result/summary/summary-calculation.service.spec.ts
@@ -41,10 +41,10 @@ describe('SummaryCalculationService', () => {
   }));
 
   it('should set average risk per assessed object', inject([SummaryCalculationService], (service: SummaryCalculationService) => {
-    service.setAverageRiskPerAssessedObject([AssessmentObjectMockFactory.mockWithRisk(3)]);
-    expect(service.numericRisk).toEqual(3);
-    service.setAverageRiskPerAssessedObject([AssessmentObjectMockFactory.mockWithRisk(3), AssessmentObjectMockFactory.mockWithRisk(0)]);
-    expect(service.numericRisk).toEqual(1.5);
+    service.setAverageRiskPerAssessedObject([AssessmentObjectMockFactory.mockWithRisk(.3)]);
+    expect(service.numericRisk).toEqual(.3);
+    service.setAverageRiskPerAssessedObject([AssessmentObjectMockFactory.mockWithRisk(.3), AssessmentObjectMockFactory.mockWithRisk(0)]);
+    expect(service.numericRisk).toEqual(.15);
   }));
 
   it('should calculate default weakness', inject([SummaryCalculationService], (service: SummaryCalculationService) => {

--- a/src/app/assess/v3/result/summary/summary-calculation.service.ts
+++ b/src/app/assess/v3/result/summary/summary-calculation.service.ts
@@ -34,6 +34,8 @@ export class SummaryCalculationService {
   isCapabilityValue: boolean;
   isValidSophisticationDataValue: boolean;
 
+  percentCompleteValue: number;
+
   constructor() {
     this.numericRisk = 0;
     this.weakness = '';
@@ -103,6 +105,10 @@ export class SummaryCalculationService {
     this.isValidSophisticationDataValue = validData;
   }
 
+  public set percentComplete(newPctComp: number) {
+    this.percentCompleteValue = newPctComp;
+  }
+
   public get numericRisk(): number {
     return this.numericRiskValue;
   }
@@ -154,6 +160,10 @@ export class SummaryCalculationService {
     return this.isValidSophisticationDataValue
   }
 
+  public get percentComplete(): number {
+    return this.percentCompleteValue;
+  }
+
   public getRiskText(): string {
     return Number((this.numericRisk) * 100).toFixed(0);
   }
@@ -168,7 +178,9 @@ export class SummaryCalculationService {
     if (assessments) {
       assessments.forEach((assessment) => {
         if (assessment.risk && typeof assessment.risk === 'number') {
-          aggregateRisk += assessment.risk;
+          if (assessment.risk >= 0 && assessment.risk <= 1) {
+            aggregateRisk += assessment.risk;
+          }
         }
       });
       if (assessments.length > 0) {

--- a/src/app/assess/v3/result/summary/summary.component.ts
+++ b/src/app/assess/v3/result/summary/summary.component.ts
@@ -147,6 +147,8 @@ export class SummaryComponent implements OnInit, OnDestroy {
           this.requestAncillaryDataLoad(summary);
           this.transformSummary(summary);
           this.summary = summary;
+
+          this.transformPctComplete();
         }),
     );
 
@@ -433,6 +435,20 @@ export class SummaryComponent implements OnInit, OnDestroy {
     if (this.summary) {
       this.summaryCalculationService.populateAssessmentsGrouping(this.summary.assessment_objects);
       this.summaryCalculationService.populateTechniqueBreakdown(this.summary.assessment_objects);
+    }
+  }
+
+  public transformPctComplete(): void {
+    if (this.summary) {
+      let completeQuestions = 0;
+
+      this.summary.assessment_objects.map((ao) => {
+        if (ao.risk >= 0 && ao.risk <= 1) {
+          completeQuestions++;
+        }
+      });
+
+      this.summaryCalculationService.percentComplete = (completeQuestions / this.summary.assessment_objects.length) * 100;
     }
   }
 

--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -1390,8 +1390,8 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
           assessment: question,
           measurements: question.measurements.map(m => ({
             ...m,
-            risk: 1,
-            selected_value: {name: 'no coverage', risk: 1}
+            risk: 999,
+            selected_value: {name: 'unanswered', risk: 999}
           }))
         };
       })

--- a/src/app/baseline/result/result-header/result-header.component.html
+++ b/src/app/baseline/result/result-header/result-header.component.html
@@ -1,5 +1,5 @@
 <div id="tabWrapper" class="flex flexColumn">
-  <div *ngIf="calculationService.percentCompleted < 100" class="flex flexRow">
+  <div *ngIf="percentCompleted < 100" class="flex flexRow">
     <div class="flex">
       <uf-info-bar isWarningMsg="true" message="{{ infoBarMsg }}" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>

--- a/src/app/baseline/result/result-header/result-header.component.html
+++ b/src/app/baseline/result/result-header/result-header.component.html
@@ -1,5 +1,5 @@
 <div id="tabWrapper" class="flex flexColumn">
-  <div *ngIf="percentCompleted < 100" class="flex flexRow">
+  <div *ngIf="calculationService.percentCompleted < 100" class="flex flexRow">
     <div class="flex">
       <uf-info-bar isWarningMsg="true" message="{{ infoBarMsg }}" [completeActionUrl]="editUrl||''"></uf-info-bar>
     </div>


### PR DESCRIPTION
Requires unfetter-discover/stix#41
Fixes unfetter-discover/unfetter#1073

Percent complete message, displayed in summary view when the assessment has incomplete answers, is now back in place, and shows a percentage of unanswered questions vs the number of total questions in the assessment.  Like that of the baseline summary view, it uses the infobar component to display a message and links to complete the assessment or dismiss the message.

### To test:
1. Pull the branch
2. Examine any of the 3 pre-created assessments, all of which have a complete set of answered questions.  In these cases, there would be no message since the completion percentage is 100%.
3. Create a new assessment of any of the 3 types, and without answering any questions, save the assessment.
4. The percent complete message should appear in summary view and should show 0%.
5. Click the Complete button, and edit view of the assessment should be displayed.  Answer some questions (making a note of how many unaswered questions remain), save the assessment and make sure the resulting percentage displayed back on the summary page is accurate.
