### PR TITLE
Feed report request limiting

### DIFF
--- a/src/app/threat-beta/store/threat.selectors.ts
+++ b/src/app/threat-beta/store/threat.selectors.ts
@@ -52,7 +52,9 @@ export const getAttachedReports = createSelector(
 
 export const getThreatBoardReports = createSelector(
     selectThreatState,
-    (state) => [...state.attachedReports, ...state.potentialReports]
+    // TODO HACKed version to limit spamming the URL length limit
+    // (state) => [...state.attachedReports, ...state.potentialReports] // <-- original
+    (state) => [...state.attachedReports, ...state.potentialReports].slice(0, 20)
 );
 
 export const getSelectedReportId = createSelector(


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1558.

Prevents massive numbers of reports from blowing up threatboard feed page.