### PR TITLE
create report button on global feed, fixed info banner overlapping ca…

### DIFF
--- a/src/app/global/components/info-bar/info-bar.component.html
+++ b/src/app/global/components/info-bar/info-bar.component.html
@@ -1,21 +1,23 @@
-<div class="info-bar-wrapper" [style.display]="shouldShow === true ? 'block': 'none'">
-  <div class="flex">
-    <div class="info-bar flex" [class.centered]="shouldCenter" [class.left-aligned]="!shouldCenter">
-      <span *ngIf="isWarningMsg">
-        <mat-icon class="mat-24" color="warn">warning</mat-icon>
-        <span class="cdk-visually-hidden">Warning</span>
-      </span>
-      <span>
-        {{message}}
-      </span>
-      <span *ngIf="completeBtnMsg && completeActionUrl">
-        <a mat-button [routerLink]="completeActionUrl">
-          {{completeBtnMsg}}
-        </a>
-      </span>
-      <span>
-        <a mat-button (click)="onDismissClick($event)">{{dismissBtnMsg}}</a>
-      </span>
+<div class="info-bar-component" [style.height]="applyHeightOnOpen && shouldShow ? '48px' : '0px'">
+  <div class="info-bar-wrapper" [style.display]="shouldShow === true ? 'block': 'none'">
+    <div class="flex">
+      <div class="info-bar flex" [class.centered]="shouldCenter" [class.left-aligned]="!shouldCenter">
+        <span *ngIf="isWarningMsg">
+          <mat-icon class="mat-24" color="warn">warning</mat-icon>
+          <span class="cdk-visually-hidden">Warning</span>
+        </span>
+        <span>
+          {{message}}
+        </span>
+        <span *ngIf="completeBtnMsg && completeActionUrl">
+          <a mat-button [routerLink]="completeActionUrl">
+            {{completeBtnMsg}}
+          </a>
+        </span>
+        <span>
+          <a mat-button (click)="onDismissClick($event)">{{dismissBtnMsg}}</a>
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/global/components/info-bar/info-bar.component.ts
+++ b/src/app/global/components/info-bar/info-bar.component.ts
@@ -15,6 +15,7 @@ export class InfoBarComponent implements OnInit {
   @Input() public message = '';
   @Input() public shouldCenter = false;
   @Input() public shouldShow = true;
+  @Input() public applyHeightOnOpen = false;
 
   constructor(
     protected router: Router,

--- a/src/app/threat-beta/global-feed/global-feed.component.scss
+++ b/src/app/threat-beta/global-feed/global-feed.component.scss
@@ -1,3 +1,4 @@
 .middle {
-    background-color: white;
+    background-color: #fafafa;
+    padding: 15px;
 }

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.scss
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.scss
@@ -1,5 +1,4 @@
 @import "../../_threat-beta.common.scss";
 
 .top {
-    padding-left: 24px;
 }

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
@@ -143,5 +143,4 @@
 
 .top {
     padding-top: 22px;
-    padding-left: 24px;
 }

--- a/src/app/threat-beta/threat-dashboard-beta.component.html
+++ b/src/app/threat-beta/threat-dashboard-beta.component.html
@@ -1,5 +1,8 @@
 <ng-container *ngIf="(finishedLoadingAll$|async) === true; else loadingBlock">
   <div #layout class="layout" *ngIf="(failedToLoad|async) === false; else failedToLoadBlock">
+    <a mat-fab color="primary" class="bottomRightFab plainLink" routerLink="/threat-beta/create">
+      <i class="material-icons mat-24">add</i>
+    </a>
     <mat-sidenav-container>
       <mat-sidenav class="side-panel mat-elevation-z8" mode="side" opened="true">
         <div class="flex flex-cols side-nav-top">
@@ -51,10 +54,10 @@
           </mat-tab>
         </mat-tab-group>
       </mat-sidenav>
-      <mat-sidenav-content class="sidenavContentPolyfill320">
+      <mat-sidenav-content class="sidenavContentPolyfill320">        
         <div class="flex flexRow">
           <div class="flex">
-            <uf-info-bar isWarningMsg="true" message="This dashboard for Beta testing. Some functionality incomplete!"></uf-info-bar>
+            <uf-info-bar isWarningMsg="true" message="This dashboard for Beta testing. Some functionality incomplete!" applyHeightOnOpen="true"></uf-info-bar>
           </div>
         </div>
         <div class="main-panel">


### PR DESCRIPTION
…roseul controls on global feed

- Create threat board button should be present and work
- The info banner in the global feed should push content down when open, and content should fill its space after its dimissed

fixes unfetter-discover/unfetter#1544