### PR TITLE
Removed unnecessary call to markForCheck()

### DIFF
--- a/src/app/assess/v3/wizard/wizard.component.ts
+++ b/src/app/assess/v3/wizard/wizard.component.ts
@@ -1345,7 +1345,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
   public onMarkingChange(marking) {
     this.markingsChips['setMarkings'](this.ext);
-    this.markingsChips['changeDetection'].markForCheck();
   }
 
   /**

--- a/src/app/baseline/wizard/wizard.component.ts
+++ b/src/app/baseline/wizard/wizard.component.ts
@@ -720,7 +720,6 @@ export class WizardComponent extends Measurements implements OnInit, AfterViewIn
 
   public onMarkingChange(marking) {
     this.markingsChips['setMarkings'](this.currentBaseline);
-    this.markingsChips['changeDetection'].markForCheck();
   }
 
   /*

--- a/src/app/global/components/marking-definitions/markings-chips.component.ts
+++ b/src/app/global/components/marking-definitions/markings-chips.component.ts
@@ -9,7 +9,7 @@ import { MarkingDefinition } from 'stix';
     selector: 'markings-chips',
     templateUrl: './markings-chips.component.html',
     styleUrls: ['./markings-chips.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MarkingsChipsComponent implements OnInit, OnChanges {
 
@@ -24,7 +24,8 @@ export class MarkingsChipsComponent implements OnInit, OnChanges {
     private tlpOrder = ['white', 'green', 'amber', 'red'];
 
     constructor(
-        private store: Store<fromRoot.AppState>
+        private store: Store<fromRoot.AppState>,
+        private chgDetectorRef: ChangeDetectorRef
     ) {
     }
 
@@ -116,6 +117,8 @@ export class MarkingsChipsComponent implements OnInit, OnChanges {
             }
         }
         this._markings = markings;
+
+        this.chgDetectorRef.markForCheck();
     }
 
     // TODO update MarkingDefinition in stix package


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1511

No need to call markForCheck - marking defs are populated and displayed correctly, and are applied to the assessment and baseline correctly on save.

### To test:
1. Pull this branch
2. For assessments and baselines, do the following:
- Create a new one, skip directly to the Summary page of the wizard
- Select one or more marking definitions
- Verify there are no exceptions
- Click Save and verify that the selected marking definitions are displayed just under the assessment/baseline name in the top left corner
- Edit the assessment/baseline and make sure the selected marking definitions are populated on the Summary page
- Change the selection and Save
- Verify the updated marking definitions are displayed correctly
 