### PR TITLE
adds comments to global feed

### DIFF
--- a/src/app/threat-beta/display-comment/display-comment.component.html
+++ b/src/app/threat-beta/display-comment/display-comment.component.html
@@ -1,0 +1,58 @@
+<mat-card class="uf-mat-card" id="display-comment">
+
+    <div class="flex">
+        <div mat-card-avatar class="activity-avatar" [style.background-image]="getCommentAvatar(comment)"></div>
+        <div class="flex1 activity-content">
+            <mat-card-header>
+                <mat-card-title>{{ getUserName(comment) }}</mat-card-title>
+                <mat-card-subtitle> &bull; {{ comment.submitted | timeAgo }}</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+                <markdown [data]="comment.comment.content"></markdown>
+            </mat-card-content>
+        </div>
+    </div>
+
+    <mat-card-actions>
+        <button mat-button class="like-button" [style.color]="hasLiked(comment) ? 'blue' : 'inherit'"
+                (click)="clickLike(comment)">
+            <i class="material-icons">thumb_up</i>
+            <span [style.margin]="'0 6px'">Like</span>
+            <span *ngIf="hasLikes(comment)">({{ comment.comment.likes.length }})</span>
+        </button>
+        <button mat-button *ngIf="commentTarget !== comment" class="comment-button" (click)="commentTarget = comment">
+            <i class="material-icons">chat_bubble</i> Reply
+        </button>
+    </mat-card-actions>
+
+    <mat-card-footer>
+        <hr *ngIf="!parent && ((comment.comment.replies && comment.comment.replies.length) || (commentTarget === comment))">
+        <!-- TODO Promote comment-input? -->
+        <comment-input *ngIf="commentTarget === comment" (cancel)="commentTarget = false"
+                (submit)="submitComment($event)"></comment-input>
+        <div *ngIf="hasComments(comment)">
+            <div *ngFor="let reply of comment.comment.replies | sortByField: 'submitted'" class="flex">
+                <div mat-card-avatar class="activity-avatar"
+                        [style.background-image]="getCommentAvatar(reply)"></div>
+                <div class="flex1 activity-content">
+                    <mat-card-header>
+                        <mat-card-title>{{ getUserName(reply) }}</mat-card-title>
+                        <mat-card-subtitle> &bull; {{ reply.submitted | timeAgo }}</mat-card-subtitle>
+                    </mat-card-header>
+                    <mat-card-content>
+                        <markdown [data]="reply.comment.content"></markdown>
+                        <button mat-button class="like-button"
+                                [style.margin-left]="'-16px'" [style.line-height]="'20px'"
+                                [style.color]="hasLiked(reply) ? 'blue' : 'inherit'"
+                                (click)="clickLike(reply)">
+                            <i class="material-icons">thumb_up</i>
+                            <span [style.margin]="'0 6px'">Like</span>
+                            <span *ngIf="hasLikes(reply)">({{ reply.comment.likes.length }})</span>
+                        </button>
+                    </mat-card-content>
+                </div>
+            </div>
+        </div>
+    </mat-card-footer>
+
+</mat-card>

--- a/src/app/threat-beta/display-comment/display-comment.component.scss
+++ b/src/app/threat-beta/display-comment/display-comment.component.scss
@@ -1,0 +1,61 @@
+.activity-avatar {
+    margin-right: 8px;
+    background-size: cover;
+}
+
+hr {
+    margin: 8px 0;
+}
+
+mat-card {
+    margin-bottom: 16px;
+}
+
+mat-card-footer {
+    padding: 0 24px 24px 64px;
+}
+
+mat-card-footer .activity-avatar {
+    width: 30px;
+    height: 30px;
+    margin-left: 6px;
+    margin-right: 12px;
+    background-size: cover;
+}
+
+.comment-button, .like-button {
+    font-size: 14px;
+}
+
+:host ::ng-deep #display-comment {
+    mat-card-header {
+        margin-bottom: 0;
+    }
+
+    mat-card-title {
+        margin-bottom: 8px;
+        font-size: 14px;
+        font-weight: bold;
+        letter-spacing: .1px;
+    }
+
+    mat-card-subtitle {
+        margin-bottom: 4px;
+        font-size: 14px;
+    }
+
+    mat-card-content {
+        margin-bottom: 0;
+        font-size: 16px;
+    }
+
+    mat-card-actions {
+        margin: 0 0 0 48px;
+        padding: 0;
+        text-align: left;
+    }
+
+    mat-card-footer mat-card-content {
+        font-size: 14px;
+    }
+}

--- a/src/app/threat-beta/display-comment/display-comment.component.spec.ts
+++ b/src/app/threat-beta/display-comment/display-comment.component.spec.ts
@@ -1,0 +1,152 @@
+import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import { StoreModule, Store } from '@ngrx/store';
+
+import { FormsModule } from '@angular/forms';
+import {
+    MatCardModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatRadioModule,
+} from '@angular/material';
+import { MarkdownModule, MarkdownService } from 'ngx-markdown';
+import { SimplemdeModule } from 'ng2-simplemde';
+
+import { Article, ThreatBoard } from 'stix/unfetter/index';
+
+import { CommentInputComponent } from '../feed/activity-list/comment-input.component';
+import { ThreatDashboardBetaService } from '../threat-beta.service';
+import MockThreatDashboardBetaService from '../testing/mock-threat.service';
+import { LoadingSpinnerComponent } from '../../global/components/loading-spinner/loading-spinner.component';
+import { FieldSortPipe } from '../../global/pipes/field-sort.pipe';
+import { TimeAgoPipe } from '../../global/pipes/time-ago.pipe';
+import { AppState, reducers } from '../../root-store/app.reducers';
+import * as userActions from '../../root-store/users/user.actions';
+import * as boardActions from '../store/threat.actions';
+import { threatReducer } from '../store/threat.reducers';
+import { StixCoreEnum } from 'stix';
+import { DisplayCommentComponent } from './display-comment.component';
+
+
+describe('DisplayCommentComponent', () => {
+  let component: DisplayCommentComponent;
+  let fixture: ComponentFixture<DisplayCommentComponent>;
+  let appStore: Store<AppState>;
+
+  const mockUser = {
+    userData: {
+        _id: '1234',
+        email: 'fake@fake.com',
+        userName: 'fake',
+        lastName: 'fakey',
+        firstName: 'faker',
+        created: '2017-11-24T17:52:13.032Z',
+        identity: {
+            name: 'afake',
+            id: 'identity--1234',
+            type: 'identity'
+        },
+        role: 'STANDARD_USER',
+        locked: false,
+        approved: true,
+        registered: true,
+        auth: {
+            service: 'gitbub',
+            id: '1234',
+            userName: 'fake',
+            avatar_url: 'https://avatars2.githubusercontent.com/u/1234?v=4'
+        }
+    },
+    token: 'Bearer 123',
+    authenticated: true,
+    approved: true,
+    role: 'STANDARD_USER'
+};
+
+const mockArticles = [
+    new Article({
+        id: 'x-unfetter-article--1',
+        name: 'Latin',
+        content: 'Lorem ipsum dolor sit amet ...',
+        created_by_ref: '1234',
+        created: new Date(),
+        modified: new Date(),
+        metaProperties: {
+            comments: [],
+            likes: [],
+        }
+    }),
+];
+
+const mockThreatBoard = new ThreatBoard({
+  id: 'tb1',
+  type: StixCoreEnum.REPORT, // <-- this is BS
+  name: 'Empty Threats',
+  created: new Date(),
+  modified: new Date().toISOString(), // <-- this is BS
+  metaProperties: {
+      published: false,
+      comments: [
+          {
+              submitted: new Date(),
+              user: {
+                  id: '1234',
+                  userName: 'fake',
+                  avatar_url: 'https://avatars2.githubusercontent.com/u/1234?v=4'
+              },
+              comment: {
+                  content: 'Comment on the board',
+                  replies: [],
+                  likes: []
+              }
+          },
+      ],
+  },
+  articles: ['x-unfetter-article--1'],
+  boundaries: {
+      start_date: new Date(),
+      end_date: new Date(),
+      intrusion_sets: [],
+      malware: [],
+      targets: [],
+  },
+  reports: [],
+  toJson: null // <-- this is BS
+});
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DisplayCommentComponent,
+        TimeAgoPipe,
+        CommentInputComponent,
+        FieldSortPipe,
+      ],
+      imports: [MatCardModule,
+        MarkdownModule.forRoot(),
+        SimplemdeModule,
+        StoreModule.forRoot(reducers),
+      ],
+      providers: [
+        MarkdownService,
+        { provide: ThreatDashboardBetaService, useValue: MockThreatDashboardBetaService },
+    ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DisplayCommentComponent);
+    component = fixture.componentInstance;
+    component.board = mockThreatBoard;
+    component.comment = mockThreatBoard.metaProperties.comments[0];
+    appStore = TestBed.get(Store);
+    appStore.addReducer('threat', threatReducer);
+    appStore.dispatch(new userActions.LoginUser(mockUser));
+    appStore.dispatch(new userActions.SetUserList([mockUser.userData])); // not working
+    appStore.dispatch(new boardActions.SetArticles(mockArticles));
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/threat-beta/display-comment/display-comment.component.ts
+++ b/src/app/threat-beta/display-comment/display-comment.component.ts
@@ -1,0 +1,160 @@
+import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { pluck, take } from 'rxjs/operators';
+import { AppState } from '../../root-store/app.reducers';
+import { UserCitationService } from '../feed/user-citations.service';
+import { ThreatBoard } from 'stix/unfetter/index';
+import { ThreatDashboardBetaService } from '../threat-beta.service';
+import { generateUUID } from '../../global/static/generate-uuid';
+
+@Component({
+  selector: 'display-comment',
+  templateUrl: './display-comment.component.html',
+  styleUrls: ['./display-comment.component.scss']
+})
+export class DisplayCommentComponent implements OnInit {
+
+  @Input() comment: any; // TODO Comment interface
+  @Input() parent: any; // TODO Comment interface
+  @Output() newComment = new EventEmitter<any>(); // TODO Comment interface
+
+  /**
+   * The threatboard the comment belongs to. We only use this when persisting likes & comments added to the threatboard itself.
+   */
+  @Input() board: ThreatBoard;
+
+  /**
+    * The current user. Needed for when they add a comment or reply.
+    */
+  private user: any;
+
+  /**
+    * Detects the user wishes to add a comment to a comment or article, pointing to the id of the object. They can
+    * therefore only comment on one thing at a time.
+    */
+  public commentTarget: boolean | any = false;
+
+  constructor(
+    private threatboardService: ThreatDashboardBetaService,
+    private appStore: Store<AppState>,
+    private citations: UserCitationService) { }  // TODO, move UCS?
+
+  ngOnInit() {
+    this.appStore.select('users')
+      .pipe(
+        pluck('userProfile'),
+        take(1),
+      )
+      .subscribe(
+        user => {
+          console['debug'](`(${new Date().toISOString()}) got user info:`, user);
+          this.user = user;
+        },
+        err => console.log('could not load user', err)
+      );
+  }
+
+  public getCommentAvatar(comment: any) {
+    return this.citations.getAvatar(comment);
+  }
+
+  public hasLikes(comment: any) {
+    return (this.getLikes(comment) || []).length > 0;
+  }
+
+  public hasLiked(comment: any) {
+    return (this.getLikes(comment) || []).some(user => this.user.identity.id);
+  }
+
+  private getLikes(comment: any) {
+    let likes = null;
+    if (comment) {
+      if (comment.comment) {
+        if (!comment.comment.likes) {
+          comment.comment.likes = [];
+        }
+        likes = comment.comment.likes;
+      }
+    }
+    return likes;
+  }
+
+  public submitComment(comment: string) {
+    const date = new Date();
+    const newComment = {
+      id: `x-unfetter-comment--${generateUUID()}`,
+      user: {
+        id: this.user.identity.id,
+        avatar_url: this.user.auth.avatar_url,
+      },
+      submitted: date,
+      comment: {
+        content: comment,
+        likes: [],
+        replies: undefined,
+      }
+    };
+    if (this.commentTarget === true) {
+      newComment.comment.replies = [];
+    }
+    this.submitThreatBoardComment(newComment);
+    this.commentTarget = false;
+  }
+
+  private submitThreatBoardComment(comment: any) {
+    if (this.board) {
+      if (!this.board.metaProperties.comments) {
+        this.board.metaProperties.comments = [];
+      }
+      this.board.metaProperties.comments.push(comment);
+      this.threatboardService.updateBoard(this.board)
+        .subscribe(
+          (response) => {
+            console['debug'](`(${new Date().toISOString()}) board updated`);
+            this.newComment.emit(comment);
+          },
+          (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
+        );
+    }
+  }
+
+  public hasComments(comment: any) {
+    if (!comment) {
+      return false;
+    }
+
+    return comment.comment && comment.comment.replies && (comment.comment.replies.length > 0);
+  }
+
+  public clickLike(comment: any) {
+    const likes = this.getLikes(comment);
+    if (likes) {
+      const liked = likes.findIndex(user => user === this.user.identity.id);
+      if (liked < 0) {
+        likes.push(this.user.identity.id);
+      } else {
+        likes.splice(liked, 1);
+      }
+      if (this.board) {
+        console.log(this.board.metaProperties);
+        this.threatboardService.updateBoard(this.board)
+          .subscribe(
+            (response) => console['debug'](`(${new Date().toISOString()}) board likes updated`),
+            (err) => console.log(`(${new Date().toISOString()}) error updating board likes`, err),
+          );
+      } else {
+        // TODO look through boards for which to update.
+        console.log('no board');
+      }
+    }
+  }
+
+  /**
+    * Attempts to grab a displayable name (rather than the UUID) of the person or organization that wrote a given
+    * comment. This code is checking for organizations, too, which it shouldn't need to do. :/
+    */
+  public getUserName(comment: any) {
+    return this.citations.getUserName(comment);
+  }
+
+}

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.html
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.html
@@ -28,9 +28,7 @@
                 <ng-container *ngTemplateOutlet="articleTemplate;context:{article:item}"></ng-container>
             </ng-container>
             <ng-container *ngIf="item.comment">
-                <mat-card class="uf-mat-card">
-                    <ng-container *ngTemplateOutlet="commentTemplate;context:{item:item,parent:null}"></ng-container>
-                </mat-card>
+                <display-comment [comment]="item" [parent]=null [board]=threatBoard (newComment)="addAComment($event)"></display-comment>
             </ng-container>
         </ng-container>
 
@@ -40,64 +38,6 @@
 
 <ng-template #loadingBlock>
     <loading-spinner height="250px"></loading-spinner>
-</ng-template>
-
-<ng-template #commentTemplate let-item="item" let-parent="parent">
-
-    <div class="flex">
-        <div mat-card-avatar class="activity-avatar" [style.background-image]="getActivityAvatar(item)"></div>
-        <div class="flex1 activity-content">
-            <mat-card-header>
-                <mat-card-title>{{ getUserName(item) }}</mat-card-title>
-                <mat-card-subtitle> &bull; {{ item.submitted | timeAgo }}</mat-card-subtitle>
-            </mat-card-header>
-            <mat-card-content>
-                <markdown [data]="item.comment.content"></markdown>
-            </mat-card-content>
-        </div>
-    </div>
-
-    <mat-card-actions>
-        <button mat-button class="like-button" [style.color]="hasLikedActivity(item) ? 'blue' : 'inherit'"
-                (click)="clickActivityLike(item)">
-            <i class="material-icons">thumb_up</i>
-            <span [style.margin]="'0 6px'">Like</span>
-            <span *ngIf="hasActivityLikes(item)">({{ item.comment.likes.length }})</span>
-        </button>
-        <button mat-button *ngIf="commentTarget !== item" class="comment-button" (click)="commentTarget = item">
-            <i class="material-icons">chat_bubble</i> Reply
-        </button>
-    </mat-card-actions>
-
-    <mat-card-footer [style.padding]="'0 24px 24px 64px'">
-        <hr *ngIf="!parent && ((item.comment.replies && item.comment.replies.length) || (commentTarget === item))">
-        <comment-input *ngIf="commentTarget === item" (cancel)="commentTarget = false"
-                (submit)="submitActivityComment($event)"></comment-input>
-        <div *ngIf="hasActivityComments(item)">
-            <div *ngFor="let reply of item.comment.replies | sortByField: 'submitted'" class="flex">
-                <div mat-card-avatar class="activity-avatar"
-                        [style.background-image]="getActivityAvatar(reply)"></div>
-                <div class="flex1 activity-content">
-                    <mat-card-header>
-                        <mat-card-title>{{ getUserName(reply) }}</mat-card-title>
-                        <mat-card-subtitle> &bull; {{ reply.submitted | timeAgo }}</mat-card-subtitle>
-                    </mat-card-header>
-                    <mat-card-content>
-                        <markdown [data]="reply.comment.content"></markdown>
-                        <button mat-button class="like-button"
-                                [style.margin-left]="'-16px'" [style.line-height]="'20px'"
-                                [style.color]="hasLikedActivity(reply) ? 'blue' : 'inherit'"
-                                (click)="clickActivityLike(reply)">
-                            <i class="material-icons">thumb_up</i>
-                            <span [style.margin]="'0 6px'">Like</span>
-                            <span *ngIf="hasActivityLikes(reply)">({{ reply.comment.likes.length }})</span>
-                        </button>
-                    </mat-card-content>
-                </div>
-            </div>
-        </div>
-    </mat-card-footer>
-
 </ng-template>
 
 <ng-template #articleTemplate let-article="article">
@@ -139,7 +79,7 @@
             <div label="Comments" *ngIf="hasActivityComments(article)">
                 <hr/>
                 <ng-container *ngFor="let comment of article.metaProperties.comments | sortByField: 'submitted'">
-                    <ng-container *ngTemplateOutlet="commentTemplate;context:{item:comment,parent:article}"></ng-container>
+                    <display-comment [comment]="comment" [parent]=article [board]=article (newComment)="addAComment($event)"></display-comment>
                 </ng-container>
             </div>
         </mat-card-footer>

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.spec.ts
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.spec.ts
@@ -25,6 +25,7 @@ import * as userActions from '../../../root-store/users/user.actions';
 import * as boardActions from '../../store/threat.actions';
 import { threatReducer } from '../../store/threat.reducers';
 import { StixCoreEnum } from 'stix';
+import { DisplayCommentComponent } from '../../display-comment/display-comment.component';
 
 describe('ActivityListComponent', () => {
 
@@ -129,6 +130,7 @@ describe('ActivityListComponent', () => {
                 declarations: [
                     ActivityListComponent,
                     CommentInputComponent,
+                    DisplayCommentComponent,
                     LoadingSpinnerComponent,
                     FieldSortPipe,
                     TimeAgoPipe,

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.ts
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { forkJoin } from 'rxjs';
 import { pluck, take } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
@@ -263,6 +262,10 @@ export class ActivityListComponent implements OnInit {
         this.commentTarget = false;
     }
 
+    public addAComment(comment: any) {
+        this._activity[comment.id] = comment;
+    }
+
     private submitThreatBoardComment(comment: any) {
         if (this.threatBoard) {
             if (!this.threatBoard.metaProperties.comments) {
@@ -273,7 +276,7 @@ export class ActivityListComponent implements OnInit {
                 .subscribe(
                     (response) => {
                         console['debug'](`(${new Date().toISOString()}) board updated`);
-                        this._activity[comment.id] = comment;
+                        this.addAComment(comment);
                     },
                     (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
                 );

--- a/src/app/threat-beta/feed/feed.component.spec.ts
+++ b/src/app/threat-beta/feed/feed.component.spec.ts
@@ -18,6 +18,7 @@ import { ThreatDashboardBetaService } from '../threat-beta.service';
 import MockThreatDashboardBetaService from '../testing/mock-threat.service';
 import { GlobalModule } from '../../global/global.module';
 import { threatReducer } from '../store/threat.reducers';
+import { DisplayCommentComponent } from '../display-comment/display-comment.component';
 
 describe('FeedComponent', () => {
 
@@ -43,6 +44,7 @@ describe('FeedComponent', () => {
                     ActivityListComponent,
                     CommentInputComponent,
                     ContributorListComponent,
+                    DisplayCommentComponent,
                     ThreatHeaderComponent,
                     SideBoardComponent,
                 ],

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.html
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.html
@@ -1,8 +1,17 @@
 <div class="top">
   <div class="flex flex-row">
-  <div class="header-text">
-    Activity
+    <div class="header-text">
+      Activity
+    </div>
+    <div class="flex1"></div>
+    <global-activity-sort></global-activity-sort>
   </div>
-  <div class="flex1"></div>
-  <global-activity-sort></global-activity-sort>
+  <ng-container *ngFor="let item of activity">
+    <ng-container *ngIf="item.type === 'x-unfetter-article'">
+        <!-- TODO <ng-container *ngTemplateOutlet="articleTemplate;context:{article:item}"></ng-container> -->
+    </ng-container>
+    <ng-container *ngIf="item.comment">
+        <display-comment [comment]="item" [parent]=null [board]=null (newComment)="addAComment($event)"></display-comment>
+    </ng-container>
+</ng-container>
 </div>

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.spec.ts
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.spec.ts
@@ -1,5 +1,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { StoreModule } from '@ngrx/store';
+import { reducers } from '../../../root-store/app.reducers';
 import { RecentActivityComponent } from './recent-activity.component';
 
 
@@ -10,6 +12,7 @@ describe('RecentActivityComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RecentActivityComponent],
+      imports: [StoreModule.forRoot(reducers)],
       schemas: [NO_ERRORS_SCHEMA],
     })
       .compileComponents();

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.ts
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { pluck } from 'rxjs/operators';
+import { Store } from '@ngrx/store';
+import { ThreatFeatureState } from '../../store/threat.reducers';
 
 @Component({
   selector: 'recent-activity',
@@ -7,9 +10,40 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RecentActivityComponent implements OnInit {
 
-  constructor() { }
+  /**
+   * The full list of comments (with replies) and threatboard article (with comments and replies). Should also list
+   * comments made on reports that are a part of the threatboard.
+   */
+  private _activity = {};
+
+  constructor(private boardStore: Store<ThreatFeatureState>) { }
 
   ngOnInit() {
+    // TODO need reports & articles (that have comments) too
+    this.boardStore.select('threat')
+      .pipe(
+        pluck('boardList')
+      )
+      .subscribe(
+        (boards: any[]) => {
+          boards.forEach(board => {
+            if (board && board.metaProperties && board.metaProperties.comments) {
+              board.metaProperties.comments.forEach(comment => this._activity[comment.id] = comment);
+            }
+          });
+        },
+        (err) => console.log(`(${new Date().toISOString()}) Error loading threat boards:`, err)
+      );
+
+    // articles.forEach(article => this._activity[article.id] = article);
+    // console['debug'](`(${new Date().toISOString()}) activity list:`, this._activity);
+    // this._loaded = true;
+
   }
 
+  public get activity() { return Object.values(this._activity); } // TODO .sort(this.activitySorts[this.activeSort].sorter); }
+
+  public addAComment(comment: any) {
+    this._activity[comment.id] = comment;
+}
 }

--- a/src/app/threat-beta/threat-beta.module.ts
+++ b/src/app/threat-beta/threat-beta.module.ts
@@ -33,6 +33,7 @@ import { ReportsCarouselComponent } from './feed/feed-carousel/reports-carousel.
 import { RelatedBoardsCarouselComponent } from './feed/feed-carousel/related-boards-carousel.component';
 import { FeedCarouselComponent } from './feed/feed-carousel/feed-carousel.component';
 import { CommentInputComponent } from './feed/activity-list/comment-input.component';
+import { DisplayCommentComponent } from './display-comment/display-comment.component';
 
 @NgModule({
   imports: [
@@ -70,6 +71,7 @@ import { CommentInputComponent } from './feed/activity-list/comment-input.compon
     ReportsCarouselComponent,
     RelatedBoardsCarouselComponent,
     CommentInputComponent,
+    DisplayCommentComponent,
   ],
   providers: [
     ThreatBetaGuard,

--- a/src/app/threat-beta/threat-dashboard-beta.component.spec.ts
+++ b/src/app/threat-beta/threat-dashboard-beta.component.spec.ts
@@ -4,7 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StoreModule } from '@ngrx/store';
 import { GlobalModule } from '../global/global.module';
-import { threatReducer } from './store/threat.reducers';
+import mockThreatReducer from './testing/mock-reducer';
 import { ThreatDashboardBetaComponent } from './threat-dashboard-beta.component';
 
 xdescribe('ThreatDashboardBetaComponent', () => {
@@ -17,7 +17,7 @@ xdescribe('ThreatDashboardBetaComponent', () => {
       imports: [GlobalModule,
         RouterTestingModule,
         NoopAnimationsModule,
-        StoreModule.forRoot(threatReducer),
+        StoreModule.forRoot(mockThreatReducer),
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })

--- a/src/app/threat-beta/threat-dashboard-beta.component.spec.ts
+++ b/src/app/threat-beta/threat-dashboard-beta.component.spec.ts
@@ -7,7 +7,7 @@ import { GlobalModule } from '../global/global.module';
 import mockThreatReducer from './testing/mock-reducer';
 import { ThreatDashboardBetaComponent } from './threat-dashboard-beta.component';
 
-xdescribe('ThreatDashboardBetaComponent', () => {
+describe('ThreatDashboardBetaComponent', () => {
   let component: ThreatDashboardBetaComponent;
   let fixture: ComponentFixture<ThreatDashboardBetaComponent>;
 


### PR DESCRIPTION
abstracts comment display component from board-feed view to use in both places

supports unfetter-discover/unfetter#1491

### To Test

- Verify that comments on multiple threat boards appear in global feed view
- Verify that comments for a specific threat board appear in threat-board feed view

### Still To Work

- Threaded comments on articles
- Article comments
- Adding replies to comments in global
- Linking comments to specific artifacts in global feed is desireable