### PR TITLE
Adjust styling of buttons for add category/capability

### DIFF
--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.html
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.html
@@ -19,8 +19,10 @@
                 <input matInput class="form-control" required placeholder="Capability Name" value="addCapability.name" [(ngModel)]="addCapability.name">
               </mat-form-field>
             </div>
-            <button type="submit"  class="mat-primary" mat-raised-button [disabled]="!addCapability.name" (click)="addNewCapability(addCapability)"><i class="material-icons">save</i> SAVE {{ addCapability.name }}</button>
-            <button type="submit"  class="mat-primary" mat-raised-button (click)="cancelAddNewCapability()">CANCEL</button>
+            <mat-card-actions class="text-right">
+              <button type="submit" mat-raised-button color="primary" [disabled]="!addCapability.name" (click)="addNewCapability(addCapability)"><i class="bmargin material-icons">save</i> SAVE {{ addCapability.name }}</button>
+              <button type="submit" mat-raised-button color="primary" (click)="cancelAddNewCapability()">CANCEL</button>
+            </mat-card-actions>
           </div>
         </div>
       </div>

--- a/src/app/baseline/wizard/capability-selector/capability-selector.component.scss
+++ b/src/app/baseline/wizard/capability-selector/capability-selector.component.scss
@@ -1,0 +1,3 @@
+.bmargin {
+    margin-bottom: 3px;
+}

--- a/src/app/baseline/wizard/category/category.component.html
+++ b/src/app/baseline/wizard/category/category.component.html
@@ -19,8 +19,10 @@
                 <input matInput class="form-control" required placeholder="Capability Group Name" value="addCategory.name" [(ngModel)]="addCategory.name">
               </mat-form-field>
             </div>
-            <button type="submit"  class="mat-primary" mat-raised-button [disabled]="!addCategory.name" (click)="addNewCategory(addCategory)"><i class="material-icons">save</i> SAVE {{ addCategory.name }}</button>
-            <button type="submit"  class="mat-primary" mat-raised-button (click)="cancelAddNewCategory()">CANCEL</button>
+            <mat-card-actions class="text-right">
+              <button type="submit"  class="mat-primary" mat-raised-button [disabled]="!addCategory.name" (click)="addNewCategory(addCategory)"><i class="bmargin material-icons">save</i> SAVE {{ addCategory.name }}</button>
+              <button type="submit"  class="mat-primary" mat-raised-button (click)="cancelAddNewCategory()">CANCEL</button>
+            </mat-card-actions>
           </div>
         </div>
       </div>

--- a/src/app/baseline/wizard/category/category.component.scss
+++ b/src/app/baseline/wizard/category/category.component.scss
@@ -1,0 +1,3 @@
+.bmargin {
+    margin-bottom: 3px;
+}


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1472

### To test:
1. Pull this branch
2. In a new or edited baseline, verify there is same space between Save and Cancel buttons of add category/capability section as those of the wizard itself.
3. Also verify that disk icon is vertically aligned with Save button text