### PR TITLE
removed unneeded async keyboards

### DIFF
--- a/src/app/threat-beta/article/article-editor/article-editor.component.ts
+++ b/src/app/threat-beta/article/article-editor/article-editor.component.ts
@@ -207,7 +207,7 @@ export class ArticleEditorComponent implements OnInit {
     });
   }
 
-  private async createNewArticle(tempArticle: Article): Promise<boolean> {
+  private createNewArticle(tempArticle: Article): Promise<boolean> {
     return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
       const addArticle$ = this.store.select(getSelectedBoard)
         .pipe(
@@ -249,7 +249,7 @@ export class ArticleEditorComponent implements OnInit {
     });    
   }
 
-  private async editArticle(tempArticle: Article): Promise<boolean> {
+  private editArticle(tempArticle: Article): Promise<boolean> {
     return new Promise((resolve: (boolean) => void, reject: (boolean) => void) => {
       tempArticle.id = this.articleToEdit.id;
       const editArticle$ = this.threatService.editArticle(tempArticle)


### PR DESCRIPTION
This "may or may not" be a fix to the issue of prod legacy attachments on the threat beta articles.  Regardless, it uses unnecessary logic so it's fine to have in the code base regardless.

Instructions to test PR:
- Confirm you can create an article with attachments

Longer term, we need to confirm that the Legacy Prod UAC build allows this.

fixes unfetter-discover/unfetter#1569