### PR TITLE
adds heirarchy back to comments in threat board feed

### DIFF
--- a/src/app/threat-beta/display-comment/display-comment.component.spec.ts
+++ b/src/app/threat-beta/display-comment/display-comment.component.spec.ts
@@ -142,7 +142,7 @@ const mockThreatBoard = new ThreatBoard({
   beforeEach(() => {
     fixture = TestBed.createComponent(DisplayCommentComponent);
     component = fixture.componentInstance;
-    component.board = mockThreatBoard;
+    component.board_article = mockThreatBoard;
     component.comment = mockThreatBoard.metaProperties.comments[0];
     appStore = TestBed.get(Store);
     appStore.addReducer('threat', threatReducer);

--- a/src/app/threat-beta/display-comment/display-comment.component.ts
+++ b/src/app/threat-beta/display-comment/display-comment.component.ts
@@ -19,9 +19,9 @@ export class DisplayCommentComponent implements OnInit {
   @Output() newComment = new EventEmitter<any>(); // TODO Comment interface
 
   /**
-   * The threatboard the comment belongs to. We only use this when persisting likes & comments added to the threatboard itself.
+   * The threatboard or article the comment belongs to. We only use this when persisting likes & comments added to the threatboard itself.
    */
-  @Input() board: ThreatBoard;
+  @Input() board_article: any;
 
   /**
     * The current user. Needed for when they add a comment or reply.
@@ -106,21 +106,44 @@ export class DisplayCommentComponent implements OnInit {
   }
 
   private submitThreatBoardComment(comment: any) {
-    if (this.board) {
-      if (!this.board.metaProperties.comments) {
-        this.board.metaProperties.comments = [];
+    let isReply = false;
+    if (this.board_article) {
+      if (this.commentTarget === this.comment) {
+        if (!this.commentTarget.comment.replies) {
+          this.commentTarget.comment.replies = [];
+        }
+        isReply = true;
+        this.commentTarget.comment.replies.push(comment);
+      } else {
+        if (!this.board_article.metaProperties.comments) {
+          this.board_article.metaProperties.comments = [];
+        }
+        this.board_article.metaProperties.comments.push(comment);
       }
-      this.board.metaProperties.comments.push(comment);
-      this.threatboardService.updateBoard(this.board)
-        .subscribe(
-          (response) => {
-            console['debug'](`(${new Date().toISOString()}) board updated`);
-            this.newComment.emit(comment);
-          },
-          (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
-        );
+      if (this.board_article.type !== 'x-unfetter-article') {
+        this.threatboardService.updateBoard(this.board_article)
+          .subscribe(
+            (response) => {
+              console['debug'](`(${new Date().toISOString()}) board updated`);
+              if (!isReply) {
+                console.log('Not a reply add to the list.');
+                this.newComment.emit(comment);
+              }
+            },
+            (err) => console.log(`(${new Date().toISOString()}) error updating board`, err)
+          );
+      } else {
+        this.threatboardService.editArticle(this.board_article)
+          .subscribe(
+            (response) => console['debug'](`(${new Date().toISOString()}) article updated`),
+            (err) => console.log(`(${new Date().toISOString()}) error updating article`, err)
+          );
+      }
+    } else { // TODO figure out what object it's part of{
+      console.error('Unimplemented');
     }
   }
+
 
   public hasComments(comment: any) {
     if (!comment) {
@@ -139,13 +162,20 @@ export class DisplayCommentComponent implements OnInit {
       } else {
         likes.splice(liked, 1);
       }
-      if (this.board) {
-        console.log(this.board.metaProperties);
-        this.threatboardService.updateBoard(this.board)
+      if (this.board_article) {
+        if (this.board_article.type !== 'x-unfetter-article') {
+        this.threatboardService.updateBoard(this.board_article)
           .subscribe(
             (response) => console['debug'](`(${new Date().toISOString()}) board likes updated`),
             (err) => console.log(`(${new Date().toISOString()}) error updating board likes`, err),
           );
+        } else {
+          this.threatboardService.editArticle(this.board_article)
+          .subscribe(
+            (response) => console['debug'](`(${new Date().toISOString()}) article updated`),
+            (err) => console.log(`(${new Date().toISOString()}) error updating article`, err)
+          );
+        }
       } else {
         // TODO look through boards for which to update.
         console.log('no board');

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.html
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.html
@@ -28,7 +28,7 @@
                 <ng-container *ngTemplateOutlet="articleTemplate;context:{article:item}"></ng-container>
             </ng-container>
             <ng-container *ngIf="item.comment">
-                <display-comment [comment]="item" [parent]=null [board]=threatBoard (newComment)="addAComment($event)"></display-comment>
+                <display-comment [comment]="item" [parent]=null [board_article]=threatBoard (newComment)="addAComment($event)"></display-comment>
             </ng-container>
         </ng-container>
 
@@ -79,7 +79,7 @@
             <div label="Comments" *ngIf="hasActivityComments(article)">
                 <hr/>
                 <ng-container *ngFor="let comment of article.metaProperties.comments | sortByField: 'submitted'">
-                    <display-comment [comment]="comment" [parent]=article [board]=article (newComment)="addAComment($event)"></display-comment>
+                    <display-comment [comment]="comment" [parent]=article [board_article]=article (newComment)="addAComment($event)"></display-comment>
                 </ng-container>
             </div>
         </mat-card-footer>

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.html
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.html
@@ -11,7 +11,7 @@
         <!-- TODO <ng-container *ngTemplateOutlet="articleTemplate;context:{article:item}"></ng-container> -->
     </ng-container>
     <ng-container *ngIf="item.comment">
-        <display-comment [comment]="item" [parent]=null [board]=null (newComment)="addAComment($event)"></display-comment>
+        <display-comment [comment]="item" [parent]=null [board_article]="boards[item.id]" (newComment)="addAComment($event)"></display-comment>
     </ng-container>
 </ng-container>
 </div>

--- a/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.ts
+++ b/src/app/threat-beta/global-feed/recent-activity/recent-activity.component.ts
@@ -15,6 +15,7 @@ export class RecentActivityComponent implements OnInit {
    * comments made on reports that are a part of the threatboard.
    */
   private _activity = {};
+  private _boards = {};
 
   constructor(private boardStore: Store<ThreatFeatureState>) { }
 
@@ -28,7 +29,10 @@ export class RecentActivityComponent implements OnInit {
         (boards: any[]) => {
           boards.forEach(board => {
             if (board && board.metaProperties && board.metaProperties.comments) {
-              board.metaProperties.comments.forEach(comment => this._activity[comment.id] = comment);
+              board.metaProperties.comments.forEach(comment => {
+                this._boards[comment.id] = board;
+                this._activity[comment.id] = comment; 
+              });
             }
           });
         },
@@ -42,6 +46,7 @@ export class RecentActivityComponent implements OnInit {
   }
 
   public get activity() { return Object.values(this._activity); } // TODO .sort(this.activitySorts[this.activeSort].sorter); }
+  public get boards() { return this._boards; } // TODO Refactor this
 
   public addAComment(comment: any) {
     this._activity[comment.id] = comment;


### PR DESCRIPTION
adds ability to comment, like, and reply to comments in global feed. 

Needs refactor, but should work as written.

### To Test

- Create multiple threat boards
- Go to the threat board feed for one
- Make a comment
- Like the comment
- Reply to the comment
- Like the reply
- Verify that you cannot reply to the reply
- Create an article in the threat board article view
- Make a comment on the article
- Like the comment on the article
- Reply to the comment on the article
- Like the reply to the comment on the article
- Verify that you cannot reply to the reply to the comment on the article
- Refresh the page
- Verify all replies and likes remain
- Navigate to the threat board feed view for a different threat board
- make a comment
- like the comment
- reply to the comment
- Navigate to the global feed view
- Try to unlike and reply to all the comments
- Refresh the page and verify that any changes persisted
- Navigate to each of the threat board feed views for any comments that you updated
- Verify that updates are visible in the feed views for each board.

fixes unfetter-discover/unfetter#1549