### PR TITLE
Adds ability to select created-by org for new/edited threatboard

### DIFF
--- a/src/app/threat-beta/create/create.component.html
+++ b/src/app/threat-beta/create/create.component.html
@@ -26,6 +26,10 @@
                     </div>
                 </div>
 
+                <div>
+                    <created-by-ref [model]="threatboard"></created-by-ref>
+                </div>
+
                 <div class="row">
                     <div class="col-xs-6 col-sm-6 mt-18 mat-h2"> Boundaries </div>
                 </div>

--- a/src/app/threat-beta/create/create.component.ts
+++ b/src/app/threat-beta/create/create.component.ts
@@ -283,8 +283,7 @@ export class CreateComponent implements OnInit {
             id: this.threatboard.id || null,
             created: this.threatboard.created || new Date(),
             modified: new Date().toISOString(),
-            created_by_ref: this.threatboard.created_by_ref ||
-                    (this.user && this.user.identity ? this.user.identity.id : null) || null,
+            created_by_ref: this.threatboard.created_by_ref || null,
             boundaries: {
                 ...this.threatboard.boundaries,
                 malware: this.mapBoundaries(this.threatboard.boundaries.malware),


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1546.

- As non-admin, create a threatboard. Select an org if you are a member of more than one. Save.

- Confirm you can see this new board on the dashboard.