### PR TITLE
Intrusion set dashboard hover fix

### DIFF
--- a/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.ts
+++ b/src/app/intrusion-set-dashboard/intrusion-set-dashboard.component.ts
@@ -96,6 +96,9 @@ export class IntrusionSetDashboardComponent implements OnInit {
                             const ap = this.attackPatterns[rel.attributes.target_ref];
                             const is = intrusions[rel.attributes.source_ref];
                             if (ap && is) {
+                                if (!Array.isArray(ap.analytics)) {
+                                    ap.analytics = [];
+                                }
                                 ap.analytics.push(is);
                                 ap.analytics.sort();
                             }

--- a/src/app/threat-beta/create/create.component.spec.ts
+++ b/src/app/threat-beta/create/create.component.spec.ts
@@ -21,8 +21,9 @@ import { ThreatDashboardBetaService } from '../threat-beta.service';
 import MockThreatDashboardBetaService from '../testing/mock-threat.service';
 import { threatReducer } from '../store/threat.reducers';
 import { GenericApi } from '../../core/services/genericapi.service';
+import { CreatedByRefComponent } from '../../global/components/created-by-ref/created-by-ref.component';
 
-describe('CreateComponent', () => {
+fdescribe('CreateComponent', () => {
 
     let fixture: ComponentFixture<CreateComponent>;
     let component: CreateComponent;
@@ -48,6 +49,7 @@ describe('CreateComponent', () => {
                 ],
                 declarations: [
                     CreateComponent,
+                    CreatedByRefComponent,
                     LoadingSpinnerComponent,
                 ],
                 providers: [

--- a/src/app/threat-beta/create/create.component.spec.ts
+++ b/src/app/threat-beta/create/create.component.spec.ts
@@ -23,7 +23,7 @@ import { threatReducer } from '../store/threat.reducers';
 import { GenericApi } from '../../core/services/genericapi.service';
 import { CreatedByRefComponent } from '../../global/components/created-by-ref/created-by-ref.component';
 
-fdescribe('CreateComponent', () => {
+describe('CreateComponent', () => {
 
     let fixture: ComponentFixture<CreateComponent>;
     let component: CreateComponent;


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1542.

- Go to the intrusion set dashboard

- Hover over an attack pattern (you may have to try a couple). Intrusion sets that use that attack pattern should flash a few times then stay highlighted. Somehow this behavior stopped working.