### PR TITLE
improve loading efficiency and reduce number of calls to backend

### DIFF
--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -123,7 +123,6 @@ export class FullComponent implements OnInit, OnDestroy {
           const assessmentType = (assessment !== undefined && assessment.determineAssessmentType) ?
               assessment.determineAssessmentType() : 'Unknown';
           this.assessmentName = `${assessment.name} - ${assessmentType}`;
-          console.log('got assessment', assessment, assessmentType, this.assessmentName);
           this.requestGroupSectionDataLoad(assessment);
         }
       );
@@ -277,7 +276,7 @@ export class FullComponent implements OnInit, OnDestroy {
       routePromise = this.router.navigate([this.masterListOptions.modifyRoute, event.rollupId]);
     }
 
-    routePromise.catch((e) => console.log(e));
+    routePromise.catch((e) => (e));
     return routePromise;
   }
 

--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -100,7 +100,6 @@ export class FullComponent implements OnInit, OnDestroy {
       },
         (err) => console.log(err));
     this.listenForDataChanges();
-    this.subscriptions.push(idParamSub$);
   }
 
   /**

--- a/src/app/assess/v3/result/full/full.component.ts
+++ b/src/app/assess/v3/result/full/full.component.ts
@@ -111,15 +111,9 @@ export class FullComponent implements OnInit, OnDestroy {
       .select(getFullAssessment)
       .pipe(
         distinctUntilChanged((a: Assessment, b: Assessment) => {
-          console.log('ANYTHING');
-          console.log(a.created + '<--a b-->' + b.created);
-          console.log(JSON.stringify(a) === JSON.stringify(b));
           return JSON.stringify(a) === JSON.stringify(b);
         }),
-        tap((assessment) => {
-          console.log('requestingGroupSectionDataLoad');
-          return this.requestGroupSectionDataLoad(assessment);
-        })
+        tap((assessment) => this.requestGroupSectionDataLoad(assessment))
       );
 
     this.finishedLoading$ = this.store
@@ -195,7 +189,6 @@ export class FullComponent implements OnInit, OnDestroy {
     if (assessmentType === AssessmentEvalTypeEnum.CAPABILITIES) {
       isCapability = true;
     }
-    console.log('GETTING GROUP DATA NOW');
     this.store.dispatch(new LoadGroupData({ id, isCapability }));
   }
 

--- a/src/app/assess/v3/result/summary/summary.component.html
+++ b/src/app/assess/v3/result/summary/summary.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
-<div id="newAssessmentsSummary" *ngIf="(summary$|async) && (failedToLoad$|async) === false; else failedToLoadBlock" class="fadeIn">
+<div id="newAssessmentsSummary" *ngIf="(failedToLoad$|async) === false; else failedToLoadBlock" class="fadeIn">
   <mat-sidenav-container>
     <mat-sidenav class="side-panel" mode="side" opened="true">
       <unfetter-side-panel class="side-panel" [item]="{ name: assessmentName$ | async }" collapsible="false" width="320">
@@ -13,12 +13,12 @@
           (edit)="onEdit($event)" (delete)="onDelete($event)"></master-list-dialog-trigger>
 
         <markings-chips [model]="summary"></markings-chips>
-        <sidepanel-list-item [label]="(summary$ | async)?.name" [items]="([summary$|async])" expandable="true">
-          <mat-list-item *ngFor="let summ of ([summary$|async]); trackBy:trackByFn" class="list-divider" [@slideInOutAnimation]>
+        <sidepanel-list-item [label]="(summary?.name)" [items]="([summary])" expandable="true">
+          <mat-list-item class="list-divider" [@slideInOutAnimation]>
             <h4 mat-line>
-              {{summ?.name}}
+              {{summary?.name}}
             </h4>
-            <div mat-line class="mat-caption"> {{summ?.assessment_objects[0]?.stix?.type}} </div>
+            <div mat-line class="mat-caption"> {{summary?.assessment_objects[0]?.stix?.type}} </div>
           </mat-list-item>
         </sidepanel-list-item>
 


### PR DESCRIPTION
Believe this solves issues with Summary view.
WIth full-view this improves things, but may be some more work to do.

To Test:
-For the summary view of an assessment, load any assessment with console up
-Should see only unique calls to backend.
-Switching to full-results view and back to summary should see only one set of unique calls to backend for summary load.
-Switching among different assessments in summary view should not multiply number of calls to backend (should be one set per assessment loading).

-For the full results view of an assessment, load any assessment with console up
-Go through same steps as for summary view 

Note: I could not solve issue of double call to "get group data" on full results assessment load. Seems to always happen and couldn't determine why. However other enhancements are good and should improve things.

fixes unfetter-discover/unfetter#1522