### PR TITLE
Fix FF31 Issues with right-hand sidenav area and global-feed reports carousel

### DIFF
--- a/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.ts
+++ b/src/app/threat-beta/feed/feed-carousel/feed-carousel.component.ts
@@ -95,7 +95,7 @@ export class FeedCarouselComponent {
             this._itemsPerPage = Math.max(perPage, 1);
             this._pages = Math.ceil(this.itemCount / this._itemsPerPage);
             if (this._page >= this._pages) {
-                this._page = this._pages - 1;
+                this._page = Math.max(0, this._pages - 1);
             }
         }
     }

--- a/src/app/threat-beta/feed/feed.component.html
+++ b/src/app/threat-beta/feed/feed.component.html
@@ -7,7 +7,7 @@
 
 <mat-sidenav-container class="flex zIndexAuto">
         
-    <mat-sidenav-content class="min-tab-height zIndexAuto">
+    <mat-sidenav-content class="min-tab-height zIndexAuto sidenavContentPolyfill384-right">
 
         <div id="feed-content" class="flex1">
 

--- a/src/app/threat-beta/feed/feed.component.scss
+++ b/src/app/threat-beta/feed/feed.component.scss
@@ -1,5 +1,5 @@
 @import '../../../styles/_variables.scss';
-@import '../threat-beta.common';
+@import '../_threat-beta.common.scss';
 
 #search-bar {
     .search-input {
@@ -23,10 +23,6 @@
     }
 }
 
-mat-sidenav-content {
-    width: calc(100% - 380px);
-}
-
 #feed-content {
     padding: 15px;
 }
@@ -34,7 +30,7 @@ mat-sidenav-content {
 #trends-trench {
     display: flex;
     flex-direction: column;
-    width: 380px;
+    width: $rightSidenavWidth;
     margin-left: 10px;
     padding: 15px;
     background: white;

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.html
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.html
@@ -1,5 +1,40 @@
 <div class="top">
-  <div id="reports-carousel">
+
+    <feed-carousel #carousel [itemCount]="reports.length" [loaded]=loaded [label]="'Latest Reports'">
+
+        <ng-container carousel-items>
+    
+            <div *ngFor="let report of reports; index as idx" id="{{ report.id }}"
+                    class="feed-item board-report" [style.background]="getReportBackground(report)"
+                    matBadgeHidden="{{ report.vetted }}" matBadge="'!'" matBadgeColor="accent"
+                    matBadgePosition="before" matBadgeSize="small"
+                    (mouseenter)="hoverIndex = idx" (mouseleave)="hoverIndex = -1">
+    
+                <div class="report-image" [style.background]="getReportBackgroundImage(report)">
+                    <div class='report-fabs' *ngIf="hoverIndex === idx">
+                        <div class="fab-row">
+                            <button mat-mini-fab [style.margin-right]="'24px'" title="Report Quick View"
+                                    (click)="viewReport(report.id)">
+                                <mat-icon class="mat-24" aria-label="report quick view">launch</mat-icon>
+                            </button>
+                            <button mat-mini-fab [style.margin-left]="'24px'" disabled title="Share Report"
+                                    (click)="shareReport(report.id)">
+                                <mat-icon class="mat-24" aria-label="share report">share</mat-icon>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+    
+                <div carousel-item class="report-info">
+                    <div class='report-title'>{{ report.name }}</div>
+                </div>
+    
+            </div>
+    
+        </ng-container>
+    
+    </feed-carousel>
+  <!-- <div id="reports-carousel">
     <div id="reports-label">
       <p class="header-text inline">
         Latest Reports
@@ -45,11 +80,11 @@
           </div>
         </div>
       </div>
+-->
+<!--    </div><!-- ends reports list -->
 
-    </div><!-- ends reports list -->
-
-  </div><!-- ends reports carousel -->
-</div>
+<!--  </div><!-- ends reports carousel -->
+</div> 
 
 <ng-template #loadingBlock>
   <loading-spinner height="250px"></loading-spinner>

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.html
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.html
@@ -34,56 +34,6 @@
         </ng-container>
     
     </feed-carousel>
-  <!-- <div id="reports-carousel">
-    <div id="reports-label">
-      <p class="header-text inline">
-        Latest Reports
-      </p>
-      <div class="carousel-pager" *ngIf="reportsPages > 1">
-        <button mat-icon-button class="pager-bullet" *ngFor="let rpg of reportsPages | times">
-          <mat-icon [style.font-size]="(reportsPage === rpg) ? '14px' : '9px'" [style.color]="(reportsPage === rpg) ? 'green' : 'black'"
-            (click)="scrollToReportsPage(rpg)">lens</mat-icon>
-        </button>
-      </div>
-    </div>
-
-    <div *ngIf="reportsLoaded; else loadingBlock" (mouseenter)="reportsHover = true" (mouseleave)="reportsHover = false">
-
-      <div class="carousel-glass" *ngIf="reportsHover && (reportsPages > 1)">
-        <button mat-icon-button mat-mini-fab class="carousel-button carousel-left" [disabled]="isFirstReport()" (click)="scrollReportsLeft()">
-          <mat-icon aria-label="scroll reports left">keyboard_arrow_left</mat-icon>
-        </button>
-        <button mat-icon-button mat-mini-fab class="carousel-button carousel-right" [disabled]="isLastReport()" (click)="scrollReportsRight()">
-          <mat-icon aria-label="scroll reports right">keyboard_arrow_right</mat-icon>
-        </button>
-      </div>
-
-      <div #reportsView id="reports-list" [style.margin-left]="reportsOffset + 'px'">
-        <div *ngFor="let report of reports; index as repidx" id="{{ report.id }}" class="board-report"
-          [style.background-image]="getReportBackground(report)" matBadge="!" matBadgeDescription="new" matBadgeColor="warn"
-          matBadgePosition="before" matBadgeHidden="{{ report.vetted }}" (mouseenter)="reportHoverIndex = repidx"
-          (mouseleave)="reportHoverIndex = -1">
-          <div class='report-image' [style.background-image]="getReportBackgroundImage(report)">
-            <div class='report-fabs' *ngIf="reportHoverIndex === repidx">
-              <div class="fab-row">
-                <button mat-mini-fab [style.margin-right]="'24px'" title="Report Quick View" (click)="viewReport(report.id)">
-                  <mat-icon class="mat-24" aria-label="report quick view">launch</mat-icon>
-                </button>
-                <button mat-mini-fab [style.margin-left]="'24px'" disabled title="Share Report" (click)="shareReport(report.id)">
-                  <mat-icon class="mat-24" aria-label="share report">share</mat-icon>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div class="report-info">
-            <div class='report-title'>{{ report.name }}</div>
-          </div>
-        </div>
-      </div>
--->
-<!--    </div><!-- ends reports list -->
-
-<!--  </div><!-- ends reports carousel -->
 </div> 
 
 <ng-template #loadingBlock>

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.scss
@@ -1,103 +1,17 @@
 @import '../../_threat-beta.common.scss';
 
-.reports {
-    width: 100%;
-    margin-top: 8px;
-    padding: 0;
-    background:#fff;
-}
-
-.inline {
-    display: inline-block;
-}
-
-#reports-carousel {
-    margin-bottom: 20px;
-
-    .carousel-pager {
-        float: right;
-
-        .pager-bullet {
-            width: 20px;
-            height: 20px;
-            line-height: 20px;
-        }
-    }
-
-    .carousel-glass {
-        position: absolute;
-        width: -moz-available;
-        width: calc(100% - 30px);
-        height: 250px;
-        margin-top: 11px;
-        background: transparent;
-    }
-
-    .carousel-button {
-        position: absolute;
-        width: 48px;
-        height: 48px;
-        top: calc(50% - 48px);
-        z-index: 100;
-        margin: 0 16px;
-        background: rgba(127, 127, 127, .4);
-        border: 2px solid rgba(255, 255, 255, .75);
-        border-radius: 50%;
-        color: rgba(255, 255, 255, .4);
-
-        mat-icon {
-            font-size: 36px;
-            margin-left: -12px;
-        }
-    }
-    
-    .carousel-button:hover {
-        border-color: white;
-        color: white;
-    }
-
-    .carousel-button[disabled] {
-        border-color: rgba(0, 0, 0, .1);
-        background: rgba(0, 0, 0, .4);
-        color: gray;
-    }
-
-    .carousel-button.carousel-left {
-        left: 0;
-    }
-
-    .carousel-button.carousel-right {
-        right: 0;
-    }
-}
-
-#reports-list {
-    // flex causes the items in the carousel to span evenly
-    display: flex;
-    flex-direction: row;
-
-    // this margin/padding allows the badges to appear properly
-    margin-top: -11px;
-    padding-top: 11px;
-    padding-left: 11px;
-
-    // hides the scrollbars for the carousel
-    overflow: hidden;
-
-    // the transition allows left-right scrolling to go smoothly
-    transition: margin-left 0.5s ease;
-}
-
 .board-report {
     width: 210px;
+    min-width: 210px;
     height: 210px;
     margin-right: 7px;
     border-radius: 4px;
 
     .report-image {
         height: 105px;
-        background-size: 210px 105px;
-        border-radius: 4px;
+        background-size: 210px 105px !important;
+        border-top-right-radius: 4px;
+        border-top-left-radius: 4px;
 
         .report-fabs {
             text-align: center;
@@ -120,15 +34,15 @@
 
     .report-info {
         width: 210px;
-        height: 150px;
+        height: 105px;
         padding: 16px;
     }
 
     .report-title {
-        font-size: 16px;
-        color: white;
         overflow: hidden;
-        text-overflow: ellipsis;
+        max-height: 73px;
+        font-size: 18px;
+        color: white;
     }
 
     .report-badge {
@@ -138,6 +52,12 @@
         background: transparent;
         font-size: 20px;
         color:  blue;
+    }
+}
+
+:host ::ng-deep .mat-badge-small.mat-badge-overlap.mat-badge-before {
+    .mat-badge-content {
+        left: 8px;
     }
 }
 

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.ts
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ThreatFeatureState } from '../../store/threat.reducers';
-import { pluck } from 'rxjs/operators';
+import { pluck, distinctUntilChanged } from 'rxjs/operators';
 import { DomSanitizer } from '@angular/platform-browser';
+import { FeedCarouselComponent } from '../../feed/feed-carousel/feed-carousel.component';
 
 @Component({
   selector: 'recent-reports',
@@ -11,24 +12,24 @@ import { DomSanitizer } from '@angular/platform-browser';
 })
 export class RecentReportsComponent implements OnInit {
 
-  public readonly carouselItemWidth = 210;
-  public readonly carouselItemPadding = 8;
 
-  public reports = [];
-  private _reportsLoaded = false;
-  public reportHoverIndex = -1;
-  public reportsHover = false;
-  public reportsPage = 0;
-  private _reportsPerPage: number;
-  private _reportsPages: number;
-  @ViewChild('reportsView') reportsView: ElementRef;
+    /**
+     * The loaded list of vetted and potential reports.
+     */
+    private _reports: any[] = [];
+
+    private _loaded: boolean = false;
+
+    @ViewChild('carousel') carousel: FeedCarouselComponent;
 
   constructor(
     private store: Store<ThreatFeatureState>,
     private sanitizer: DomSanitizer) {
   }
 
-  public get reportsLoaded() { return this._reportsLoaded; }
+  public get loaded() { return this._loaded; }
+
+  public get reports() { return this._reports; }
 
   ngOnInit() {
     this.store.select('threat')
@@ -37,71 +38,14 @@ export class RecentReportsComponent implements OnInit {
       )
       .subscribe(
         (reports: any[]) => {
-          this.reports = reports
-            //            .map(report => ({ ...report, vetted: board.reports.includes(report.id) }))
+          this._reports = reports
             .sort(this.sortByLastModified);
           console.log(`(${new Date().toISOString()}) reports list`, this.reports);
-          this.calculateReportsWindow();
-          this._reportsLoaded = true;
+          this.carousel.calculateWindow();
+          this._loaded = true;
         },
         (err) => console.log(`(${new Date().toISOString()}) Error loading reports:`, err)
       );
-  }
-
-  private calculateReportsWindow() {
-    if (!this.reportsView) {
-      requestAnimationFrame(() => this.calculateReportsWindow());
-    } else {
-      let perPage = 1;
-      const itemWidth = this.carouselItemWidth + this.carouselItemPadding;
-      const reportsWidth = this.reportsView.nativeElement.offsetWidth +
-        (Number.parseInt(this.reportsView.nativeElement.style['margin-left'] || 0, 10));
-      perPage = Math.floor(reportsWidth / itemWidth);
-      if (reportsWidth - perPage * itemWidth < this.carouselItemPadding) {
-        perPage++;
-      }
-      this._reportsPerPage = Math.max(perPage, 1);
-      this._reportsPages = Math.ceil(this.reports.length / this._reportsPerPage);
-    }
-  }
-
-  private get reportsPerPage() {
-    return this._reportsPerPage;
-  }
-
-  public get reportsPages() {
-    return this._reportsPages;
-  }
-
-  public get reportsOffset() {
-    return this.reportsPage * this._reportsPerPage * -220;
-  }
-
-  public isFirstReport() {
-    return this.reportsPage === 0;
-  }
-
-  public isLastReport() {
-    return this.reportsPage >= this._reportsPages - 1;
-  }
-
-  public scrollReportsLeft() {
-    if (this.reportsPage > 0) {
-      this.reportsPage--;
-    }
-  }
-
-  public scrollReportsRight() {
-    if (this.reportsPage < this._reportsPages - 1) {
-      this.reportsPage++;
-    }
-  }
-
-  public scrollToReportsPage(page: number) {
-    page = Math.max(0, Math.min(page, this._reportsPages - 1));
-    if (this.reportsPage !== page) {
-      this.reportsPage = page;
-    }
   }
 
   public viewReport(id: string) {
@@ -112,22 +56,23 @@ export class RecentReportsComponent implements OnInit {
     console.log(`Request to share report '${id}' received`);
   }
 
-  public getReportBackground(report: any) {
+  public getReportBackground(item: any): string {
     const colors = [
-      ['darkred', 'rosybrown'],
-      ['lightblue', 'darkblue'],
-      ['lightgreen', 'darkgreen'],
-      ['orchid', 'darkorchid'],
-      ['palevioletred', 'mediumvioletred'],
+        ['darkred', 'rosybrown'],
+        ['lightblue', 'darkblue'],
+        ['lightgreen', 'darkgreen'],
+        ['orchid', 'darkorchid'],
+        ['palevioletred', 'mediumvioletred'],
     ];
-    const n = report.name.charCodeAt(0) % colors.length;
+    const n = item.name.charCodeAt(0) % colors.length;
     return `linear-gradient(${colors[n][0]}, ${colors[n][1]})`;
-  }
+}
 
-  public getReportBackgroundImage(report: any) {
-    return this.sanitizer.bypassSecurityTrustStyle(
-      `url(${report.metaProperties.image}), linear-gradient(transparent, transparent)`);
-  }
+public getReportBackgroundImage(item: any) {
+  return this.sanitizer.bypassSecurityTrustStyle(
+          (item.metaProperties.image ? `url(${item.metaProperties.image}), ` : '') +
+          'linear-gradient(transparent, transparent)');
+}
 
   public sortByLastModified(a: any, b: any) {
     return b.modified.localeCompare(a.modified);

--- a/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.ts
+++ b/src/app/threat-beta/global-feed/recent-reports/recent-reports.component.ts
@@ -14,7 +14,7 @@ export class RecentReportsComponent implements OnInit {
 
 
     /**
-     * The loaded list of vetted and potential reports.
+     * The loaded list of latest 20 reports.
      */
     private _reports: any[] = [];
 

--- a/src/app/threat-beta/threat-dashboard-beta.component.html
+++ b/src/app/threat-beta/threat-dashboard-beta.component.html
@@ -54,7 +54,7 @@
           </mat-tab>
         </mat-tab-group>
       </mat-sidenav>
-      <mat-sidenav-content class="sidenavContentPolyfill320">        
+      <mat-sidenav-content class="sidenavContentPolyfill320 sidenavContentPolyfill384-right">        
         <div class="flex flexRow">
           <div class="flex">
             <uf-info-bar isWarningMsg="true" message="This dashboard for Beta testing. Some functionality incomplete!" applyHeightOnOpen="true"></uf-info-bar>

--- a/src/app/threat-beta/threat-dashboard-beta.component.scss
+++ b/src/app/threat-beta/threat-dashboard-beta.component.scss
@@ -36,7 +36,7 @@
 }
 
 .right-side-panel {
-  min-width: 384px;
+  width: $rightSidenavWidth;
 }
 
 .pointer {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -83,6 +83,7 @@ $navbar-window-offset: 45;
 $table-padding: 10px;
 $elastic-transition: cubic-bezier(0.175, 0.885, 0.32, 1.275);
 $mde-background: #f2f2f2;
+$rightSidenavWidth: 384px;
 
 // ~~~ Functions & Mixins ~~~
 

--- a/src/styles/partials/_angular_material_config.scss
+++ b/src/styles/partials/_angular_material_config.scss
@@ -219,6 +219,10 @@ a.mat-button {
   margin-left: 320px;
 }
 
+.sidenavContentPolyfill384-right {
+  margin-right: $rightSidenavWidth;
+}
+
 .sidenavContentPolyfill360 {
   margin-left: 360px;
 }


### PR DESCRIPTION

### To Test
In FF31 Browser hitting page running legacy-prod or legacy-prod-uac build, unsure global feed carousel is visible and works as expected.
Verify that right section is not obscuring any carousel controls or anything in the activity feed.



fixes unfetter-discover/unfetter#1560 