### PR TITLE
Small polish issues for Threat Beta Dashboard

### DIFF
--- a/src/app/threat-beta/board/board.component.html
+++ b/src/app/threat-beta/board/board.component.html
@@ -1,5 +1,5 @@
 <div id="boardComponenet">
   <div class="main-panel min-tab-height">
-    Info about an individual board here.
+    COMING SOON: Info about an individual thread board will appear here: List of reports associated with the board, attachments to articles about the board, display of articles, and comments on the board itself.
   </div>
 </div>

--- a/src/app/threat-beta/threat-dashboard-beta.component.html
+++ b/src/app/threat-beta/threat-dashboard-beta.component.html
@@ -5,51 +5,58 @@
         <div class="flex flex-cols side-nav-top">
         </div>
         <mat-tab-group>
-            <mat-tab label="MY BOARDS">
-              <div class="side-nav-item header-text" *ngFor="let board of boards$ | async">
-                <div>
+          <mat-tab label="MY BOARDS">
+            <div class="side-nav-item header-text" *ngFor="let board of boards$ | async">
+              <div class="pointer" (click)="boardView(board.id)"> 
                 {{board.name}}
-                </div>
-                <div class="flex1"></div>
-                <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
-                  <mat-icon>more_vert</mat-icon>
+              </div>
+              <div class="flex1"></div>
+              <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
+                <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
-                  <button mat-menu-item (click)="boardView(board.id)" *ngIf="!canCrud"> <!-- TODO reverse & fix "canCrud" check -->
-                    <mat-icon>details</mat-icon>
-                    <span>View</span>
-                  </button>
-                  <button mat-menu-item (click)="editBoard(board.id)" *ngIf="!canCrud">
-                    <mat-icon>edit</mat-icon>
-                    <span>Edit</span>
-                  </button>
-                  <button mat-menu-item (click)="deleteBoard(board.id)" *ngIf="!canCrud">
-                      <mat-icon>delete</mat-icon>
-                      <span>Delete</span>
-                  </button>
+                <button mat-menu-item (click)="boardView(board.id)">
+                  <!-- TODO reverse & fix "canCrud" check -->
+                  <mat-icon>details</mat-icon>
+                  <span>View</span>
+                </button>
+                <button mat-menu-item (click)="editBoard(board.id)" *ngIf="!canCrud">
+                  <mat-icon>edit</mat-icon>
+                  <span>Edit</span>
+                </button>
+                <button mat-menu-item (click)="deleteBoard(board.id)" *ngIf="!canCrud">
+                  <mat-icon>delete</mat-icon>
+                  <span>Delete</span>
+                </button>
               </mat-menu>
-              </div>
-            </mat-tab>
-            <mat-tab label="FOLLOWING">
-              <div class="side-nav-item header-text" *ngFor="let board of boards$ | async"> <!-- TODO use different list of boards -->
-                <div>
+            </div>
+          </mat-tab>
+          <mat-tab label="FOLLOWING">
+            <div class="side-nav-item header-text" *ngFor="let board of boards$ | async">
+              <!-- TODO use different list of boards -->
+              <div>
                 {{board.name}}
-                </div>
-                <div class="flex1"></div>
-                <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
-                  <mat-icon>more_vert</mat-icon>
+              </div>
+              <div class="flex1"></div>
+              <button mat-icon-button [matMenuTriggerFor]="menu" class="align mat-24">
+                <mat-icon>more_vert</mat-icon>
               </button>
               <mat-menu #menu="matMenu">
-                  <button mat-menu-item (click)="boardClicked(board.id)" *ngIf="!canCrud">
-                    <mat-icon>details</mat-icon>
-                    <span>View</span>
-                  </button>
+                <button mat-menu-item (click)="boardClicked(board.id)" *ngIf="!canCrud">
+                  <mat-icon>details</mat-icon>
+                  <span>View</span>
+                </button>
               </mat-menu>
-              </div>
-            </mat-tab>
-          </mat-tab-group>
+            </div>
+          </mat-tab>
+        </mat-tab-group>
       </mat-sidenav>
       <mat-sidenav-content class="sidenavContentPolyfill320">
+        <div class="flex flexRow">
+          <div class="flex">
+            <uf-info-bar isWarningMsg="true" message="This dashboard for Beta testing. Some functionality incomplete!"></uf-info-bar>
+          </div>
+        </div>
         <div class="main-panel">
           <global-feed></global-feed>
         </div>

--- a/src/app/threat-beta/threat-dashboard-beta.component.scss
+++ b/src/app/threat-beta/threat-dashboard-beta.component.scss
@@ -38,3 +38,7 @@
 .right-side-panel {
   min-width: 384px;
 }
+
+.pointer {
+  cursor: pointer;
+}

--- a/src/app/threat-beta/threat-dashboard-beta.component.ts
+++ b/src/app/threat-beta/threat-dashboard-beta.component.ts
@@ -29,7 +29,7 @@ export class ThreatDashboardBetaComponent implements OnInit {
 
   private location: Location;
 
-  readonly baseAssessUrl = '/threat-beta/';
+  readonly baseThreatBetaUrl = '/threat-beta/';
   readonly boardFeedRoute = 'feed';
   readonly boardRoute = 'board';
   readonly articleRoute = 'article';
@@ -39,9 +39,9 @@ export class ThreatDashboardBetaComponent implements OnInit {
   masterListOptions = {
     dataSource: null,
     columns: new MasterListDialogTableHeaders('modified', 'Modified'),
-    displayRoute: this.baseAssessUrl + '/result/summary',
-    modifyRoute: this.baseAssessUrl + '/wizard/edit',
-    createRoute: this.baseAssessUrl + '/create',
+    displayRoute: this.baseThreatBetaUrl + '/result/summary',
+    modifyRoute: this.baseThreatBetaUrl + '/wizard/edit',
+    createRoute: this.baseThreatBetaUrl + '/create',
   };
 
   constructor(private router: Router, private store: Store<ThreatFeatureState>) { // private location: Location) {
@@ -54,8 +54,14 @@ export class ThreatDashboardBetaComponent implements OnInit {
 
   public boardView(boardId): Promise<boolean> {
     let routePromise: Promise<boolean>;
-    routePromise = this.router.navigate([this.baseAssessUrl, boardId, this.boardFeedRoute]);
+    routePromise = this.router.navigate([this.baseThreatBetaUrl, boardId, this.boardFeedRoute]);
     routePromise.catch((e) => console.log(e));
+    return routePromise;
+  }
+
+  public editBoard(boardId): Promise<boolean> {
+    let routePromise: Promise<boolean>;
+    routePromise = this.router.navigate([this.baseThreatBetaUrl, 'edit', boardId]);
     return routePromise;
   }
 

--- a/src/app/threat-beta/threat-header/threat-header.component.html
+++ b/src/app/threat-beta/threat-header/threat-header.component.html
@@ -1,9 +1,9 @@
 <div id="tabWrapper" class="flex flexColumn">
     <div class="flex flexRow">
-      <div class="flex">
-          <uf-info-bar shouldShow="false" shouldCenter="true" isWarningMsg="false" message=""></uf-info-bar>
+        <div class="flex">
+          <uf-info-bar isWarningMsg="true" message="This dashboard for Beta testing. Some functionality incomplete!"></uf-info-bar>
+        </div>
       </div>
-    </div>
     <div class="flex1"></div>
     <div class="flex flexRow">
       <nav mat-tab-nav-bar class="indent uf-tabs-borderless">


### PR DESCRIPTION
Added beta banner warning; access editing a threat board from global feed, enable clicking on a threat board in global feed to access board feed view, created a description with "COMING SOON" for board view

### To Test

- verify that banner warning appears for threat feed and in any of the three specific board views
- verify that clicking on a board name in the list of boards in global feed moves to the specific board's feed view
- verify that clicking the Edit option in the "More" menu for a board in global feed moves to the specific board's edit view
- verify that coming soon text appears in the Board view for a specific board with a list of what is expected to be on the page.

fixes unfetter-discover/unfetter#1535