### PR TITLE
Fixes content area of threatboard feed page for FF31

### DIFF
--- a/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.html
+++ b/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.html
@@ -3,8 +3,8 @@
     <div id="feed-item-label">
         <h4>{{ label }}</h4>
         <div class="carousel-pager" *ngIf="pages > 1">
-            <button mat-icon-button class="pager-bullet" *ngFor="let pg of pages | times">
-                <mat-icon [ngClass]="{'active-page-bullet' : (page === pg)}" (click)="scrollToPage(pg)">lens</mat-icon>
+            <button mat-icon-button class="pager-bullet" *ngFor="let pg of pages | times" (click)="scrollToPage(pg)">
+                <mat-icon [ngClass]="{'active-page-bullet' : (page === pg)}">lens</mat-icon>
             </button>
         </div>
     </div>
@@ -22,7 +22,7 @@
             </button>
         </div>
 
-        <div #view class="item-list" [style.margin-left]="offset + 'px'">
+        <div #view class="item-list" [style.margin]="'-11px 0 0 ' + offset + 'px'">
             <ng-content select="[carousel-items]"></ng-content>
         </div>
 

--- a/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.ts
+++ b/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.ts
@@ -87,8 +87,7 @@ export class FeedCarouselComponent {
         } else {
             let perPage = 1;
             const itemWidth = this.itemWidth + this.itemSpacing;
-            const itemsWidth = this.itemView.nativeElement.offsetWidth +
-                    (Number.parseInt(this.itemView.nativeElement.style['margin-left'] || 0, 10));
+            const itemsWidth = this.itemView.nativeElement.offsetWidth;
             perPage = Math.floor(itemsWidth / itemWidth);
             if (itemsWidth - perPage * itemWidth < this.itemSpacing) {
                 perPage++;

--- a/src/app/threat-beta/feed/feed-carousel/related-boards-carousel.component.ts
+++ b/src/app/threat-beta/feed/feed-carousel/related-boards-carousel.component.ts
@@ -67,7 +67,7 @@ export class RelatedBoardsCarouselComponent implements OnChanges {
     public getBoardBackground(board: any) {
         const colors = [
             ['indianred', 'firebrick'],
-            ['rebeccapurple', 'indigo'],
+            ['purple', 'indigo'],
             ['olivedrab', 'olive'],
             ['slateblue', 'darkslateblue'],
             ['cadetblue', 'darkslategray'],

--- a/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.html
+++ b/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.html
@@ -3,12 +3,12 @@
     <ng-container carousel-items>
 
         <div *ngFor="let report of reports; index as idx" id="{{ report.id }}"
-                class="feed-item board-report" [style.background-image]="getReportBackground(report)"
+                class="feed-item board-report" [style.background]="getReportBackground(report)"
                 matBadgeHidden="{{ report.vetted }}" matBadge="'!'" matBadgeColor="accent"
                 matBadgePosition="before" matBadgeSize="small"
                 (mouseenter)="hoverIndex = idx" (mouseleave)="hoverIndex = -1">
 
-            <div class="report-image" [style.background-image]="getReportBackgroundImage(report)">
+            <div class="report-image" [style.background]="getReportBackgroundImage(report)">
                 <div class='report-fabs' *ngIf="hoverIndex === idx">
                     <div class="fab-row">
                         <button mat-mini-fab [disabled]="report.vetted" title="Approve Report"

--- a/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.scss
+++ b/src/app/threat-beta/feed/feed-carousel/reports-carousel.component.scss
@@ -7,7 +7,7 @@
 
     .report-image {
         height: 105px;
-        background-size: 210px 105px;
+        background-size: 210px 105px !important;
         border-top-right-radius: 4px;
         border-top-left-radius: 4px;
 

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -24,7 +24,7 @@
 }
 
 mat-sidenav-content {
-    width: 100%;
+    width: calc(100% - 380px);
 }
 
 #feed-content {


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1551.

In older Firefox browser, go to a threatboard feed page. Both reports and boards carousels should render properly, with working scroll buttons, pager buttons. All four Activity sort buttons should be visible.