### PR TITLE
A couple more places we need to restrict number of reports requested

### DIFF
--- a/src/app/threat-beta/store/threat.effects.ts
+++ b/src/app/threat-beta/store/threat.effects.ts
@@ -82,7 +82,7 @@ export class ThreatEffects {
                                     const options: StixApiOptions = {
                                         filter: {
                                             _id: {
-                                                $in: board.reports
+                                                $in: [...board.reports].slice(0, 20)
                                             }
                                         },
                                         sort: {
@@ -101,7 +101,7 @@ export class ThreatEffects {
                                     const options: StixApiOptions = {
                                         filter: {
                                             _id: {
-                                                $in: board.metaProperties.potentials
+                                                $in: [...board.metaProperties.potentials].slice(0, 20)
                                             }
                                         },
                                         sort: {

--- a/src/app/threat-beta/store/threat.selectors.ts
+++ b/src/app/threat-beta/store/threat.selectors.ts
@@ -47,7 +47,7 @@ export const getBoundaryObjects = createSelector(
 
 export const getAttachedReports = createSelector(
     selectThreatState,
-    (state) => state.attachedReports
+    (state) => [...state.attachedReports].slice(0, 20)
 );
 
 export const getThreatBoardReports = createSelector(


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1562.

- Throw every report you have into the potentials array of a threatboard (assuming you have at least 21 reports in your stix collection). This is the query I ran in Robo3T to do it:
```
var reps = db.getCollection('stix').find({'stix.type': 'report'}, {'stix.id': 1, _id: 0})
    .toArray()
    .reduce((reports, report) => reports.concat(report.stix.id), [])
db.getCollection('stix').update({'stix.id': 'x-unfetter-threat-board--b6974637-3258-4041-b70c-74693f0cfdb5'},
    {$set: {'metaProperties.potentials': reps}})
```

(Naturally, you may have a different threatboard id).

- Bring up the threatboard's feed page. Should load without issue.