### PR TITLE
Adds edit button for articles

### DIFF
--- a/src/app/threat-beta/feed/activity-list/activity-list.component.html
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.html
@@ -52,6 +52,9 @@
                     <mat-card-subtitle>
                         {{ getUserName(article) }} &bull; Last edited {{ article.modified | timeAgo }}
                     </mat-card-subtitle>
+                    <a class="article-edit-button" [routerLink]="['../article/edit', article.id]">
+                        <i class="material-icons">edit</i>
+                    </a>
                 </mat-card-header>
                 <mat-card-content>
                     <markdown-mentions [markDown]="article.content"></markdown-mentions>

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.scss
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.scss
@@ -66,3 +66,14 @@
         font-size: 14px;
     }
 }
+
+.article-edit-button {
+    position: absolute;
+    right: 12px;
+    font-size: large;
+    color: lightgray;
+}
+
+.article-edit-button:hover {
+    color: slategray !important;
+}

--- a/src/app/threat-beta/feed/activity-list/activity-list.component.ts
+++ b/src/app/threat-beta/feed/activity-list/activity-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { pluck, take } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
@@ -66,6 +67,7 @@ export class ActivityListComponent implements OnInit {
         private boardStore: Store<ThreatFeatureState>,
         private appStore: Store<AppState>,
         private citations: UserCitationService,
+        private router: Router,
         private sanitizer: DomSanitizer,
     ) {
     }
@@ -302,6 +304,15 @@ export class ActivityListComponent implements OnInit {
                 (response) => console['debug'](`(${new Date().toISOString()}) article updated`),
                 (err) => console.log(`(${new Date().toISOString()}) error updating article`, err)
             );
+    }
+
+    /**
+     * The user has selected to edit a specific article.
+     */
+    public editArticle(article: string) {
+        if (article) {
+            this.router.navigate([`/threat_beta/article/edit`, this.threatBoard.id, article]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes unfetter-discover/unfetter#1567.

Go to a threatboard. If it does not have an article yet, click on the Article tab and create one.

Go to the threatboard feed page. Next to an/the article you will see an edit (pencil) icon. Click on it.

It will take you back to the Article tab (unhighlighted) and display the article contents for editing.