### PR TITLE
Threatboard creation/edit

### DIFF
--- a/src/app/threat-beta/create/create.component.html
+++ b/src/app/threat-beta/create/create.component.html
@@ -1,3 +1,154 @@
-<div class="main-panel">
-  Creation things here.
+<div class="container" id="threatReportEditor" *ngIf="!loading; else loadingBlock">
+
+    <div class="row">
+
+        <div class="col-xs-12 col-sm-12 mt-10 flex">
+
+            <button mat-icon-button class="mat-24 edit-close-button" matTooltip="Cancel" aria-label="Cancel"
+                    (click)="onCancel($event)">
+                <mat-icon>close</mat-icon>
+            </button>
+
+            <div class="flex1">
+
+                <div>
+                    <mat-form-field class="edit-title">
+                        <input matInput #filter [(ngModel)]="threatboard.name" color="primary"
+                                placeholder="ThreatBoard Name" matTooltip="Enter the work product's name"
+                                aria-label="enter threatboard name" autocomplete="off">
+                    </mat-form-field>
+                    <div class="edit-title-buttons">
+                        <button mat-button class="edit-cancel-button" matTooltip="Cancel" aria-label="Cancel"
+                                (click)="onCancel($event)">CANCEL</button>
+                        <button mat-raised-button class="edit-save-button" [disabled]="!isValid()" color="primary"
+                                matTooltip="Save Changes" aria-label="Save Changes"
+                                (click)="onSave($event)">SAVE</button>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-xs-6 col-sm-6 mt-18 mat-h2"> Boundaries </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-xs-12 col-sm-12 boundaries-fieldsets dates-fieldset">
+                        <div class="boundaries-column">
+                            <mat-form-field floatPlaceholder="always">
+                                <input #startDateInput matInput [(ngModel)]="threatboard.boundaries.start_date"
+                                        [max]="maxStartDate" [matDatepicker]="startDatePicker" color="primary"
+                                        placeholder="Date From" floatPlaceholder="always"
+                                        matTooltip="Enter the date the threat situation began"
+                                        aria-label="Enter the date the threat situation began (m/d/y format)"
+                                        (dateChange)="startDateChanged(startDateInput.value)" autocomplete="off" />
+                                <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+                                <mat-datepicker #startDatePicker></mat-datepicker>
+                            </mat-form-field>
+                            <small *ngIf="dateError.startDate.isError"
+                                    class="error">{{ dateError.errorMessage }}</small>
+                        </div>
+                        <div class="boundaries-column">
+                            <mat-form-field floatPlaceholder="always">
+                                <input #endDateInput matInput [(ngModel)]="threatboard.boundaries.end_date"
+                                        [min]="minEndDate" [matDatepicker]="endDatePicker" color="primary"
+                                        placeholder="Date To" floatPlaceholder="always"
+                                        matTooltip="Enter the date the threat situation ended"
+                                        aria-label="Enter the date the threat situation ended (m/d/y format)"
+                                        (dateChange)="endDateChanged(endDateInput.value)" autocomplete="off" />
+                                <mat-datepicker-toggle matSuffix [for]="endDatePicker"></mat-datepicker-toggle>
+                                <mat-datepicker #endDatePicker></mat-datepicker>
+                            </mat-form-field>
+                            <small *ngIf="dateError.endDate.isError"
+                                    class="error">{{ dateError.errorMessage }}</small>
+                            <small *ngIf="dateError.endDate.isSameOrBefore"
+                                    class="error">{{ dateError.endDate.isSameOrBeforeMessage }}</small>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+
+                    <div class="col-xs-12 col-sm-12 boundaries-fieldsets">
+
+                        <div class="boundaries-column targets-fieldset">
+                            <mat-form-field floatPlaceholder="always">
+                                <input matInput #targetSelected [(ngModel)]="target"
+                                        class="targets-input" color="primary" placeholder="Targets"
+                                        floatPlaceholder="always" spellcheck="false" autocomplete="off"
+                                        matTooltip="Enter the name of a target of interest to the board"
+                                        aria-label="Enter the name of a target of interest to the board"
+                                        (change)="addChip($event.value, 'targets')">
+                            </mat-form-field>
+                            <mat-chip-list class="mat-chip-list-stacked" selectable="true">
+                                <mat-chip *ngFor="let target of threatboard.boundaries.targets" removable="true">
+                                    <div class="flex">
+                                        <span class="flex1 flexNowrap">{{ target }}</span>
+                                        <mat-icon matChipRemove
+                                                aria-label="Click here to remove this target from the board"
+                                                (click)="removeChip(target, 'targets')">cancel</mat-icon>
+                                    </div>
+                                </mat-chip>
+                            </mat-chip-list>
+                        </div>
+
+                        <div class="boundaries-column malware-fieldset">
+                            <mat-form-field floatPlaceholder="always">
+                                <mat-select #malwareSelected color="primary" placeholder="Malware"
+                                        matTooltip="Select all the malware of interest to the board"
+                                        aria-label="Select all the malware of interest to the board"
+                                        (selectionChange)="addChip($event.source.selected.value, 'malware')">
+                                    <mat-option *ngFor="let malware of malwares" [value]="malware">
+                                        {{ malware.displayValue }}
+                                    </mat-option>
+                                </mat-select>
+                            </mat-form-field>
+                            <mat-chip-list class="mat-chip-list-stacked" selectable="true">
+                                <mat-chip *ngFor="let malware of threatboard.boundaries.malware" removable="true">
+                                    <div class="flex">
+                                        <span class="flex1 flexNowrap">{{ malware.displayValue }}</span>
+                                        <mat-icon matChipRemove
+                                                aria-label="Click here to remove this malware from the board"
+                                                (click)="removeChip(malware, 'malware')">cancel</mat-icon>
+                                    </div>
+                                </mat-chip>
+                            </mat-chip-list>
+                        </div>
+                
+                        <div class="boundaries-column intrusions-fieldset">
+                            <mat-form-field floatPlaceholder="always">
+                                <mat-select color="primary" placeholder="Intrusion Set"
+                                        matTooltip="Select the intrusion sets of interest to the board"
+                                        aria-label="Select the intrusion sets of interest to the board"
+                                        (selectionChange)="addChip($event.source.selected.value, 'intrusion_sets')">
+                                    <mat-option *ngFor="let intrusion of intrusions" [value]="intrusion">
+                                        {{ intrusion.displayValue }}
+                                    </mat-option>
+                                </mat-select>
+                            </mat-form-field>
+                            <mat-chip-list class="mat-chip-list-stacked" selectable="true">
+                                <mat-chip *ngFor="let intrusion of threatboard.boundaries.intrusions"
+                                        removable="true" selectable="true">
+                                    <div class="flex">
+                                        <span class="flex1 flexNowrap">{{ intrusion.displayValue }}</span>
+                                        <mat-icon matChipRemove
+                                                aria-label="Click here to remove this intrusion set from the board"
+                                                (click)="removeChip(intrusion, 'intrusion_sets')">cancel</mat-icon>
+                                    </div>
+                                </mat-chip>
+                            </mat-chip-list>
+                        </div>
+
+                    </div>
+
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>
+
 </div>
+
+<ng-template #loadingBlock>
+    <loading-spinner></loading-spinner>
+</ng-template>

--- a/src/app/threat-beta/create/create.component.html
+++ b/src/app/threat-beta/create/create.component.html
@@ -13,15 +13,15 @@
 
                 <div>
                     <mat-form-field class="edit-title">
-                        <input matInput #filter [(ngModel)]="threatboard.name" color="primary"
+                        <input matInput #filter [(ngModel)]="threatboard.name" color="primary" required
                                 placeholder="ThreatBoard Name" matTooltip="Enter the work product's name"
                                 aria-label="enter threatboard name" autocomplete="off">
                     </mat-form-field>
                     <div class="edit-title-buttons">
                         <button mat-button class="edit-cancel-button" matTooltip="Cancel" aria-label="Cancel"
                                 (click)="onCancel($event)">CANCEL</button>
-                        <button mat-raised-button class="edit-save-button" [disabled]="!isValid()" color="primary"
-                                matTooltip="Save Changes" aria-label="Save Changes"
+                        <button mat-raised-button class="edit-save-button" [disabled]="isValid() === false"
+                                color="primary" matTooltip="Save Changes" aria-label="Save Changes"
                                 (click)="onSave($event)">SAVE</button>
                     </div>
                 </div>
@@ -36,7 +36,7 @@
                             <mat-form-field floatPlaceholder="always">
                                 <input #startDateInput matInput [(ngModel)]="threatboard.boundaries.start_date"
                                         [max]="maxStartDate" [matDatepicker]="startDatePicker" color="primary"
-                                        placeholder="Date From" floatPlaceholder="always"
+                                        required placeholder="Date From" floatPlaceholder="always"
                                         matTooltip="Enter the date the threat situation began"
                                         aria-label="Enter the date the threat situation began (m/d/y format)"
                                         (dateChange)="startDateChanged(startDateInput.value)" autocomplete="off" />
@@ -71,12 +71,13 @@
 
                         <div class="boundaries-column targets-fieldset">
                             <mat-form-field floatPlaceholder="always">
-                                <input matInput #targetSelected [(ngModel)]="target"
+                                <input matInput #targetInput [(ngModel)]="target"
                                         class="targets-input" color="primary" placeholder="Targets"
                                         floatPlaceholder="always" spellcheck="false" autocomplete="off"
                                         matTooltip="Enter the name of a target of interest to the board"
                                         aria-label="Enter the name of a target of interest to the board"
-                                        (change)="addChip($event.value, 'targets')">
+                                        (keyup.enter)="addChip(targetInput.value, 'targets')"
+                                        (blur)="addChip(targetInput.value, 'targets')">
                             </mat-form-field>
                             <mat-chip-list class="mat-chip-list-stacked" selectable="true">
                                 <mat-chip *ngFor="let target of threatboard.boundaries.targets" removable="true">
@@ -125,7 +126,7 @@
                                 </mat-select>
                             </mat-form-field>
                             <mat-chip-list class="mat-chip-list-stacked" selectable="true">
-                                <mat-chip *ngFor="let intrusion of threatboard.boundaries.intrusions"
+                                <mat-chip *ngFor="let intrusion of threatboard.boundaries.intrusion_sets"
                                         removable="true" selectable="true">
                                     <div class="flex">
                                         <span class="flex1 flexNowrap">{{ intrusion.displayValue }}</span>

--- a/src/app/threat-beta/create/create.component.scss
+++ b/src/app/threat-beta/create/create.component.scss
@@ -12,20 +12,14 @@
 
 .edit-title-buttons {
     display: inline-block;
-
-    .edit-save-button {
-        background-color: $threat-dashboard-primary;
-        color: $light-text-default;
-    }
 }
 
 .boundaries-fieldsets {
-    vertical-align: top;
-
     .boundaries-column {
         display: inline-block;
         width: 256px;
         margin-right: 24px;
+        vertical-align: top;
 
         mat-form-field {
             width: 100%;
@@ -37,7 +31,7 @@
     margin-bottom: 24px;
 }
 
-.target-fieldset, .malware-fieldset, .intrusions-fieldset {
+.targets-fieldset, .malware-fieldset, .intrusions-fieldset {
     ::ng-deep {
         mat-chip {
             display: inline-block;

--- a/src/app/threat-beta/create/create.component.scss
+++ b/src/app/threat-beta/create/create.component.scss
@@ -1,2 +1,47 @@
 @import '../../../styles/_variables.scss';
 @import '../threat-beta.common';
+
+.edit-close-button {
+    margin-right: 20px;
+}
+
+.edit-title {
+    width: 500px;
+    color: $dark-text-default;
+}
+
+.edit-title-buttons {
+    display: inline-block;
+
+    .edit-save-button {
+        background-color: $threat-dashboard-primary;
+        color: $light-text-default;
+    }
+}
+
+.boundaries-fieldsets {
+    vertical-align: top;
+
+    .boundaries-column {
+        display: inline-block;
+        width: 256px;
+        margin-right: 24px;
+
+        mat-form-field {
+            width: 100%;
+        }
+    }
+}
+
+.dates-fieldset {
+    margin-bottom: 24px;
+}
+
+.target-fieldset, .malware-fieldset, .intrusions-fieldset {
+    ::ng-deep {
+        mat-chip {
+            display: inline-block;
+            margin: 0px 8px 8px 0px;
+        }
+    }
+}

--- a/src/app/threat-beta/create/create.component.spec.ts
+++ b/src/app/threat-beta/create/create.component.spec.ts
@@ -1,25 +1,30 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 
 import { CreateComponent } from './create.component';
 
 describe('CreateComponent', () => {
-  let component: CreateComponent;
-  let fixture: ComponentFixture<CreateComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ CreateComponent ]
-    })
-    .compileComponents();
-  }));
+    let component: CreateComponent;
+    let fixture: ComponentFixture<CreateComponent>;
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(CreateComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    beforeEach(async(() => {
+        TestBed
+            .configureTestingModule({
+                declarations: [
+                    CreateComponent,
+                ],
+            })
+            .compileComponents();
+    }));
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CreateComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
 });

--- a/src/app/threat-beta/create/create.component.spec.ts
+++ b/src/app/threat-beta/create/create.component.spec.ts
@@ -1,17 +1,61 @@
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { StoreModule } from '@ngrx/store';
+
+import { FormsModule } from '@angular/forms';
+import {
+    MatDatepickerModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatChipsModule,
+    MatOptionModule,
+    MatSelectModule,
+    MatProgressSpinnerModule,
+} from '@angular/material';
 
 import { CreateComponent } from './create.component';
+import { LoadingSpinnerComponent } from '../../global/components/loading-spinner/loading-spinner.component';
+import { ThreatDashboardBetaService } from '../threat-beta.service';
+import MockThreatDashboardBetaService from '../testing/mock-threat.service';
+import { threatReducer } from '../store/threat.reducers';
+import { GenericApi } from '../../core/services/genericapi.service';
 
-describe('CreateComponent', () => {
+fdescribe('CreateComponent', () => {
 
-    let component: CreateComponent;
     let fixture: ComponentFixture<CreateComponent>;
+    let component: CreateComponent;
+
+    const mockRouter = {
+        navigate: (paths: string[]) => { },
+    }
 
     beforeEach(async(() => {
         TestBed
             .configureTestingModule({
+                imports: [
+                    FormsModule,
+                    MatIconModule,
+                    MatFormFieldModule,
+                    MatDatepickerModule,
+                    MatSelectModule,
+                    MatOptionModule,
+                    MatChipsModule,
+                    MatProgressSpinnerModule,
+                    StoreModule.forRoot(threatReducer),
+                    HttpClientTestingModule,
+                ],
                 declarations: [
                     CreateComponent,
+                    LoadingSpinnerComponent,
+                ],
+                providers: [
+                    GenericApi,
+                    { provide: Router, useValue: mockRouter },
+                    { provide: ActivatedRoute, useValue: { snapshot: { routeConfig: { path: 'create' } } } },
+                    { provide: Location, useValue: { back: () => { } } },
+                    { provide: ThreatDashboardBetaService, useValue: MockThreatDashboardBetaService },
                 ],
             })
             .compileComponents();

--- a/src/app/threat-beta/create/create.component.ts
+++ b/src/app/threat-beta/create/create.component.ts
@@ -1,16 +1,170 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { take } from 'rxjs/operators';
+
+import { Malware, IntrusionSet } from 'stix';
+import { ThreatBoard } from 'stix/unfetter/index';
+
+import { SelectOption } from './select-option';
+import { GenericApi } from '../../core/services/genericapi.service';
+import { SortHelper } from '../../global/static/sort-helper';
+import { Constance } from '../../utils/constance';
 
 @Component({
-  selector: 'create',
-  templateUrl: './create.component.html',
-  styleUrls: ['./create.component.scss']
+    selector: 'create',
+    templateUrl: './create.component.html',
+    styleUrls: ['./create.component.scss']
 })
 export class CreateComponent implements OnInit {
-  
 
-  constructor() { }
+    @Input() threatboard: ThreatBoard = new ThreatBoard({
+        boundaries: {
+            start_date: null,
+            end_date: null,
+        },
+    } as ThreatBoard);
 
-  ngOnInit() {
-  }
+    public maxStartDate;
+
+    public minEndDate;
+
+    public readonly dateError = {
+        startDate: { isError: false },
+        endDate: {
+            isError: false,
+            isSameOrBefore: false,
+            isSameOrBeforeMessage: 'End Date must be after Start Date.'
+        },
+        errorMessage: 'Not a valid date'
+    };
+
+    public readonly dateFormat = 'M/D/YYYY';
+
+    public target: string = '';
+
+    public malwares: SelectOption[];
+
+    public intrusions: SelectOption[];
+
+    public loading: boolean = true;
+
+    constructor(
+        protected genericApi: GenericApi,
+    ) {
+    }
+
+    ngOnInit() {
+        const malwareFilter = 'sort=' + encodeURIComponent(JSON.stringify({ name: '1' }));
+        const malwareUrl = `${Constance.MALWARE_URL}?${malwareFilter}`;
+        const malwareQuery$ = this.genericApi.get(malwareUrl);
+
+        const intrusionFilter = 'sort=' + encodeURIComponent(JSON.stringify({ name: '1' }));
+        const instrusionUrl = `${Constance.INTRUSION_SET_URL}?${intrusionFilter}`;
+        const intrusionsQuery$ = this.genericApi.get(instrusionUrl);
+
+        const sub1$ = forkJoin(malwareQuery$, intrusionsQuery$, (s1, s2) => [s1, s2])
+            .pipe(take(1))
+            .subscribe(
+                (data: [Malware[], IntrusionSet[]]) => {
+                    console.log('malware and intrusions loaded:', data);
+                    const [malware, intrusions] = data;
+                    this.malwares = malware
+                        .map((el) => ({ value: el.id, displayValue: el.attributes.name } as SelectOption))
+                        .sort(SortHelper.sortDescByField('displayValue'));
+                    this.intrusions = intrusions
+                        .map((el) => ({ value: el.id, displayValue: el.attributes.name } as SelectOption))
+                        .sort(SortHelper.sortDescByField('displayValue'));
+                    console.log('malware options', this.malwares);
+                    console.log('intrusion options', this.intrusions);
+                },
+                (err) => console.log(err),
+                () => this.loading = false
+            );
+    }
+
+    isValid() {
+        return this.threatboard.boundaries.start_date !== null;
+    }
+
+    /**
+     * @description handle start date changed, does validation
+     */
+    public startDateChanged(value: any): void {
+        if (!value) {
+            this.minEndDate = null;
+            this.dateError.startDate.isError = false;
+            this.dateError.endDate.isSameOrBefore = false;
+            this.threatboard.boundaries.start_date = null;
+        } else if (moment(value, this.dateFormat).isValid()) {
+            this.threatboard.boundaries.start_date = moment(value, this.dateFormat).toDate();
+            this.dateError.startDate.isError = false;
+            const date = moment(value, this.dateFormat).add(1, 'd');
+            this.minEndDate = new Date(date.year(), date.month(), date.date());
+            this.isEndDateSameOrBeforeStartDate(value);
+        } else {
+            this.threatboard.boundaries.start_date = null;
+            this.dateError.startDate.isError = true;
+        }
+    }
+
+    /**
+     * @description handle end date changed, does validation
+     */
+    public endDateChanged(value: any): void {
+        if (!value) {
+            this.dateError.endDate.isError = false;
+            this.dateError.endDate.isSameOrBefore = false;
+            this.threatboard.boundaries.end_date = null;
+        } else if (moment(value, this.dateFormat).isValid()) {
+            this.dateError.endDate.isError = false;
+            this.threatboard.boundaries.end_date = moment(value, this.dateFormat).toDate();
+            this.isEndDateSameOrBeforeStartDate(value);
+        } else {
+            this.threatboard.boundaries.end_date = null;
+            this.dateError.endDate.isError = true;
+            this.dateError.endDate.isSameOrBefore = false;
+        }
+    }
+
+    /**
+     * @description Determine if the current end date is invalid against the current start date.
+     */
+    public isEndDateSameOrBeforeStartDate(value: any): void {
+        const dateValue = moment(value, this.dateFormat);
+        const endDate = moment(this.threatboard.boundaries.end_date, this.dateFormat);
+        const startDate = moment(this.threatboard.boundaries.start_date, this.dateFormat);
+        if (dateValue.isValid() && endDate.isSameOrBefore(startDate)) {
+            this.dateError.endDate.isSameOrBefore = true;
+        } else {
+            this.dateError.endDate.isSameOrBefore = false;
+        }
+    }
+
+    /**
+     * @description add to selected malwares, add a chip
+     */
+    public addChip(value: any, stixType: 'intrusion_sets' | 'malware' | 'targets'): void {
+        if (!value || !stixType) {
+            return;
+        }
+        let chips = new Set(this.threatboard.boundaries[stixType] || []);
+        chips.add(value);
+        const sortedChips = Array.from(chips).sort(SortHelper.sortDescByField<any, any>('displayValue'));
+        this.threatboard.boundaries[stixType] = sortedChips;
+        console.log(`adding '${value}' to ${stixType}:`, this.threatboard.boundaries);
+    }
+
+    /**
+     * @description Remove a chip from the correct chip Set
+     */
+    public removeChip(stixName: any, stixType: 'intrusion_sets' | 'malware' | 'targets') {
+        if (!stixName || !stixType) {
+            return;
+        }
+        let chips = new Set(this.threatboard.boundaries[stixType] || []);
+        chips.delete(stixName);
+        const sortedChips = Array.from(chips).sort(SortHelper.sortDescByField<any, any>('displayValue'));
+        this.threatboard.boundaries[stixType] = sortedChips;
+    }
 
 }

--- a/src/app/threat-beta/create/select-option.ts
+++ b/src/app/threat-beta/create/select-option.ts
@@ -1,0 +1,4 @@
+export interface SelectOption {
+    value: string;
+    displayValue: string;
+}

--- a/src/app/threat-beta/feed/feed-carousel/related-boards-carousel.component.ts
+++ b/src/app/threat-beta/feed/feed-carousel/related-boards-carousel.component.ts
@@ -52,7 +52,7 @@ export class RelatedBoardsCarouselComponent implements OnChanges {
             .subscribe(
                 (boards: any[]) => {
                     this._boards = boards.filter(b => b.id !== this.threatBoard.id);
-                    console.log(`(${new Date().toISOString()}) board list`, this._boards);
+                    console['debug'](`(${new Date().toISOString()}) board list`, this._boards);
                     this.carousel.calculateWindow();
                     this._loaded = true;
                 },

--- a/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.ts
+++ b/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.ts
@@ -62,7 +62,7 @@ export class ReportsCarouselComponent implements OnInit, OnChanges {
                     this._reports = reports
                         .map(report => ({ ...report, vetted: this.threatBoard.reports.includes(report.id) }))
                         .sort((a, b) => b.modified.localeCompare(a.modified));
-                    console.log(`(${new Date().toISOString()}) reports list`, this._reports);
+                    console['debug'](`(${new Date().toISOString()}) reports list`, this._reports);
                     this.carousel.calculateWindow();
                     this._loaded = true;
                 },
@@ -110,7 +110,7 @@ export class ReportsCarouselComponent implements OnInit, OnChanges {
             this.threatBoard.reports.push(id);
             this.threatboardService.updateBoard(this.threatBoard)
                 .subscribe(
-                    (response) => console.log(`(${new Date().toISOString()}) board updated`),
+                    (response) => console['debug'](`(${new Date().toISOString()}) board updated`),
                     (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
                 );
         }
@@ -139,7 +139,7 @@ export class ReportsCarouselComponent implements OnInit, OnChanges {
                 }
                 this.threatboardService.updateBoard(this.threatBoard)
                     .subscribe(
-                        (response) => console.log(`(${new Date().toISOString()}) board updated`),
+                        (response) => console['debug'](`(${new Date().toISOString()}) board updated`),
                         (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
                     );
             }

--- a/src/app/threat-beta/feed/feed.component.ts
+++ b/src/app/threat-beta/feed/feed.component.ts
@@ -34,7 +34,7 @@ export class FeedComponent implements OnInit {
         this.boardStore.select(getSelectedBoard)
             .subscribe(
                 (board) => {
-                    console.log(`(${new Date().toISOString()}) retrieved threat board:`, board);
+                    console['debug'](`(${new Date().toISOString()}) retrieved threat board:`, board);
                     this.threatBoard = board;
                     this._threatboardLoaded = true;
                 },

--- a/src/app/threat-beta/feed/user-citations.service.ts
+++ b/src/app/threat-beta/feed/user-citations.service.ts
@@ -32,7 +32,7 @@ export class UserCitationService {
             ([orgs, users]) => {
                 const morgs = orgs.map(org => ({...org, userName: org.name}));
                 this.users = [...morgs, ...users as any[]];
-                console.log(`(${new Date().toISOString()}) got user and orgs lists:`, this.users);
+                console['debug'](`(${new Date().toISOString()}) got user and orgs lists:`, this.users);
             },
             err => console.log('could not load users', err)
         );

--- a/src/app/threat-beta/side-board/side-board.component.ts
+++ b/src/app/threat-beta/side-board/side-board.component.ts
@@ -34,7 +34,7 @@ export class SideBoardComponent implements OnInit {
   masterListOptions = {
     dataSource: null,
     columns: new MasterListDialogTableHeaders('modified', 'Modified'),
-    modifyRoute: this.baseThreatUrl + '/wizard/edit',
+    modifyRoute: this.baseThreatUrl + '/edit',
     createRoute: this.baseThreatUrl + '/create',
   };
 

--- a/src/app/threat-beta/threat-beta.module.ts
+++ b/src/app/threat-beta/threat-beta.module.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatProgressBarModule, MatRadioModule } from '@angular/material';
+import { MatProgressBarModule, MatRadioModule, MatDatepickerModule, MatNativeDateModule } from '@angular/material';
 import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
+
 import { GlobalModule } from '../global/global.module';
 import { ArticleEditorComponent } from './article/article-editor/article-editor.component';
 import { ArticleReportPaneComponent } from './article/article-report-pane/article-report-pane.component';
@@ -33,12 +34,13 @@ import { RelatedBoardsCarouselComponent } from './feed/feed-carousel/related-boa
 import { FeedCarouselComponent } from './feed/feed-carousel/feed-carousel.component';
 import { CommentInputComponent } from './feed/activity-list/comment-input.component';
 
-
 @NgModule({
   imports: [
     CommonModule,
     GlobalModule,
     FormsModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     MatProgressBarModule,
     MatRadioModule,
     ReactiveFormsModule,

--- a/src/app/threat-beta/threat-beta.routing.ts
+++ b/src/app/threat-beta/threat-beta.routing.ts
@@ -11,9 +11,12 @@ const routes: Routes = [
   { 
     path: '', 
     component: MasterLayoutComponent,
-    children: [     
+    children: [
       {
         path: 'create', component: CreateComponent
+      }, 
+      {
+        path: 'edit/:id', component: CreateComponent
       }, 
       {
         path: ':boardId',

--- a/src/app/threat-beta/threat-beta.service.ts
+++ b/src/app/threat-beta/threat-beta.service.ts
@@ -31,4 +31,8 @@ export class ThreatDashboardBetaService {
         )
         .pipe(pluck('attributes'));
     }
+
+    public createBoard(board: ThreatBoard): Observable<ThreatBoard> {
+        return this.genericApi.post(`${StixUrls.X_UNFETTER_THREAT_BOARD}`, { data: { attributes: board } });
+    }
 }


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1514.

- Edit an existing threatboard (you will have to do this from the threatboard's page, not the global threatboard page). Change a thing or two, hit Save. You should be returned to the board's feed page, changes should be visible in the sidebar.

- Open the master list dialog, hit Create. Valid threatboard needs at least a name and start date before you can hit Save. After hitting Save, you should be redirected to the new board's feed page.

On another note:
- Still need a way to ask threat-ingest-service to scan existing reports to find potential matches for the new/modified board. Note that modified boards will probably get previously-rejected reports added to the potentials list, because we don't remember what was previously rejected.